### PR TITLE
docs: fix Wayland status in ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 |----------|-----------|-------------|--------|
 | **Windows** | Win32 | Vulkan, GLES | Production |
 | **Linux X11** | X11 | Vulkan, GLES | Planned |
-| **Linux Wayland** | Wayland | Vulkan, GLES | Planned |
+| **Linux Wayland** | Wayland | Vulkan, GLES | Community Testing |
 | **macOS** | Cocoa | Metal | Planned |
 
 All platforms use Pure Go FFI (no CGO required).
@@ -48,12 +48,16 @@ All platforms use Pure Go FFI (no CGO required).
 
 ## Roadmap
 
+### Q4 2025 (Current)
+
+**Platform Expansion:**
+- ✅ Linux Wayland windowing (Pure Go, 5,700 LOC) — Community Testing
+
 ### Q1 2026
 
 **Platform Expansion:**
 - Linux X11 windowing support
 - macOS Cocoa windowing support
-- Linux Wayland windowing support
 
 **Performance:**
 - SIMD optimization for 2D rendering (gg)


### PR DESCRIPTION
Fix Wayland platform status: Community Testing, not Planned. Add Q4 2025 section.