### PR TITLE
feat(platform): add macOS Cocoa platform support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,16 @@ name: CI
 # CI Strategy:
 # - Tests run on Linux, macOS, and Windows (cross-platform GPU library)
 # - Go 1.25+ required (matches go.mod requirement)
-# - Requires wgpu-native for Rust backend tests
+# - CGO_ENABLED=0: Pure Go library, no C compiler required
 #
 # Branch Strategy (GitHub Flow):
 # - main branch: Production-ready code
 # - feat/** branches: Feature development
 # - fix/** branches: Bug fixes
 # - Pull requests: Must pass all checks before merge
+
+env:
+  CGO_ENABLED: "0"
 
 on:
   push:
@@ -79,9 +82,12 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: go vet ./...
 
+    - name: Install race detector
+      run: go install github.com/kolkov/racedetector/cmd/racedetector@latest
+
     - name: Run tests with race detector
       shell: bash
-      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+      run: racedetector test -v -coverprofile=coverage.txt -covermode=atomic ./...
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2025-12-23
+
+### Added
+- **macOS Cocoa Platform** (Pure Go, ~950 LOC)
+  - Objective-C runtime via goffi (go-webgpu/goffi)
+  - NSApplication lifecycle management
+  - NSWindow and NSView creation
+  - CAMetalLayer integration for GPU rendering
+  - Cached selector system for performance
+  - Cross-compilable from Windows/Linux to macOS
+- **Platform types for macOS**
+  - CGFloat, CGPoint, CGSize, CGRect
+  - NSWindowStyleMask constants
+  - NSBackingStoreType constants
+
+### Changed
+- Updated ecosystem: wgpu v0.6.0 (Metal backend), naga v0.5.0 (MSL backend)
+- Pre-release check script now uses kolkov/racedetector (Pure Go, no CGO)
+
+### Notes
+- **Community Testing Requested**: macOS Cocoa implementation needs testing on real macOS systems (12+ Monterey)
+- Metal backend available in wgpu v0.6.0
+- MSL shader compilation available in naga v0.5.0
+
 ## [0.4.0] - 2025-12-21
 
 ### Added
@@ -100,7 +124,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Examples**
   - `examples/triangle/` — Simple triangle demo
 
-[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/gogpu/gogpu/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/gogpu/gogpu/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gogpu/gogpu/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gogpu/gogpu/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@
 
 ---
 
-## Status: v0.4.0 — Linux Wayland Platform
+## Status: v0.5.0 — macOS Cocoa Platform
 
-> **Linux support is here!** Pure Go Wayland implementation (5,700 LOC).
+> **macOS support is here!** Pure Go Cocoa implementation via goffi.
 >
-> **🧪 Community Testing Requested** — Help us test on Wayland compositors!
+> **🧪 Community Testing Requested** — Help us test on macOS!
 >
 > **Star the repo to follow progress!**
 
@@ -120,23 +120,24 @@ tex, err := renderer.LoadTextureWithOptions("tile.png", opts)
 
 ---
 
-## Linux Platform (New in v0.4.0)
+## macOS Platform (New in v0.5.0)
 
-**Pure Go Wayland implementation** — no libwayland-client required!
+**Pure Go Cocoa implementation** — via goffi Objective-C runtime!
 
 ```
-internal/platform/wayland/
-├── wire.go          # Wayland wire protocol (message encoding)
-├── display.go       # wl_display connection via Unix socket
-├── compositor.go    # wl_compositor, wl_surface
-├── xdg_shell.go     # Window management (xdg_toplevel)
-├── input.go         # Keyboard and mouse (wl_seat)
-└── ...              # ~5,700 lines total
+internal/platform/darwin/
+├── types.go         # CGFloat, CGPoint, CGRect, NSWindowStyleMask
+├── objc.go          # Objective-C runtime via goffi
+├── selectors.go     # Cached ObjC selectors
+├── application.go   # NSApplication lifecycle
+├── window.go        # NSWindow, NSView management
+├── surface.go       # CAMetalLayer integration
+└── ...              # ~950 lines total
 ```
 
 **🧪 Community Testing Requested:**
-- GNOME 45+, KDE Plasma 6, Sway, Hyprland
-- Run `go build -tags purego ./examples/triangle/` on Linux Wayland
+- macOS 12+ (Monterey and later)
+- Run `go build -tags purego ./examples/triangle/` on macOS
 - Report issues at [github.com/gogpu/gogpu/issues](https://github.com/gogpu/gogpu/issues)
 
 ---
@@ -150,7 +151,7 @@ This project was inspired by [a discussion on r/golang](https://www.reddit.com/r
 1. **Simple API** — Hide WebGPU complexity behind intuitive Go code
 2. **Dual Backend** — Choose performance (Rust) or simplicity (Pure Go)
 3. **Zero CGO** — No C compiler required
-4. **Cross-Platform** — Windows, Linux (Wayland), macOS (planned)
+4. **Cross-Platform** — Windows, Linux (Wayland), macOS (Cocoa)
 
 | Layer | Component |
 |-------|-----------|
@@ -212,16 +213,17 @@ gogpu/
 
 See **[ROADMAP.md](ROADMAP.md)** for the full roadmap.
 
-**Current:** v0.4.0 — Linux Wayland Platform
+**Current:** v0.5.0 — macOS Cocoa Platform
 
 **Recent:**
-- ✅ Linux Wayland windowing (Pure Go, 5,700 LOC) — Community Testing
+- ✅ macOS Cocoa windowing (Pure Go, 950 LOC) — Community Testing
+- ✅ Linux Wayland windowing (Pure Go, 5,700 LOC)
 - ✅ Dual Backend, Textures, Build Tags
 
 **Next:**
 - Linux X11 windowing support
-- macOS Cocoa windowing support
-- Metal backend for macOS
+- Metal backend for macOS (implemented in wgpu v0.6.0)
+- DX12 backend for Windows
 
 ---
 
@@ -229,9 +231,9 @@ See **[ROADMAP.md](ROADMAP.md)** for the full roadmap.
 
 | Project | Description | Status |
 |---------|-------------|--------|
-| [gogpu/gogpu](https://github.com/gogpu/gogpu) | Graphics framework (this repo) | **v0.4.0** |
-| [gogpu/wgpu](https://github.com/gogpu/wgpu) | Pure Go WebGPU implementation | v0.5.0 |
-| [gogpu/naga](https://github.com/gogpu/naga) | Pure Go shader compiler (WGSL → SPIR-V) | v0.4.0 |
+| [gogpu/gogpu](https://github.com/gogpu/gogpu) | Graphics framework (this repo) | **v0.5.0** |
+| [gogpu/wgpu](https://github.com/gogpu/wgpu) | Pure Go WebGPU implementation | v0.6.0 |
+| [gogpu/naga](https://github.com/gogpu/naga) | Pure Go shader compiler (WGSL → SPIR-V, MSL) | v0.5.0 |
 | [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics library | v0.9.2 |
 | [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) | Zero-CGO WebGPU bindings | Stable |
 
@@ -244,7 +246,7 @@ The Pure Go WebGPU implementation (gogpu/wgpu) now includes:
 | **Software** | ✅ Done | ~10K | **Full rasterizer!** Triangle rendering, depth/stencil, blending, clipping, parallel |
 | OpenGL ES | ✅ Done | ~7.5K | Windows (WGL) + Linux (EGL) |
 | **Vulkan** | ✅ Done | ~27K | **Cross-platform!** Windows/Linux/macOS, goffi FFI, Vulkan 1.3, memory allocator |
-| Metal | Planned | - | macOS/iOS |
+| **Metal** | ✅ Done | ~3K | **macOS/iOS!** Pure Go via goffi Objective-C bridge |
 | DX12 | Planned | - | Windows |
 
 **Software backend** enables headless rendering:
@@ -272,9 +274,10 @@ Read our launch announcement on Dev.to:
 Contributions are welcome! This is an early-stage project, so there's lots to do.
 
 **Areas where we need help:**
-- 🧪 **Linux Wayland testing** — Test on real Wayland compositors
-- Platform support (X11, macOS Cocoa)
-- Metal backend for macOS
+- 🧪 **macOS testing** — Test on real macOS systems (Monterey+)
+- 🧪 **Linux Wayland testing** — Test on Wayland compositors
+- Platform support (X11)
+- DX12 backend for Windows
 - Documentation and examples
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,19 +16,19 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State (v0.4.0)
+## Current State (v0.5.0)
 
 | Component | Version | Description |
 |-----------|---------|-------------|
-| **gogpu/gogpu** | v0.4.0 | GPU abstraction, windowing, dual backend |
-| **gogpu/wgpu** | v0.5.0 | Pure Go WebGPU (Vulkan, GLES, Software) |
-| **gogpu/naga** | v0.4.0 | WGSL shader compiler |
+| **gogpu/gogpu** | v0.5.0 | GPU abstraction, windowing, dual backend |
+| **gogpu/wgpu** | v0.6.0 | Pure Go WebGPU (Vulkan, Metal, GLES, Software) |
+| **gogpu/naga** | v0.5.0 | WGSL shader compiler (SPIR-V, MSL) |
 | **gogpu/gg** | v0.9.2 | 2D graphics library |
 
 **Key Features:**
 - Zero CGO — Pure Go, easy cross-compilation
 - Dual backend — Rust (wgpu-native) or Pure Go
-- Windows platform fully supported
+- Cross-platform — Windows, Linux (Wayland), macOS (Cocoa)
 - WebGPU-first API design
 
 ---
@@ -40,7 +40,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 | **Windows** | Win32 | Vulkan, GLES | Production |
 | **Linux X11** | X11 | Vulkan, GLES | Planned |
 | **Linux Wayland** | Wayland | Vulkan, GLES | Community Testing |
-| **macOS** | Cocoa | Metal | Planned |
+| **macOS** | Cocoa | Metal | Community Testing |
 
 All platforms use Pure Go FFI (no CGO required).
 
@@ -52,12 +52,14 @@ All platforms use Pure Go FFI (no CGO required).
 
 **Platform Expansion:**
 - ✅ Linux Wayland windowing (Pure Go, 5,700 LOC) — Community Testing
+- ✅ macOS Cocoa windowing (Pure Go, 950 LOC) — Community Testing
+- ✅ Metal backend for macOS (wgpu v0.6.0, ~3K LOC)
+- ✅ MSL shader backend (naga v0.5.0, ~3.6K LOC)
 
 ### Q1 2026
 
 **Platform Expansion:**
 - Linux X11 windowing support
-- macOS Cocoa windowing support
 
 **Performance:**
 - SIMD optimization for 2D rendering (gg)
@@ -66,7 +68,7 @@ All platforms use Pure Go FFI (no CGO required).
 ### Q2 2026
 
 **GPU Backends:**
-- Metal backend for macOS/iOS
+- DX12 backend for Windows
 - GLES improvements for Linux
 
 **Shader Compiler:**
@@ -101,7 +103,7 @@ All platforms use Pure Go FFI (no CGO required).
 │   Rust Backend        │     Pure Go Backend                 │
 │  (go-webgpu/webgpu)   │       (gogpu/wgpu)                  │
 ├─────────────────────────────────────────────────────────────┤
-│   Vulkan    │   OpenGL ES   │   Software   │    Metal       │
+│   Vulkan    │   OpenGL ES   │   Software   │    Metal  ✅   │
 │  (Win+Lin)  │   (Win+Lin)   │  (Headless)  │   (macOS)      │
 └─────────────────────────────────────────────────────────────┘
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	golang.org/x/sys v0.39.0
 )
 
-require github.com/go-webgpu/goffi v0.3.1 // indirect
+require github.com/go-webgpu/goffi v0.3.1

--- a/internal/platform/darwin/application.go
+++ b/internal/platform/darwin/application.go
@@ -1,0 +1,273 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"errors"
+	"sync"
+	"unsafe"
+)
+
+// Errors returned by Application operations.
+var (
+	ErrApplicationNotInitialized = errors.New("darwin: application not initialized")
+	ErrApplicationAlreadyRunning = errors.New("darwin: application already running")
+)
+
+// Application manages the NSApplication lifecycle.
+// There is only one NSApplication per process.
+type Application struct {
+	mu              sync.Mutex
+	nsApp           ID
+	pool            ID
+	initialized     bool
+	running         bool
+	shouldTerminate bool
+}
+
+// global application instance
+var app *Application
+
+// GetApplication returns the shared Application instance.
+// Call Init() before using other methods.
+func GetApplication() *Application {
+	if app == nil {
+		app = &Application{}
+	}
+	return app
+}
+
+// Init initializes the NSApplication.
+// This must be called before creating windows or processing events.
+func (a *Application) Init() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.initialized {
+		return nil
+	}
+
+	// Initialize runtime, selectors, and classes
+	if err := initRuntime(); err != nil {
+		return err
+	}
+	initSelectors()
+	initClasses()
+
+	// Create autorelease pool for initialization
+	a.pool = classes.NSAutoreleasePool.Send(selectors.new)
+	if a.pool.IsNil() {
+		return errors.New("darwin: failed to create NSAutoreleasePool")
+	}
+
+	// Get shared NSApplication instance
+	a.nsApp = classes.NSApplication.Send(selectors.sharedApplication)
+	if a.nsApp.IsNil() {
+		return errors.New("darwin: failed to get NSApplication")
+	}
+
+	// Set activation policy to regular app (with dock icon)
+	a.nsApp.SendInt(selectors.setActivationPolicy, int64(NSApplicationActivationPolicyRegular))
+
+	// Finish launching (required for event processing)
+	a.nsApp.Send(selectors.finishLaunching)
+
+	// Activate the application
+	a.nsApp.SendBool(selectors.activateIgnoringOtherApps, true)
+
+	a.initialized = true
+	return nil
+}
+
+// Terminate requests application termination.
+// This sets a flag that can be checked with ShouldTerminate().
+func (a *Application) Terminate() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.shouldTerminate = true
+}
+
+// ShouldTerminate returns true if termination was requested.
+func (a *Application) ShouldTerminate() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.shouldTerminate
+}
+
+// Destroy releases application resources.
+func (a *Application) Destroy() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.pool != 0 {
+		a.pool.Send(selectors.drain)
+		a.pool = 0
+	}
+
+	a.initialized = false
+	a.running = false
+}
+
+// PollEvents processes all pending events without blocking.
+// Returns true if any events were processed.
+func (a *Application) PollEvents() bool {
+	if !a.initialized {
+		return false
+	}
+
+	processed := false
+
+	// Create local autorelease pool for event processing
+	pool := classes.NSAutoreleasePool.Send(selectors.new)
+	defer pool.Send(selectors.drain)
+
+	// Get distant past date for non-blocking poll
+	distantPast := classes.NSDate.Send(selectors.distantPast)
+
+	// Get default run loop mode string
+	modeStr := NewNSString("kCFRunLoopDefaultMode")
+	defer modeStr.Release()
+
+	// Poll for events
+	for {
+		event := a.nextEvent(distantPast, modeStr.ID())
+		if event.IsNil() {
+			break
+		}
+		a.nsApp.SendPtr(selectors.sendEvent, event.Ptr())
+		processed = true
+	}
+
+	return processed
+}
+
+// WaitEvents waits for events and processes them.
+// This blocks until at least one event is available.
+func (a *Application) WaitEvents() {
+	if !a.initialized {
+		return
+	}
+
+	// Create local autorelease pool
+	pool := classes.NSAutoreleasePool.Send(selectors.new)
+	defer pool.Send(selectors.drain)
+
+	// Get distant future date for blocking wait
+	distantFuture := classes.NSDate.Send(selectors.distantFuture)
+
+	// Get default run loop mode string
+	modeStr := NewNSString("kCFRunLoopDefaultMode")
+	defer modeStr.Release()
+
+	// Wait for first event
+	event := a.nextEvent(distantFuture, modeStr.ID())
+	if !event.IsNil() {
+		a.nsApp.SendPtr(selectors.sendEvent, event.Ptr())
+	}
+
+	// Process any remaining events
+	a.PollEvents()
+}
+
+// nextEvent retrieves the next event from the event queue.
+// date controls blocking behavior: distantPast for non-blocking, distantFuture for blocking.
+func (a *Application) nextEvent(date ID, mode ID) ID {
+	// Call [NSApp nextEventMatchingMask:untilDate:inMode:dequeue:]
+	// This requires a special calling convention for the multi-argument method
+	return a.nsApp.nextEventMatchingMask(NSEventMaskAny, date, mode, true)
+}
+
+// nextEventMatchingMask calls the Objective-C method with proper arguments.
+func (id ID) nextEventMatchingMask(mask NSEventMask, date ID, mode ID, dequeue bool) ID {
+	if id == 0 {
+		return 0
+	}
+
+	initSelectors()
+
+	var dequeueVal uintptr
+	if dequeue {
+		dequeueVal = 1
+	}
+
+	return msgSend(id, selectors.nextEventMatchingMaskUntilDateInModeDequeue,
+		uintptr(mask),
+		date.Ptr(),
+		mode.Ptr(),
+		dequeueVal,
+	)
+}
+
+// NSApp returns the raw NSApplication ID for advanced usage.
+func (a *Application) NSApp() ID {
+	return a.nsApp
+}
+
+// IsInitialized returns true if the application has been initialized.
+func (a *Application) IsInitialized() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.initialized
+}
+
+// NSString wraps an Objective-C NSString.
+type NSString struct {
+	id ID
+}
+
+// NewNSString creates an NSString from a Go string.
+func NewNSString(s string) *NSString {
+	initSelectors()
+	initClasses()
+
+	// Allocate NSString
+	nsstr := classes.NSString.Send(selectors.alloc)
+	if nsstr.IsNil() {
+		return nil
+	}
+
+	// Convert Go string to C string (null-terminated)
+	cstr := append([]byte(s), 0)
+
+	// Initialize with UTF8 string
+	// Pass the address of the first byte as uintptr
+	nsstr = nsstr.SendPtr(selectors.initWithUTF8String, bytesPtr(cstr))
+
+	return &NSString{id: nsstr}
+}
+
+// ID returns the underlying Objective-C object ID.
+func (s *NSString) ID() ID {
+	if s == nil {
+		return 0
+	}
+	return s.id
+}
+
+// Release releases the NSString.
+func (s *NSString) Release() {
+	if s != nil && s.id != 0 {
+		s.id.Send(selectors.release)
+		s.id = 0
+	}
+}
+
+// String returns the Go string representation.
+// Note: This requires reading from the NSString's UTF8String pointer,
+// which is more complex than shown here.
+func (s *NSString) String() string {
+	// Simplified: return empty string
+	// A full implementation would call UTF8String and read the C string
+	return ""
+}
+
+// bytesPtr returns a uintptr to the first element of the byte slice.
+// The caller must ensure the slice remains valid during use.
+func bytesPtr(b []byte) uintptr {
+	if len(b) == 0 {
+		return 0
+	}
+	return uintptr(unsafe.Pointer(&b[0]))
+}

--- a/internal/platform/darwin/doc.go
+++ b/internal/platform/darwin/doc.go
@@ -1,0 +1,68 @@
+//go:build darwin
+
+// Package darwin implements macOS platform support via Cocoa/AppKit.
+//
+// This package provides a pure Go implementation of macOS windowing and
+// Metal surface creation using Objective-C runtime FFI through goffi.
+// No CGO is required.
+//
+// # Architecture
+//
+// The implementation uses goffi to call Objective-C runtime functions:
+//   - objc_getClass: Get class references (NSApplication, NSWindow, etc.)
+//   - objc_msgSend: Send messages to Objective-C objects
+//   - sel_registerName: Register selector names
+//
+// # Memory Management
+//
+// Cocoa uses reference counting for memory management:
+//   - Objects from alloc/init/copy must be released
+//   - Objects from other methods are autoreleased
+//   - Use NSAutoreleasePool for temporary objects
+//
+// # Thread Safety
+//
+// NSApplication and NSWindow operations must occur on the main thread.
+// The main event loop (PollEvents, WaitEvents) handles this automatically.
+//
+// # Metal Integration
+//
+// For GPU rendering, the window's content view uses a CAMetalLayer:
+//   - SetWantsLayer(true) enables layer-backing
+//   - SetLayer(metalLayer) attaches the Metal layer
+//   - Layer provides drawables for rendering
+//
+// # Example
+//
+//	platform := darwin.NewPlatform()
+//	if err := platform.Init(); err != nil {
+//	    return err
+//	}
+//	defer platform.Terminate()
+//
+//	window, err := platform.CreateWindow(darwin.WindowConfig{
+//	    Title:  "My App",
+//	    Width:  800,
+//	    Height: 600,
+//	})
+//	if err != nil {
+//	    return err
+//	}
+//
+//	for !window.ShouldClose() {
+//	    platform.PollEvents()
+//	    // ... render ...
+//	}
+//
+// # Build Tags
+//
+// This package only builds on darwin (macOS):
+//
+//	//go:build darwin
+//
+// # References
+//
+//   - Apple Cocoa Documentation: https://developer.apple.com/documentation/appkit
+//   - Objective-C Runtime: https://developer.apple.com/documentation/objectivec
+//   - CAMetalLayer: https://developer.apple.com/documentation/quartzcore/cametallayer
+package darwin

--- a/internal/platform/darwin/objc.go
+++ b/internal/platform/darwin/objc.go
@@ -1,0 +1,636 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"errors"
+	"sync"
+	"unsafe"
+
+	"github.com/go-webgpu/goffi/ffi"
+	"github.com/go-webgpu/goffi/types"
+)
+
+// Errors returned by Objective-C runtime operations.
+var (
+	ErrLibraryNotLoaded = errors.New("darwin: failed to load library")
+	ErrSymbolNotFound   = errors.New("darwin: symbol not found")
+	ErrClassNotFound    = errors.New("darwin: class not found")
+	ErrSendFailed       = errors.New("darwin: objc_msgSend failed")
+)
+
+// ID represents an Objective-C object pointer.
+// It wraps uintptr for type safety when working with objc objects.
+type ID uintptr
+
+// Class represents an Objective-C class pointer.
+type Class uintptr
+
+// SEL represents an Objective-C selector (method name).
+type SEL uintptr
+
+// objcRuntime holds the loaded Objective-C runtime library and function pointers.
+type objcRuntime struct {
+	once sync.Once
+	err  error
+
+	// Library handles
+	libobjc        unsafe.Pointer
+	foundation     unsafe.Pointer
+	appKit         unsafe.Pointer
+	quartzCore     unsafe.Pointer
+	coreFoundation unsafe.Pointer
+
+	// Function pointers
+	objcGetClass     unsafe.Pointer
+	objcMsgSend      unsafe.Pointer
+	objcMsgSendFpret unsafe.Pointer
+	objcMsgSendStret unsafe.Pointer
+	selRegisterName  unsafe.Pointer
+
+	// Call interfaces (reusable)
+	cifVoidPtr  *types.CallInterface // Returns void*, takes variadic args
+	cifFpret    *types.CallInterface // Returns floating point
+	cifSelector *types.CallInterface // For sel_registerName
+}
+
+var runtime objcRuntime
+
+// initRuntime initializes the Objective-C runtime by loading required libraries
+// and resolving function symbols. This is called once on first use.
+func initRuntime() error {
+	runtime.once.Do(func() {
+		runtime.err = loadRuntime()
+	})
+	return runtime.err
+}
+
+// loadRuntime loads all required macOS libraries and resolves symbols.
+func loadRuntime() error {
+	var err error
+
+	// Load libobjc.A.dylib (Objective-C runtime)
+	runtime.libobjc, err = ffi.LoadLibrary("/usr/lib/libobjc.A.dylib")
+	if err != nil {
+		return errors.Join(ErrLibraryNotLoaded, err)
+	}
+
+	// Load Foundation framework
+	runtime.foundation, err = ffi.LoadLibrary(
+		"/System/Library/Frameworks/Foundation.framework/Foundation")
+	if err != nil {
+		return errors.Join(ErrLibraryNotLoaded, err)
+	}
+
+	// Load AppKit framework
+	runtime.appKit, err = ffi.LoadLibrary(
+		"/System/Library/Frameworks/AppKit.framework/AppKit")
+	if err != nil {
+		return errors.Join(ErrLibraryNotLoaded, err)
+	}
+
+	// Load QuartzCore framework (for CAMetalLayer)
+	runtime.quartzCore, err = ffi.LoadLibrary(
+		"/System/Library/Frameworks/QuartzCore.framework/QuartzCore")
+	if err != nil {
+		return errors.Join(ErrLibraryNotLoaded, err)
+	}
+
+	// Load CoreFoundation framework
+	runtime.coreFoundation, err = ffi.LoadLibrary(
+		"/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")
+	if err != nil {
+		return errors.Join(ErrLibraryNotLoaded, err)
+	}
+
+	// Resolve objc_getClass
+	runtime.objcGetClass, err = ffi.GetSymbol(runtime.libobjc, "objc_getClass")
+	if err != nil {
+		return errors.Join(ErrSymbolNotFound, err)
+	}
+
+	// Resolve objc_msgSend
+	runtime.objcMsgSend, err = ffi.GetSymbol(runtime.libobjc, "objc_msgSend")
+	if err != nil {
+		return errors.Join(ErrSymbolNotFound, err)
+	}
+
+	// Resolve objc_msgSend_fpret (for floating point returns)
+	runtime.objcMsgSendFpret, err = ffi.GetSymbol(runtime.libobjc, "objc_msgSend_fpret")
+	if err != nil {
+		// Some platforms may not have this, fall back to objc_msgSend
+		runtime.objcMsgSendFpret = runtime.objcMsgSend
+	}
+
+	// Resolve objc_msgSend_stret (for struct returns)
+	runtime.objcMsgSendStret, err = ffi.GetSymbol(runtime.libobjc, "objc_msgSend_stret")
+	if err != nil {
+		// ARM64 doesn't use stret, fall back to objc_msgSend
+		runtime.objcMsgSendStret = runtime.objcMsgSend
+	}
+
+	// Resolve sel_registerName
+	runtime.selRegisterName, err = ffi.GetSymbol(runtime.libobjc, "sel_registerName")
+	if err != nil {
+		return errors.Join(ErrSymbolNotFound, err)
+	}
+
+	// Prepare reusable call interfaces
+	runtime.cifVoidPtr = &types.CallInterface{}
+	runtime.cifFpret = &types.CallInterface{}
+	runtime.cifSelector = &types.CallInterface{}
+
+	// CIF for generic pointer-returning calls (2 args: self, _cmd)
+	err = ffi.PrepareCallInterface(
+		runtime.cifVoidPtr,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // self (ID)
+			types.PointerTypeDescriptor, // _cmd (SEL)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// CIF for sel_registerName (1 arg: const char*)
+	err = ffi.PrepareCallInterface(
+		runtime.cifSelector,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // name
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetClass returns the Objective-C class with the given name.
+// Returns 0 if the class is not found.
+func GetClass(name string) Class {
+	if err := initRuntime(); err != nil {
+		return 0
+	}
+
+	// Convert string to C string (null-terminated)
+	cname := append([]byte(name), 0)
+
+	var result uintptr
+	namePtr := unsafe.Pointer(&cname[0])
+
+	err := ffi.CallFunction(
+		runtime.cifSelector,
+		runtime.objcGetClass,
+		unsafe.Pointer(&result),
+		[]unsafe.Pointer{unsafe.Pointer(&namePtr)},
+	)
+	if err != nil {
+		return 0
+	}
+
+	return Class(result)
+}
+
+// RegisterSelector registers a selector name and returns its SEL.
+// Selectors are cached by the runtime, so calling this multiple times
+// with the same name returns the same SEL.
+func RegisterSelector(name string) SEL {
+	if err := initRuntime(); err != nil {
+		return 0
+	}
+
+	// Convert string to C string (null-terminated)
+	cname := append([]byte(name), 0)
+
+	var result uintptr
+	namePtr := unsafe.Pointer(&cname[0])
+
+	err := ffi.CallFunction(
+		runtime.cifSelector,
+		runtime.selRegisterName,
+		unsafe.Pointer(&result),
+		[]unsafe.Pointer{unsafe.Pointer(&namePtr)},
+	)
+	if err != nil {
+		return 0
+	}
+
+	return SEL(result)
+}
+
+// Send sends a message to an Objective-C object and returns the result.
+// This is equivalent to calling objc_msgSend(self, sel).
+// For methods with arguments, use SendArgs.
+func (id ID) Send(sel SEL) ID {
+	if id == 0 || sel == 0 {
+		return 0
+	}
+
+	if err := initRuntime(); err != nil {
+		return 0
+	}
+
+	var result uintptr
+	self := uintptr(id)
+	cmd := uintptr(sel)
+
+	err := ffi.CallFunction(
+		runtime.cifVoidPtr,
+		runtime.objcMsgSend,
+		unsafe.Pointer(&result),
+		[]unsafe.Pointer{
+			unsafe.Pointer(&self),
+			unsafe.Pointer(&cmd),
+		},
+	)
+	if err != nil {
+		return 0
+	}
+
+	return ID(result)
+}
+
+// SendClass sends a message to a Class and returns the result.
+// This is used for class methods like [NSApplication sharedApplication].
+func (c Class) Send(sel SEL) ID {
+	return ID(c).Send(sel)
+}
+
+// SendSuper sends a message to the superclass implementation.
+// This is useful for delegate callbacks that need to call super.
+func (id ID) SendSuper(sel SEL) ID {
+	// For simplicity, we just call the regular Send here.
+	// A full implementation would use objc_msgSendSuper.
+	return id.Send(sel)
+}
+
+// IsNil returns true if the ID is nil (0).
+func (id ID) IsNil() bool {
+	return id == 0
+}
+
+// Ptr returns the ID as a uintptr for use with FFI.
+func (id ID) Ptr() uintptr {
+	return uintptr(id)
+}
+
+// ClassPtr returns the Class as a uintptr for use with FFI.
+func (c Class) ClassPtr() uintptr {
+	return uintptr(c)
+}
+
+// SELPtr returns the SEL as a uintptr for use with FFI.
+func (s SEL) SELPtr() uintptr {
+	return uintptr(s)
+}
+
+// msgSend is a low-level helper that calls objc_msgSend with arbitrary arguments.
+// The arguments slice contains the values to pass after self and _cmd.
+// This function creates a new CIF for each call, which is not optimal for
+// performance-critical code paths. For hot paths, create a dedicated CIF.
+func msgSend(self ID, sel SEL, args ...uintptr) ID {
+	if self == 0 || sel == 0 {
+		return 0
+	}
+
+	if err := initRuntime(); err != nil {
+		return 0
+	}
+
+	// Build argument type list: self, _cmd, then user args
+	argTypes := make([]*types.TypeDescriptor, 2+len(args))
+	argTypes[0] = types.PointerTypeDescriptor // self
+	argTypes[1] = types.PointerTypeDescriptor // _cmd
+	for i := range args {
+		argTypes[2+i] = types.PointerTypeDescriptor // Each arg as pointer
+	}
+
+	// Prepare CIF
+	cif := &types.CallInterface{}
+	err := ffi.PrepareCallInterface(
+		cif,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		argTypes,
+	)
+	if err != nil {
+		return 0
+	}
+
+	// Build argument pointers: self, sel, then user args
+	selfPtr := uintptr(self)
+	selPtr := uintptr(sel)
+	argPtrs := make([]unsafe.Pointer, 2+len(args))
+	argPtrs[0] = unsafe.Pointer(&selfPtr)
+	argPtrs[1] = unsafe.Pointer(&selPtr)
+	for i := range args {
+		argPtrs[2+i] = unsafe.Pointer(&args[i])
+	}
+
+	var result uintptr
+	err = ffi.CallFunction(
+		cif,
+		runtime.objcMsgSend,
+		unsafe.Pointer(&result),
+		argPtrs,
+	)
+	if err != nil {
+		return 0
+	}
+
+	return ID(result)
+}
+
+// SendPtr sends a message with one pointer argument.
+func (id ID) SendPtr(sel SEL, arg uintptr) ID {
+	return msgSend(id, sel, arg)
+}
+
+// SendBool sends a message with one boolean argument.
+func (id ID) SendBool(sel SEL, arg bool) ID {
+	var val uintptr
+	if arg {
+		val = 1
+	}
+	return msgSend(id, sel, val)
+}
+
+// SendInt sends a message with one integer argument.
+func (id ID) SendInt(sel SEL, arg int64) ID {
+	return msgSend(id, sel, uintptr(arg))
+}
+
+// SendUint sends a message with one unsigned integer argument.
+func (id ID) SendUint(sel SEL, arg uint64) ID {
+	return msgSend(id, sel, uintptr(arg))
+}
+
+// SendRect sends a message with an NSRect argument.
+// On x86_64, NSRect is passed by value in registers.
+// On ARM64, it may be passed differently.
+func (id ID) SendRect(sel SEL, rect NSRect) ID {
+	if id == 0 || sel == 0 {
+		return 0
+	}
+
+	if err := initRuntime(); err != nil {
+		return 0
+	}
+
+	// NSRect consists of 4 CGFloat values (32 bytes total on 64-bit)
+	// We pass them as 4 separate double arguments
+	argTypes := []*types.TypeDescriptor{
+		types.PointerTypeDescriptor, // self
+		types.PointerTypeDescriptor, // _cmd
+		types.DoubleTypeDescriptor,  // x
+		types.DoubleTypeDescriptor,  // y
+		types.DoubleTypeDescriptor,  // width
+		types.DoubleTypeDescriptor,  // height
+	}
+
+	cif := &types.CallInterface{}
+	err := ffi.PrepareCallInterface(
+		cif,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		argTypes,
+	)
+	if err != nil {
+		return 0
+	}
+
+	selfPtr := uintptr(id)
+	selPtr := uintptr(sel)
+	x := rect.Origin.X
+	y := rect.Origin.Y
+	w := rect.Size.Width
+	h := rect.Size.Height
+
+	argPtrs := []unsafe.Pointer{
+		unsafe.Pointer(&selfPtr),
+		unsafe.Pointer(&selPtr),
+		unsafe.Pointer(&x),
+		unsafe.Pointer(&y),
+		unsafe.Pointer(&w),
+		unsafe.Pointer(&h),
+	}
+
+	var result uintptr
+	err = ffi.CallFunction(
+		cif,
+		runtime.objcMsgSend,
+		unsafe.Pointer(&result),
+		argPtrs,
+	)
+	if err != nil {
+		return 0
+	}
+
+	return ID(result)
+}
+
+// SendRectUintUintBool sends a message for initWithContentRect:styleMask:backing:defer:
+// This is the standard NSWindow initialization method.
+func (id ID) SendRectUintUintBool(sel SEL, rect NSRect, style NSUInteger, backing NSBackingStoreType, deferFlag bool) ID {
+	if id == 0 || sel == 0 {
+		return 0
+	}
+
+	if err := initRuntime(); err != nil {
+		return 0
+	}
+
+	// Arguments: self, _cmd, rect (4 doubles), styleMask, backing, defer
+	argTypes := []*types.TypeDescriptor{
+		types.PointerTypeDescriptor, // self
+		types.PointerTypeDescriptor, // _cmd
+		types.DoubleTypeDescriptor,  // rect.origin.x
+		types.DoubleTypeDescriptor,  // rect.origin.y
+		types.DoubleTypeDescriptor,  // rect.size.width
+		types.DoubleTypeDescriptor,  // rect.size.height
+		types.UInt64TypeDescriptor,  // styleMask
+		types.UInt64TypeDescriptor,  // backing
+		types.UInt8TypeDescriptor,   // defer (BOOL)
+	}
+
+	cif := &types.CallInterface{}
+	err := ffi.PrepareCallInterface(
+		cif,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		argTypes,
+	)
+	if err != nil {
+		return 0
+	}
+
+	selfPtr := uintptr(id)
+	selPtr := uintptr(sel)
+	x := rect.Origin.X
+	y := rect.Origin.Y
+	w := rect.Size.Width
+	h := rect.Size.Height
+	styleVal := style     // NSUInteger is already uint64
+	backingVal := backing // NSBackingStoreType is already uint64
+	var deferVal uint8
+	if deferFlag {
+		deferVal = 1
+	}
+
+	argPtrs := []unsafe.Pointer{
+		unsafe.Pointer(&selfPtr),
+		unsafe.Pointer(&selPtr),
+		unsafe.Pointer(&x),
+		unsafe.Pointer(&y),
+		unsafe.Pointer(&w),
+		unsafe.Pointer(&h),
+		unsafe.Pointer(&styleVal),
+		unsafe.Pointer(&backingVal),
+		unsafe.Pointer(&deferVal),
+	}
+
+	var result uintptr
+	err = ffi.CallFunction(
+		cif,
+		runtime.objcMsgSend,
+		unsafe.Pointer(&result),
+		argPtrs,
+	)
+	if err != nil {
+		return 0
+	}
+
+	return ID(result)
+}
+
+// GetRect receives an NSRect return value from a method like frame.
+// On x86_64, small structs may be returned in registers.
+// On ARM64, the behavior differs.
+func (id ID) GetRect(sel SEL) NSRect {
+	if id == 0 || sel == 0 {
+		return NSRect{}
+	}
+
+	if err := initRuntime(); err != nil {
+		return NSRect{}
+	}
+
+	// For struct returns, we use a struct type descriptor
+	// NSRect is: { CGPoint origin { CGFloat x, y }, CGSize size { CGFloat width, height } }
+	// Which flattens to: { double x, double y, double width, double height }
+	// Total 32 bytes
+
+	// Create a struct type for NSRect manually
+	// TypeDescriptor with StructType kind and Members
+	rectType := &types.TypeDescriptor{
+		Size:      32, // 4 * 8 bytes (4 doubles)
+		Alignment: 8,  // double alignment
+		Kind:      types.StructType,
+		Members: []*types.TypeDescriptor{
+			types.DoubleTypeDescriptor,
+			types.DoubleTypeDescriptor,
+			types.DoubleTypeDescriptor,
+			types.DoubleTypeDescriptor,
+		},
+	}
+
+	argTypes := []*types.TypeDescriptor{
+		types.PointerTypeDescriptor, // self
+		types.PointerTypeDescriptor, // _cmd
+	}
+
+	cif := &types.CallInterface{}
+	err := ffi.PrepareCallInterface(
+		cif,
+		types.DefaultCall,
+		rectType,
+		argTypes,
+	)
+	if err != nil {
+		return NSRect{}
+	}
+
+	selfPtr := uintptr(id)
+	selPtr := uintptr(sel)
+
+	argPtrs := []unsafe.Pointer{
+		unsafe.Pointer(&selfPtr),
+		unsafe.Pointer(&selPtr),
+	}
+
+	// Result buffer for the struct
+	var result [4]float64
+	err = ffi.CallFunction(
+		cif,
+		runtime.objcMsgSend,
+		unsafe.Pointer(&result),
+		argPtrs,
+	)
+	if err != nil {
+		return NSRect{}
+	}
+
+	return NSRect{
+		Origin: NSPoint{X: result[0], Y: result[1]},
+		Size:   NSSize{Width: result[2], Height: result[3]},
+	}
+}
+
+// SendSize sends a message with an NSSize argument.
+func (id ID) SendSize(sel SEL, size NSSize) ID {
+	if id == 0 || sel == 0 {
+		return 0
+	}
+
+	if err := initRuntime(); err != nil {
+		return 0
+	}
+
+	argTypes := []*types.TypeDescriptor{
+		types.PointerTypeDescriptor, // self
+		types.PointerTypeDescriptor, // _cmd
+		types.DoubleTypeDescriptor,  // width
+		types.DoubleTypeDescriptor,  // height
+	}
+
+	cif := &types.CallInterface{}
+	err := ffi.PrepareCallInterface(
+		cif,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		argTypes,
+	)
+	if err != nil {
+		return 0
+	}
+
+	selfPtr := uintptr(id)
+	selPtr := uintptr(sel)
+	w := size.Width
+	h := size.Height
+
+	argPtrs := []unsafe.Pointer{
+		unsafe.Pointer(&selfPtr),
+		unsafe.Pointer(&selPtr),
+		unsafe.Pointer(&w),
+		unsafe.Pointer(&h),
+	}
+
+	var result uintptr
+	err = ffi.CallFunction(
+		cif,
+		runtime.objcMsgSend,
+		unsafe.Pointer(&result),
+		argPtrs,
+	)
+	if err != nil {
+		return 0
+	}
+
+	return ID(result)
+}

--- a/internal/platform/darwin/selectors.go
+++ b/internal/platform/darwin/selectors.go
@@ -1,0 +1,309 @@
+//go:build darwin
+
+package darwin
+
+import "sync"
+
+// selectors holds cached selector values.
+// Selectors are registered once and reused throughout the application lifetime.
+var selectors struct {
+	once sync.Once
+
+	// NSObject - Memory management
+	alloc   SEL
+	init    SEL
+	new     SEL
+	release SEL
+	retain  SEL
+
+	// NSApplication - Application lifecycle
+	sharedApplication                           SEL
+	setActivationPolicy                         SEL
+	activateIgnoringOtherApps                   SEL
+	run                                         SEL
+	stop                                        SEL
+	terminate                                   SEL
+	nextEventMatchingMaskUntilDateInModeDequeue SEL
+	sendEvent                                   SEL
+	finishLaunching                             SEL
+
+	// NSApplication delegate
+	setDelegate SEL
+
+	// NSWindow - Window management
+	initWithContentRectStyleMaskBackingDefer SEL
+	setTitle                                 SEL
+	title                                    SEL
+	setContentView                           SEL
+	contentView                              SEL
+	makeKeyAndOrderFront                     SEL
+	orderOut                                 SEL
+	close                                    SEL
+	miniaturize                              SEL
+	deminiaturize                            SEL
+	zoom                                     SEL
+	setFrame                                 SEL
+	frame                                    SEL
+	contentRectForFrameRect                  SEL
+	frameRectForContentRect                  SEL
+	styleMask                                SEL
+	setStyleMask                             SEL
+	setAcceptsMouseMovedEvents               SEL
+	makeFirstResponder                       SEL
+	isKeyWindow                              SEL
+	isVisible                                SEL
+	isMiniaturized                           SEL
+	isZoomed                                 SEL
+	setReleasedWhenClosed                    SEL
+	center                                   SEL
+
+	// NSView - View management
+	setWantsLayer   SEL
+	wantsLayer      SEL
+	setLayer        SEL
+	layer           SEL
+	bounds          SEL
+	setBounds       SEL
+	setNeedsDisplay SEL
+
+	// NSScreen
+	mainScreen   SEL
+	screens      SEL
+	visibleFrame SEL
+
+	// NSDate
+	distantPast   SEL
+	distantFuture SEL
+
+	// NSString
+	initWithUTF8String SEL
+	UTF8String         SEL
+	length             SEL
+
+	// NSAutoreleasePool
+	drain SEL
+
+	// CALayer / CAMetalLayer
+	setContentsScale        SEL
+	contentsScale           SEL
+	setDrawableSize         SEL
+	drawableSize            SEL
+	setDevice               SEL
+	device                  SEL
+	setPixelFormat          SEL
+	pixelFormat             SEL
+	nextDrawable            SEL
+	setFramebufferOnly      SEL
+	setMaximumDrawableCount SEL
+	setDisplaySyncEnabled   SEL
+
+	// NSEvent
+	eventType                   SEL
+	locationInWindow            SEL
+	modifierFlags               SEL
+	keyCode                     SEL
+	characters                  SEL
+	charactersIgnoringModifiers SEL
+	isARepeat                   SEL
+	buttonNumber                SEL
+	scrollingDeltaX             SEL
+	scrollingDeltaY             SEL
+	hasPreciseScrollingDeltas   SEL
+
+	// NSNotificationCenter
+	defaultCenter                 SEL
+	addObserverSelectorNameObject SEL
+	removeObserver                SEL
+
+	// NSRunLoop
+	currentRunLoop SEL
+	runMode        SEL
+}
+
+// classes holds cached class references.
+var classes struct {
+	once sync.Once
+
+	NSObject             Class
+	NSApplication        Class
+	NSWindow             Class
+	NSView               Class
+	NSScreen             Class
+	NSDate               Class
+	NSString             Class
+	NSAutoreleasePool    Class
+	NSEvent              Class
+	NSNotificationCenter Class
+	NSRunLoop            Class
+	CALayer              Class
+	CAMetalLayer         Class
+}
+
+// initSelectors registers all selectors used by the darwin package.
+func initSelectors() {
+	selectors.once.Do(func() {
+		// NSObject
+		selectors.alloc = RegisterSelector("alloc")
+		selectors.init = RegisterSelector("init")
+		selectors.new = RegisterSelector("new")
+		selectors.release = RegisterSelector("release")
+		selectors.retain = RegisterSelector("retain")
+
+		// NSApplication
+		selectors.sharedApplication = RegisterSelector("sharedApplication")
+		selectors.setActivationPolicy = RegisterSelector("setActivationPolicy:")
+		selectors.activateIgnoringOtherApps = RegisterSelector("activateIgnoringOtherApps:")
+		selectors.run = RegisterSelector("run")
+		selectors.stop = RegisterSelector("stop:")
+		selectors.terminate = RegisterSelector("terminate:")
+		selectors.nextEventMatchingMaskUntilDateInModeDequeue = RegisterSelector(
+			"nextEventMatchingMask:untilDate:inMode:dequeue:")
+		selectors.sendEvent = RegisterSelector("sendEvent:")
+		selectors.finishLaunching = RegisterSelector("finishLaunching")
+
+		// NSApplication delegate
+		selectors.setDelegate = RegisterSelector("setDelegate:")
+
+		// NSWindow
+		selectors.initWithContentRectStyleMaskBackingDefer = RegisterSelector(
+			"initWithContentRect:styleMask:backing:defer:")
+		selectors.setTitle = RegisterSelector("setTitle:")
+		selectors.title = RegisterSelector("title")
+		selectors.setContentView = RegisterSelector("setContentView:")
+		selectors.contentView = RegisterSelector("contentView")
+		selectors.makeKeyAndOrderFront = RegisterSelector("makeKeyAndOrderFront:")
+		selectors.orderOut = RegisterSelector("orderOut:")
+		selectors.close = RegisterSelector("close")
+		selectors.miniaturize = RegisterSelector("miniaturize:")
+		selectors.deminiaturize = RegisterSelector("deminiaturize:")
+		selectors.zoom = RegisterSelector("zoom:")
+		selectors.setFrame = RegisterSelector("setFrame:display:")
+		selectors.frame = RegisterSelector("frame")
+		selectors.contentRectForFrameRect = RegisterSelector("contentRectForFrameRect:")
+		selectors.frameRectForContentRect = RegisterSelector("frameRectForContentRect:")
+		selectors.styleMask = RegisterSelector("styleMask")
+		selectors.setStyleMask = RegisterSelector("setStyleMask:")
+		selectors.setAcceptsMouseMovedEvents = RegisterSelector("setAcceptsMouseMovedEvents:")
+		selectors.makeFirstResponder = RegisterSelector("makeFirstResponder:")
+		selectors.isKeyWindow = RegisterSelector("isKeyWindow")
+		selectors.isVisible = RegisterSelector("isVisible")
+		selectors.isMiniaturized = RegisterSelector("isMiniaturized")
+		selectors.isZoomed = RegisterSelector("isZoomed")
+		selectors.setReleasedWhenClosed = RegisterSelector("setReleasedWhenClosed:")
+		selectors.center = RegisterSelector("center")
+
+		// NSView
+		selectors.setWantsLayer = RegisterSelector("setWantsLayer:")
+		selectors.wantsLayer = RegisterSelector("wantsLayer")
+		selectors.setLayer = RegisterSelector("setLayer:")
+		selectors.layer = RegisterSelector("layer")
+		selectors.bounds = RegisterSelector("bounds")
+		selectors.setBounds = RegisterSelector("setBounds:")
+		selectors.setNeedsDisplay = RegisterSelector("setNeedsDisplay:")
+
+		// NSScreen
+		selectors.mainScreen = RegisterSelector("mainScreen")
+		selectors.screens = RegisterSelector("screens")
+		selectors.visibleFrame = RegisterSelector("visibleFrame")
+
+		// NSDate
+		selectors.distantPast = RegisterSelector("distantPast")
+		selectors.distantFuture = RegisterSelector("distantFuture")
+
+		// NSString
+		selectors.initWithUTF8String = RegisterSelector("initWithUTF8String:")
+		selectors.UTF8String = RegisterSelector("UTF8String")
+		selectors.length = RegisterSelector("length")
+
+		// NSAutoreleasePool
+		selectors.drain = RegisterSelector("drain")
+
+		// CALayer / CAMetalLayer
+		selectors.setContentsScale = RegisterSelector("setContentsScale:")
+		selectors.contentsScale = RegisterSelector("contentsScale")
+		selectors.setDrawableSize = RegisterSelector("setDrawableSize:")
+		selectors.drawableSize = RegisterSelector("drawableSize")
+		selectors.setDevice = RegisterSelector("setDevice:")
+		selectors.device = RegisterSelector("device")
+		selectors.setPixelFormat = RegisterSelector("setPixelFormat:")
+		selectors.pixelFormat = RegisterSelector("pixelFormat")
+		selectors.nextDrawable = RegisterSelector("nextDrawable")
+		selectors.setFramebufferOnly = RegisterSelector("setFramebufferOnly:")
+		selectors.setMaximumDrawableCount = RegisterSelector("setMaximumDrawableCount:")
+		selectors.setDisplaySyncEnabled = RegisterSelector("setDisplaySyncEnabled:")
+
+		// NSEvent
+		selectors.eventType = RegisterSelector("type")
+		selectors.locationInWindow = RegisterSelector("locationInWindow")
+		selectors.modifierFlags = RegisterSelector("modifierFlags")
+		selectors.keyCode = RegisterSelector("keyCode")
+		selectors.characters = RegisterSelector("characters")
+		selectors.charactersIgnoringModifiers = RegisterSelector("charactersIgnoringModifiers")
+		selectors.isARepeat = RegisterSelector("isARepeat")
+		selectors.buttonNumber = RegisterSelector("buttonNumber")
+		selectors.scrollingDeltaX = RegisterSelector("scrollingDeltaX")
+		selectors.scrollingDeltaY = RegisterSelector("scrollingDeltaY")
+		selectors.hasPreciseScrollingDeltas = RegisterSelector("hasPreciseScrollingDeltas")
+
+		// NSNotificationCenter
+		selectors.defaultCenter = RegisterSelector("defaultCenter")
+		selectors.addObserverSelectorNameObject = RegisterSelector(
+			"addObserver:selector:name:object:")
+		selectors.removeObserver = RegisterSelector("removeObserver:")
+
+		// NSRunLoop
+		selectors.currentRunLoop = RegisterSelector("currentRunLoop")
+		selectors.runMode = RegisterSelector("runMode:beforeDate:")
+	})
+}
+
+// initClasses loads all class references used by the darwin package.
+func initClasses() {
+	classes.once.Do(func() {
+		classes.NSObject = GetClass("NSObject")
+		classes.NSApplication = GetClass("NSApplication")
+		classes.NSWindow = GetClass("NSWindow")
+		classes.NSView = GetClass("NSView")
+		classes.NSScreen = GetClass("NSScreen")
+		classes.NSDate = GetClass("NSDate")
+		classes.NSString = GetClass("NSString")
+		classes.NSAutoreleasePool = GetClass("NSAutoreleasePool")
+		classes.NSEvent = GetClass("NSEvent")
+		classes.NSNotificationCenter = GetClass("NSNotificationCenter")
+		classes.NSRunLoop = GetClass("NSRunLoop")
+		classes.CALayer = GetClass("CALayer")
+		classes.CAMetalLayer = GetClass("CAMetalLayer")
+	})
+}
+
+// Sel returns the cached selector for common operations.
+// This provides type-safe access to selectors.
+type Sel struct{}
+
+// Selectors returns the global selector cache.
+func Selectors() *Sel {
+	initSelectors()
+	return &Sel{}
+}
+
+// Classes initializes and returns class cache.
+func Classes() {
+	initClasses()
+}
+
+// Convenience accessors for selectors
+
+// Alloc returns the alloc selector.
+func (s *Sel) Alloc() SEL { return selectors.alloc }
+
+// Init returns the init selector.
+func (s *Sel) Init() SEL { return selectors.init }
+
+// New returns the new selector.
+func (s *Sel) New() SEL { return selectors.new }
+
+// Release returns the release selector.
+func (s *Sel) Release() SEL { return selectors.release }
+
+// Retain returns the retain selector.
+func (s *Sel) Retain() SEL { return selectors.retain }

--- a/internal/platform/darwin/surface.go
+++ b/internal/platform/darwin/surface.go
@@ -1,0 +1,369 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"errors"
+)
+
+// Errors returned by Surface operations.
+var (
+	ErrMetalLayerCreationFailed = errors.New("darwin: failed to create CAMetalLayer")
+	ErrMetalDeviceNotSet        = errors.New("darwin: Metal device not set on layer")
+	ErrNoDrawableAvailable      = errors.New("darwin: no drawable available")
+)
+
+// MetalPixelFormat represents Metal pixel formats.
+type MetalPixelFormat uint
+
+// Common Metal pixel formats.
+const (
+	// MetalPixelFormatBGRA8UNorm is the standard BGRA 8-bit format.
+	MetalPixelFormatBGRA8UNorm MetalPixelFormat = 80
+
+	// MetalPixelFormatBGRA8UNormSRGB is BGRA 8-bit with sRGB gamma.
+	MetalPixelFormatBGRA8UNormSRGB MetalPixelFormat = 81
+
+	// MetalPixelFormatRGBA8UNorm is the standard RGBA 8-bit format.
+	MetalPixelFormatRGBA8UNorm MetalPixelFormat = 70
+
+	// MetalPixelFormatRGBA8UNormSRGB is RGBA 8-bit with sRGB gamma.
+	MetalPixelFormatRGBA8UNormSRGB MetalPixelFormat = 71
+
+	// MetalPixelFormatRGBA16Float is RGBA 16-bit float (HDR).
+	MetalPixelFormatRGBA16Float MetalPixelFormat = 115
+)
+
+// MetalLayer wraps a CAMetalLayer for Metal rendering.
+type MetalLayer struct {
+	id ID
+}
+
+// NewMetalLayer creates a new CAMetalLayer.
+func NewMetalLayer() (*MetalLayer, error) {
+	initSelectors()
+	initClasses()
+
+	// Create CAMetalLayer
+	layer := classes.CAMetalLayer.Send(selectors.new)
+	if layer.IsNil() {
+		return nil, ErrMetalLayerCreationFailed
+	}
+
+	return &MetalLayer{id: layer}, nil
+}
+
+// ID returns the underlying Objective-C object ID.
+func (l *MetalLayer) ID() ID {
+	if l == nil {
+		return 0
+	}
+	return l.id
+}
+
+// Ptr returns the layer as a uintptr for FFI.
+func (l *MetalLayer) Ptr() uintptr {
+	if l == nil {
+		return 0
+	}
+	return l.id.Ptr()
+}
+
+// SetDevice sets the Metal device for the layer.
+// device should be an MTLDevice pointer.
+func (l *MetalLayer) SetDevice(device uintptr) {
+	if l == nil || l.id.IsNil() {
+		return
+	}
+
+	l.id.SendPtr(selectors.setDevice, device)
+}
+
+// Device returns the Metal device used by the layer.
+func (l *MetalLayer) Device() uintptr {
+	if l == nil || l.id.IsNil() {
+		return 0
+	}
+
+	return l.id.Send(selectors.device).Ptr()
+}
+
+// SetPixelFormat sets the pixel format for the layer.
+func (l *MetalLayer) SetPixelFormat(format MetalPixelFormat) {
+	if l == nil || l.id.IsNil() {
+		return
+	}
+
+	l.id.SendUint(selectors.setPixelFormat, uint64(format))
+}
+
+// PixelFormat returns the current pixel format.
+func (l *MetalLayer) PixelFormat() MetalPixelFormat {
+	if l == nil || l.id.IsNil() {
+		return 0
+	}
+
+	result := l.id.Send(selectors.pixelFormat)
+	return MetalPixelFormat(result)
+}
+
+// SetDrawableSize sets the size of the layer's drawable textures.
+func (l *MetalLayer) SetDrawableSize(width, height int) {
+	if l == nil || l.id.IsNil() {
+		return
+	}
+
+	size := NSSize{Width: CGFloat(width), Height: CGFloat(height)}
+	l.id.SendSize(selectors.setDrawableSize, size)
+}
+
+// DrawableSize returns the current drawable size.
+func (l *MetalLayer) DrawableSize() (width, height int) {
+	if l == nil || l.id.IsNil() {
+		return 0, 0
+	}
+
+	// Get size struct - this requires GetSize method which we need to add
+	// For now, return 0,0 - this would need proper implementation
+	return 0, 0
+}
+
+// SetFramebufferOnly sets whether textures are used only for rendering.
+// Setting this to true may improve performance.
+func (l *MetalLayer) SetFramebufferOnly(framebufferOnly bool) {
+	if l == nil || l.id.IsNil() {
+		return
+	}
+
+	l.id.SendBool(selectors.setFramebufferOnly, framebufferOnly)
+}
+
+// SetMaximumDrawableCount sets the maximum number of drawables.
+// Valid values are 2 (double buffering) or 3 (triple buffering).
+func (l *MetalLayer) SetMaximumDrawableCount(count int) {
+	if l == nil || l.id.IsNil() {
+		return
+	}
+
+	// Clamp to valid range
+	if count < 2 {
+		count = 2
+	}
+	if count > 3 {
+		count = 3
+	}
+
+	l.id.SendUint(selectors.setMaximumDrawableCount, uint64(count))
+}
+
+// SetDisplaySyncEnabled enables or disables VSync.
+func (l *MetalLayer) SetDisplaySyncEnabled(enabled bool) {
+	if l == nil || l.id.IsNil() {
+		return
+	}
+
+	l.id.SendBool(selectors.setDisplaySyncEnabled, enabled)
+}
+
+// SetContentsScale sets the scale factor for the layer.
+// This should match the window's backing scale factor for Retina displays.
+func (l *MetalLayer) SetContentsScale(scale float64) {
+	if l == nil || l.id.IsNil() {
+		return
+	}
+
+	// Send CGFloat (double) argument
+	l.id.SendUint(selectors.setContentsScale, uint64(scale))
+}
+
+// NextDrawable returns the next available drawable.
+// Returns a CAMetalDrawable object ID, or 0 if none available.
+func (l *MetalLayer) NextDrawable() ID {
+	if l == nil || l.id.IsNil() {
+		return 0
+	}
+
+	return l.id.Send(selectors.nextDrawable)
+}
+
+// Release releases the layer.
+func (l *MetalLayer) Release() {
+	if l != nil && l.id != 0 {
+		l.id.Send(selectors.release)
+		l.id = 0
+	}
+}
+
+// MetalDrawable wraps a CAMetalDrawable for presentation.
+type MetalDrawable struct {
+	id ID
+}
+
+// NewMetalDrawableFromID creates a MetalDrawable from an ID.
+func NewMetalDrawableFromID(id ID) *MetalDrawable {
+	if id.IsNil() {
+		return nil
+	}
+	return &MetalDrawable{id: id}
+}
+
+// ID returns the underlying Objective-C object ID.
+func (d *MetalDrawable) ID() ID {
+	if d == nil {
+		return 0
+	}
+	return d.id
+}
+
+// Ptr returns the drawable as a uintptr for FFI.
+func (d *MetalDrawable) Ptr() uintptr {
+	if d == nil {
+		return 0
+	}
+	return d.id.Ptr()
+}
+
+// Texture returns the drawable's texture (MTLTexture).
+// The returned uintptr is an MTLTexture pointer.
+func (d *MetalDrawable) Texture() uintptr {
+	if d == nil || d.id.IsNil() {
+		return 0
+	}
+
+	texture := RegisterSelector("texture")
+	return d.id.Send(texture).Ptr()
+}
+
+// Present presents the drawable.
+// This should be called after rendering is complete.
+func (d *MetalDrawable) Present() {
+	if d == nil || d.id.IsNil() {
+		return
+	}
+
+	present := RegisterSelector("present")
+	d.id.Send(present)
+}
+
+// Surface provides a Metal rendering surface for a window.
+type Surface struct {
+	layer  *MetalLayer
+	window *Window
+}
+
+// NewSurface creates a new Metal surface for the given window.
+func NewSurface(window *Window) (*Surface, error) {
+	if window == nil {
+		return nil, errors.New("darwin: window is nil")
+	}
+
+	// Create Metal layer
+	layer, err := NewMetalLayer()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set default configuration
+	layer.SetPixelFormat(MetalPixelFormatBGRA8UNorm)
+	layer.SetFramebufferOnly(true)
+	layer.SetMaximumDrawableCount(3) // Triple buffering
+
+	// Get window size and set drawable size
+	width, height := window.Size()
+	layer.SetDrawableSize(width, height)
+
+	// Attach layer to window
+	window.SetMetalLayer(layer.ID())
+
+	return &Surface{
+		layer:  layer,
+		window: window,
+	}, nil
+}
+
+// Layer returns the underlying Metal layer.
+func (s *Surface) Layer() *MetalLayer {
+	return s.layer
+}
+
+// LayerPtr returns the CAMetalLayer pointer for Vulkan/Metal surface creation.
+func (s *Surface) LayerPtr() uintptr {
+	if s == nil || s.layer == nil {
+		return 0
+	}
+	return s.layer.Ptr()
+}
+
+// Resize updates the surface size.
+// Call this when the window is resized.
+func (s *Surface) Resize(width, height int) {
+	if s == nil || s.layer == nil {
+		return
+	}
+
+	s.layer.SetDrawableSize(width, height)
+}
+
+// AcquireDrawable acquires the next drawable for rendering.
+func (s *Surface) AcquireDrawable() (*MetalDrawable, error) {
+	if s == nil || s.layer == nil {
+		return nil, ErrMetalLayerCreationFailed
+	}
+
+	drawableID := s.layer.NextDrawable()
+	if drawableID.IsNil() {
+		return nil, ErrNoDrawableAvailable
+	}
+
+	return NewMetalDrawableFromID(drawableID), nil
+}
+
+// Destroy releases surface resources.
+func (s *Surface) Destroy() {
+	if s == nil {
+		return
+	}
+
+	if s.layer != nil {
+		s.layer.Release()
+		s.layer = nil
+	}
+
+	s.window = nil
+}
+
+// ConfigureSurface applies surface configuration.
+type SurfaceConfig struct {
+	PixelFormat          MetalPixelFormat
+	FramebufferOnly      bool
+	MaximumDrawableCount int
+	DisplaySync          bool
+	ContentsScale        float64
+}
+
+// DefaultSurfaceConfig returns a default surface configuration.
+func DefaultSurfaceConfig() SurfaceConfig {
+	return SurfaceConfig{
+		PixelFormat:          MetalPixelFormatBGRA8UNorm,
+		FramebufferOnly:      true,
+		MaximumDrawableCount: 3,
+		DisplaySync:          true,
+		ContentsScale:        1.0,
+	}
+}
+
+// Configure applies configuration to the surface.
+func (s *Surface) Configure(config SurfaceConfig) {
+	if s == nil || s.layer == nil {
+		return
+	}
+
+	s.layer.SetPixelFormat(config.PixelFormat)
+	s.layer.SetFramebufferOnly(config.FramebufferOnly)
+	s.layer.SetMaximumDrawableCount(config.MaximumDrawableCount)
+	s.layer.SetDisplaySyncEnabled(config.DisplaySync)
+
+	if config.ContentsScale > 0 {
+		s.layer.SetContentsScale(config.ContentsScale)
+	}
+}

--- a/internal/platform/darwin/types.go
+++ b/internal/platform/darwin/types.go
@@ -1,0 +1,148 @@
+//go:build darwin
+
+package darwin
+
+// CGFloat is the floating-point type used by Core Graphics.
+// On 64-bit systems (all supported macOS versions), CGFloat is float64.
+type CGFloat = float64
+
+// CGPoint represents a point in a two-dimensional coordinate system.
+type CGPoint struct {
+	X CGFloat
+	Y CGFloat
+}
+
+// CGSize represents the dimensions of a rectangle.
+type CGSize struct {
+	Width  CGFloat
+	Height CGFloat
+}
+
+// CGRect represents a rectangle defined by origin and size.
+// macOS uses a bottom-left origin coordinate system.
+type CGRect struct {
+	Origin CGPoint
+	Size   CGSize
+}
+
+// NSPoint is an alias for CGPoint in AppKit.
+type NSPoint = CGPoint
+
+// NSSize is an alias for CGSize in AppKit.
+type NSSize = CGSize
+
+// NSRect is an alias for CGRect in AppKit.
+type NSRect = CGRect
+
+// NSUInteger is the unsigned integer type used by Cocoa.
+// On 64-bit systems, NSUInteger is uint64.
+type NSUInteger = uint64
+
+// NSInteger is the signed integer type used by Cocoa.
+// On 64-bit systems, NSInteger is int64.
+type NSInteger = int64
+
+// BOOL is the Objective-C boolean type.
+// YES = 1, NO = 0.
+type BOOL = int8
+
+// Objective-C BOOL constants.
+const (
+	YES BOOL = 1
+	NO  BOOL = 0
+)
+
+// NSWindowStyleMask specifies the style of a window and its capabilities.
+type NSWindowStyleMask NSUInteger
+
+// Window style mask values.
+const (
+	// NSWindowStyleMaskBorderless creates a window with no border or title bar.
+	NSWindowStyleMaskBorderless NSWindowStyleMask = 0
+
+	// NSWindowStyleMaskTitled creates a window with a title bar.
+	NSWindowStyleMaskTitled NSWindowStyleMask = 1 << 0
+
+	// NSWindowStyleMaskClosable allows the window to be closed.
+	NSWindowStyleMaskClosable NSWindowStyleMask = 1 << 1
+
+	// NSWindowStyleMaskMiniaturizable allows the window to be minimized.
+	NSWindowStyleMaskMiniaturizable NSWindowStyleMask = 1 << 2
+
+	// NSWindowStyleMaskResizable allows the window to be resized.
+	NSWindowStyleMaskResizable NSWindowStyleMask = 1 << 3
+
+	// NSWindowStyleMaskFullScreen enables fullscreen mode.
+	NSWindowStyleMaskFullScreen NSWindowStyleMask = 1 << 14
+
+	// NSWindowStyleMaskFullSizeContentView extends content under title bar.
+	NSWindowStyleMaskFullSizeContentView NSWindowStyleMask = 1 << 15
+)
+
+// NSBackingStoreType specifies how the window buffer is stored.
+type NSBackingStoreType NSUInteger
+
+// Backing store types.
+const (
+	// NSBackingStoreBuffered uses a buffer for window contents.
+	// This is the standard mode for modern macOS.
+	NSBackingStoreBuffered NSBackingStoreType = 2
+)
+
+// NSEventMask specifies which events to receive.
+type NSEventMask NSUInteger
+
+// Event mask values.
+const (
+	// NSEventMaskAny matches any event type.
+	NSEventMaskAny NSEventMask = ^NSEventMask(0)
+)
+
+// NSEventType specifies the type of an event.
+type NSEventType NSUInteger
+
+// Event types.
+const (
+	NSEventTypeLeftMouseDown  NSEventType = 1
+	NSEventTypeLeftMouseUp    NSEventType = 2
+	NSEventTypeRightMouseDown NSEventType = 3
+	NSEventTypeRightMouseUp   NSEventType = 4
+	NSEventTypeMouseMoved     NSEventType = 5
+	NSEventTypeKeyDown        NSEventType = 10
+	NSEventTypeKeyUp          NSEventType = 11
+	NSEventTypeFlagsChanged   NSEventType = 12
+	NSEventTypeScrollWheel    NSEventType = 22
+)
+
+// NSApplicationActivationPolicy specifies how an app is activated.
+type NSApplicationActivationPolicy NSInteger
+
+// Activation policies.
+const (
+	// NSApplicationActivationPolicyRegular is a regular app with dock icon.
+	NSApplicationActivationPolicyRegular NSApplicationActivationPolicy = 0
+
+	// NSApplicationActivationPolicyAccessory is an accessory app without dock icon.
+	NSApplicationActivationPolicyAccessory NSApplicationActivationPolicy = 1
+
+	// NSApplicationActivationPolicyProhibited is a background app.
+	NSApplicationActivationPolicyProhibited NSApplicationActivationPolicy = 2
+)
+
+// MakeRect creates an NSRect from origin and size components.
+func MakeRect(x, y, width, height CGFloat) NSRect {
+	return NSRect{
+		Origin: NSPoint{X: x, Y: y},
+		Size:   NSSize{Width: width, Height: height},
+	}
+}
+
+// MakePoint creates an NSPoint from coordinates.
+func MakePoint(x, y CGFloat) NSPoint {
+	return NSPoint{X: x, Y: y}
+}
+
+// MakeSize creates an NSSize from dimensions.
+func MakeSize(width, height CGFloat) NSSize {
+	return NSSize{Width: width, Height: height}
+}

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -1,0 +1,422 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"errors"
+	"sync"
+)
+
+// Errors returned by Window operations.
+var (
+	ErrWindowCreationFailed = errors.New("darwin: window creation failed")
+	ErrViewCreationFailed   = errors.New("darwin: view creation failed")
+)
+
+// WindowConfig holds configuration for creating a window.
+type WindowConfig struct {
+	Title      string
+	Width      int
+	Height     int
+	Resizable  bool
+	Fullscreen bool
+}
+
+// Window represents an NSWindow with its content view.
+type Window struct {
+	mu          sync.Mutex
+	nsWindow    ID
+	contentView ID
+	metalLayer  ID
+	width       int
+	height      int
+	shouldClose bool
+	visible     bool
+}
+
+// NewWindow creates a new window with the given configuration.
+func NewWindow(config WindowConfig) (*Window, error) {
+	initSelectors()
+	initClasses()
+
+	w := &Window{
+		width:  config.Width,
+		height: config.Height,
+	}
+
+	// Calculate style mask
+	styleMask := NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable
+	if config.Resizable {
+		styleMask |= NSWindowStyleMaskResizable
+	}
+
+	// Create content rect
+	rect := MakeRect(0, 0, CGFloat(config.Width), CGFloat(config.Height))
+
+	// Allocate NSWindow
+	nsWindow := classes.NSWindow.Send(selectors.alloc)
+	if nsWindow.IsNil() {
+		return nil, ErrWindowCreationFailed
+	}
+
+	// Initialize window with content rect
+	nsWindow = nsWindow.SendRectUintUintBool(
+		selectors.initWithContentRectStyleMaskBackingDefer,
+		rect,
+		NSUInteger(styleMask),
+		NSBackingStoreBuffered,
+		false,
+	)
+	if nsWindow.IsNil() {
+		return nil, ErrWindowCreationFailed
+	}
+
+	w.nsWindow = nsWindow
+
+	// Set window title
+	if config.Title != "" {
+		title := NewNSString(config.Title)
+		if title != nil {
+			nsWindow.SendPtr(selectors.setTitle, title.ID().Ptr())
+			title.Release()
+		}
+	}
+
+	// Get content view
+	w.contentView = nsWindow.Send(selectors.contentView)
+	if w.contentView.IsNil() {
+		return nil, ErrViewCreationFailed
+	}
+
+	// Enable mouse events
+	nsWindow.SendBool(selectors.setAcceptsMouseMovedEvents, true)
+
+	// Don't release when closed (we manage lifecycle)
+	nsWindow.SendBool(selectors.setReleasedWhenClosed, false)
+
+	// Center window on screen
+	nsWindow.Send(selectors.center)
+
+	return w, nil
+}
+
+// Show makes the window visible and brings it to front.
+func (w *Window) Show() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	// Make key and order front (nil sender)
+	w.nsWindow.SendPtr(selectors.makeKeyAndOrderFront, 0)
+	w.visible = true
+}
+
+// Hide hides the window.
+func (w *Window) Hide() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	// Order out (nil sender)
+	w.nsWindow.SendPtr(selectors.orderOut, 0)
+	w.visible = false
+}
+
+// Close closes the window.
+func (w *Window) Close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	w.nsWindow.Send(selectors.close)
+	w.shouldClose = true
+}
+
+// SetTitle sets the window title.
+func (w *Window) SetTitle(title string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	nsTitle := NewNSString(title)
+	if nsTitle != nil {
+		w.nsWindow.SendPtr(selectors.setTitle, nsTitle.ID().Ptr())
+		nsTitle.Release()
+	}
+}
+
+// Size returns the current content size of the window.
+func (w *Window) Size() (width, height int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.width, w.height
+}
+
+// SetSize sets the window content size.
+func (w *Window) SetSize(width, height int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	w.width = width
+	w.height = height
+
+	// Get current frame
+	frame := w.nsWindow.GetRect(selectors.frame)
+
+	// Create new frame with updated size
+	newFrame := MakeRect(
+		frame.Origin.X,
+		frame.Origin.Y,
+		CGFloat(width),
+		CGFloat(height),
+	)
+
+	// Set frame with display
+	w.nsWindow.SendRect(selectors.setFrame, newFrame)
+}
+
+// ShouldClose returns true if the window should close.
+func (w *Window) ShouldClose() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.shouldClose
+}
+
+// SetShouldClose sets the should close flag.
+func (w *Window) SetShouldClose(shouldClose bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.shouldClose = shouldClose
+}
+
+// IsVisible returns true if the window is visible.
+func (w *Window) IsVisible() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.visible
+}
+
+// NSWindow returns the underlying NSWindow ID.
+func (w *Window) NSWindow() ID {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.nsWindow
+}
+
+// ContentView returns the window's content view ID.
+func (w *Window) ContentView() ID {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.contentView
+}
+
+// Handle returns the native window handle (NSWindow pointer) for surface creation.
+func (w *Window) Handle() uintptr {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.nsWindow.Ptr()
+}
+
+// ViewHandle returns the content view handle for Metal surface creation.
+func (w *Window) ViewHandle() uintptr {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.contentView.Ptr()
+}
+
+// Destroy releases window resources.
+func (w *Window) Destroy() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.metalLayer != 0 {
+		w.metalLayer.Send(selectors.release)
+		w.metalLayer = 0
+	}
+
+	if w.nsWindow != 0 {
+		w.nsWindow.Send(selectors.close)
+		w.nsWindow.Send(selectors.release)
+		w.nsWindow = 0
+	}
+
+	w.contentView = 0
+}
+
+// SetMetalLayer attaches a CAMetalLayer to the content view.
+// This enables Metal rendering for the window.
+func (w *Window) SetMetalLayer(layer ID) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.contentView.IsNil() {
+		return
+	}
+
+	// Enable layer backing
+	w.contentView.SendBool(selectors.setWantsLayer, true)
+
+	// Set the layer
+	w.contentView.SendPtr(selectors.setLayer, layer.Ptr())
+
+	w.metalLayer = layer
+}
+
+// MetalLayer returns the attached CAMetalLayer, if any.
+func (w *Window) MetalLayer() ID {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.metalLayer
+}
+
+// UpdateSize updates the cached size from the actual window size.
+// Call this after resize events.
+func (w *Window) UpdateSize() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.contentView.IsNil() {
+		return
+	}
+
+	// Get bounds of content view
+	bounds := w.contentView.GetRect(selectors.bounds)
+	w.width = int(bounds.Size.Width)
+	w.height = int(bounds.Size.Height)
+}
+
+// Frame returns the window's frame rectangle (position and size).
+func (w *Window) Frame() NSRect {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return NSRect{}
+	}
+
+	return w.nsWindow.GetRect(selectors.frame)
+}
+
+// ContentRect returns the content rectangle (inside title bar and borders).
+func (w *Window) ContentRect() NSRect {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.contentView.IsNil() {
+		return NSRect{}
+	}
+
+	return w.contentView.GetRect(selectors.bounds)
+}
+
+// Center centers the window on the screen.
+func (w *Window) Center() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	w.nsWindow.Send(selectors.center)
+}
+
+// Miniaturize minimizes the window.
+func (w *Window) Miniaturize() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	w.nsWindow.SendPtr(selectors.miniaturize, 0)
+}
+
+// Deminiaturize restores a minimized window.
+func (w *Window) Deminiaturize() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	w.nsWindow.SendPtr(selectors.deminiaturize, 0)
+}
+
+// Zoom toggles the window zoom state.
+func (w *Window) Zoom() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	w.nsWindow.SendPtr(selectors.zoom, 0)
+}
+
+// IsMiniaturized returns true if the window is minimized.
+func (w *Window) IsMiniaturized() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return false
+	}
+
+	result := w.nsWindow.Send(selectors.isMiniaturized)
+	return result != 0
+}
+
+// IsZoomed returns true if the window is zoomed (maximized).
+func (w *Window) IsZoomed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return false
+	}
+
+	result := w.nsWindow.Send(selectors.isZoomed)
+	return result != 0
+}
+
+// IsKeyWindow returns true if this is the key window.
+func (w *Window) IsKeyWindow() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return false
+	}
+
+	result := w.nsWindow.Send(selectors.isKeyWindow)
+	return result != 0
+}

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -2,34 +2,178 @@
 
 package platform
 
-import "errors"
+import (
+	"sync"
 
-// darwinPlatform is a stub for macOS.
-// TODO: Implement using Cocoa/AppKit
-type darwinPlatform struct{}
+	"github.com/gogpu/gogpu/internal/platform/darwin"
+)
+
+// darwinPlatform implements Platform for macOS using Cocoa/AppKit.
+type darwinPlatform struct {
+	mu          sync.Mutex
+	app         *darwin.Application
+	window      *darwin.Window
+	surface     *darwin.Surface
+	config      Config
+	shouldClose bool
+	events      []Event
+}
 
 func newPlatform() Platform {
 	return &darwinPlatform{}
 }
 
 func (p *darwinPlatform) Init(config Config) error {
-	return errors.New("macOS platform not yet implemented")
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.config = config
+
+	// Initialize NSApplication
+	p.app = darwin.GetApplication()
+	if err := p.app.Init(); err != nil {
+		return err
+	}
+
+	// Create window
+	windowConfig := darwin.WindowConfig{
+		Title:      config.Title,
+		Width:      config.Width,
+		Height:     config.Height,
+		Resizable:  config.Resizable,
+		Fullscreen: config.Fullscreen,
+	}
+
+	window, err := darwin.NewWindow(windowConfig)
+	if err != nil {
+		return err
+	}
+	p.window = window
+
+	// Create Metal surface for GPU rendering
+	surface, err := darwin.NewSurface(window)
+	if err != nil {
+		// Non-fatal: window works without Metal surface
+		// This allows the window to still be used with software rendering
+		p.surface = nil
+	} else {
+		p.surface = surface
+	}
+
+	// Show window
+	p.window.Show()
+
+	return nil
 }
 
 func (p *darwinPlatform) PollEvents() Event {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Process OS events
+	if p.app != nil {
+		p.app.PollEvents()
+	}
+
+	// Check if window should close
+	if p.window != nil && p.window.ShouldClose() {
+		p.shouldClose = true
+		return Event{Type: EventClose}
+	}
+
+	// Update window size and check for resize
+	if p.window != nil {
+		oldWidth, oldHeight := p.config.Width, p.config.Height
+		p.window.UpdateSize()
+		newWidth, newHeight := p.window.Size()
+
+		if newWidth != oldWidth || newHeight != oldHeight {
+			p.config.Width = newWidth
+			p.config.Height = newHeight
+
+			// Update surface size
+			if p.surface != nil {
+				p.surface.Resize(newWidth, newHeight)
+			}
+
+			return Event{
+				Type:   EventResize,
+				Width:  newWidth,
+				Height: newHeight,
+			}
+		}
+	}
+
+	// Return queued event if any
+	if len(p.events) > 0 {
+		event := p.events[0]
+		p.events = p.events[1:]
+		return event
+	}
+
 	return Event{Type: EventNone}
 }
 
 func (p *darwinPlatform) ShouldClose() bool {
-	return true
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.window != nil {
+		return p.window.ShouldClose() || p.shouldClose
+	}
+	return p.shouldClose
 }
 
 func (p *darwinPlatform) GetSize() (width, height int) {
-	return 0, 0
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.window != nil {
+		return p.window.Size()
+	}
+	return p.config.Width, p.config.Height
 }
 
 func (p *darwinPlatform) GetHandle() (instance, window uintptr) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// On macOS:
+	// - instance: 0 (not used)
+	// - window: CAMetalLayer pointer for surface creation
+	if p.surface != nil {
+		return 0, p.surface.LayerPtr()
+	}
+
+	// Fallback to content view if no surface
+	if p.window != nil {
+		return 0, p.window.ViewHandle()
+	}
+
 	return 0, 0
 }
 
-func (p *darwinPlatform) Destroy() {}
+func (p *darwinPlatform) Destroy() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.surface != nil {
+		p.surface.Destroy()
+		p.surface = nil
+	}
+
+	if p.window != nil {
+		p.window.Destroy()
+		p.window = nil
+	}
+
+	if p.app != nil {
+		p.app.Destroy()
+		p.app = nil
+	}
+}
+
+// queueEvent adds an event to the event queue.
+func (p *darwinPlatform) queueEvent(event Event) {
+	p.events = append(p.events, event)
+}

--- a/scripts/pre-release-check.sh
+++ b/scripts/pre-release-check.sh
@@ -156,79 +156,41 @@ else
 fi
 echo ""
 
-# 7. Run tests with race detector (supports WSL2 fallback)
-USE_WSL=0
-WSL_DISTRO=""
+# 7. Run tests with race detector
+# Priority: 1) kolkov/racedetector (Pure Go), 2) go test -race (requires CGO), 3) no race detection
+RACE_MODE="none"
 
-# Helper function to find WSL distro with Go installed
-find_wsl_distro() {
-    if ! command -v wsl &> /dev/null; then
-        return 1
-    fi
-
-    # Try common distros first
-    for distro in "Gentoo" "Ubuntu" "Debian" "Alpine"; do
-        if wsl -d "$distro" bash -c "command -v go &> /dev/null" 2>/dev/null; then
-            echo "$distro"
-            return 0
-        fi
-    done
-
-    return 1
-}
-
-if command -v gcc &> /dev/null || command -v clang &> /dev/null; then
-    log_info "Running tests with race detector..."
-    RACE_FLAG="-race"
-    TEST_CMD="go test -race ./... 2>&1"
+if command -v racedetector &> /dev/null; then
+    log_info "Using kolkov/racedetector (Pure Go, no CGO required)..."
+    RACE_MODE="racedetector"
+elif command -v gcc &> /dev/null || command -v clang &> /dev/null; then
+    log_info "Using standard race detector (CGO enabled)..."
+    RACE_MODE="standard"
 else
-    # Try to find WSL distro with Go
-    WSL_DISTRO=$(find_wsl_distro)
-    if [ -n "$WSL_DISTRO" ]; then
-        log_info "GCC not found locally, but WSL2 ($WSL_DISTRO) detected!"
-        log_info "Running tests with race detector via WSL2 $WSL_DISTRO..."
-        USE_WSL=1
-        RACE_FLAG="-race"
-
-        # Convert Windows path to WSL path (D:\projects\... -> /mnt/d/projects/...)
-        CURRENT_DIR=$(pwd)
-        if [[ "$CURRENT_DIR" =~ ^/([a-z])/ ]]; then
-            # Already in /d/... format (MSYS), convert to /mnt/d/...
-            WSL_PATH="/mnt${CURRENT_DIR}"
-        else
-            # Windows format D:\... convert to /mnt/d/...
-            DRIVE_LETTER=$(echo "$CURRENT_DIR" | cut -d: -f1 | tr '[:upper:]' '[:lower:]')
-            PATH_WITHOUT_DRIVE=${CURRENT_DIR#*:}
-            WSL_PATH="/mnt/$DRIVE_LETTER${PATH_WITHOUT_DRIVE//\\//}"
-        fi
-
-        TEST_CMD="wsl -d \"$WSL_DISTRO\" bash -c \"cd \\\"$WSL_PATH\\\" && go test -race -ldflags '-linkmode=external' ./... 2>&1\""
-    else
-        log_warning "GCC not found, running tests WITHOUT race detector"
-        log_info "Install GCC (mingw-w64) or setup WSL2 with Go for race detection"
-        WARNINGS=$((WARNINGS + 1))
-        RACE_FLAG=""
-        TEST_CMD="go test ./... 2>&1"
-    fi
+    log_warning "No race detector available"
+    log_info "Install: go install github.com/kolkov/racedetector/cmd/racedetector@latest"
+    WARNINGS=$((WARNINGS + 1))
 fi
 
 log_info "Running tests..."
-if [ $USE_WSL -eq 1 ]; then
-    TEST_OUTPUT=$(wsl -d "$WSL_DISTRO" bash -c "cd $WSL_PATH && timeout 180 stdbuf -oL -eL go test -race -ldflags '-linkmode=external' ./... 2>&1" || true)
-    if [ -z "$TEST_OUTPUT" ]; then
-        log_error "WSL2 tests timed out or failed to run"
-        ERRORS=$((ERRORS + 1))
-    fi
-else
-    TEST_OUTPUT=$(eval "$TEST_CMD")
-fi
+case "$RACE_MODE" in
+    "racedetector")
+        TEST_OUTPUT=$(racedetector test ./... 2>&1 || true)
+        ;;
+    "standard")
+        TEST_OUTPUT=$(go test -race ./... 2>&1 || true)
+        ;;
+    *)
+        TEST_OUTPUT=$(go test ./... 2>&1 || true)
+        ;;
+esac
 
 if echo "$TEST_OUTPUT" | grep -q "FAIL"; then
     log_error "Tests failed"
     echo "$TEST_OUTPUT"
     ERRORS=$((ERRORS + 1))
 elif echo "$TEST_OUTPUT" | grep -q "PASS\|ok"; then
-    if [ -n "$RACE_FLAG" ]; then
+    if [ "$RACE_MODE" != "none" ]; then
         log_success "All tests passed with race detector"
     else
         log_success "All tests passed (race detector not available)"


### PR DESCRIPTION
## Summary
- Pure Go Cocoa implementation via goffi (~950 LOC)
- NSApplication lifecycle management
- NSWindow and NSView creation
- CAMetalLayer integration for GPU rendering
- Cross-compilable from Windows/Linux to macOS

## Test plan
- [ ] Cross-compile: `GOOS=darwin go build ./...`
- [ ] Community testing on macOS 12+ (Monterey)

## Notes
- Requires wgpu v0.6.0 Metal backend
- Requires naga v0.5.0 MSL backend