### PR TITLE
docs: update ecosystem versions (wgpu v0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ gogpu/
 | Project | Description | Status |
 |---------|-------------|--------|
 | [gogpu/gogpu](https://github.com/gogpu/gogpu) | Graphics framework (this repo) | v0.3.0 |
-| [gogpu/wgpu](https://github.com/gogpu/wgpu) | Pure Go WebGPU implementation | v0.4.0 |
+| [gogpu/wgpu](https://github.com/gogpu/wgpu) | Pure Go WebGPU implementation | **v0.5.0** |
 | [gogpu/naga](https://github.com/gogpu/naga) | Pure Go shader compiler (WGSL → SPIR-V) | v0.4.0 |
 | [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics with GPU backend, scene graph, SIMD | **v0.9.0** |
 | [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) | Zero-CGO WebGPU bindings | Stable |
@@ -233,7 +233,7 @@ The Pure Go WebGPU implementation (gogpu/wgpu) now includes:
 
 | Backend | Status | Lines | Features |
 |---------|--------|-------|----------|
-| **Software** | ✅ Done | ~1K | **Headless!** CPU rendering, CI/CD, no GPU required |
+| **Software** | ✅ Done | ~10K | **Full rasterizer!** Triangle rendering, depth/stencil, blending, clipping, parallel |
 | OpenGL ES | ✅ Done | ~7.5K | Windows (WGL) + Linux (EGL) |
 | **Vulkan** | ✅ Done | ~27K | **Cross-platform!** Windows/Linux/macOS, goffi FFI, Vulkan 1.3, memory allocator |
 | Metal | Planned | - | macOS/iOS |

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/go-webgpu/webgpu v0.1.0
-	github.com/gogpu/wgpu v0.1.0
+	github.com/gogpu/wgpu v0.5.0
 	golang.org/x/sys v0.39.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.3.1 h1:q1a7eG5gvMNbTOY8/YNGcBxyn5iVvtl9N8ifqJXiZRk
 github.com/go-webgpu/goffi v0.3.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.1.0 h1:+9YLyPmcnw6s3V0i11sHuqoBFvHIMQRFOL/S1BM1TP8=
 github.com/go-webgpu/webgpu v0.1.0/go.mod h1:pbHKdndiR4UdG/X78x9e/XmNH/0KCuHTEo061CKtAJA=
-github.com/gogpu/wgpu v0.1.0 h1:H+EF9/EZn8kBN3pqpet0Bqp5WUTNfYZimSrldkMS7cc=
-github.com/gogpu/wgpu v0.1.0/go.mod h1:U7UV1rImGO1ql7YLOb62nzT1gNhkkXpN/SSXJF42P5k=
+github.com/gogpu/wgpu v0.5.0 h1:Wy285FqBIH+OK+CDFIf4ulOgy1iVOSKxcrm01blFHdg=
+github.com/gogpu/wgpu v0.5.0/go.mod h1:LM+xYpxVOZ0U2D+RmMYoLQcZXu4h96LJJM0z+BpXkuE=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
Update wgpu dependency to v0.5.0 and ecosystem table.