### PR TITLE
fix(deps): update goffi to v0.3.2 for ARM64 macOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2025-12-23
+
+### Fixed
+- **macOS Apple Silicon (ARM64) support** — Updated goffi to v0.3.2
+  - Fixes runtime failure on M1/M2/M3/M4 Macs
+  - HFA structs (NSRect, NSPoint, NSSize) now correctly passed via float registers
+  - Resolves: `darwin: failed to create NSAutoreleasePool`
+
+### Changed
+- Updated dependency: go-webgpu/goffi v0.3.1 → v0.3.2
+
 ## [0.6.0] - 2025-12-23
 
 ### Added
@@ -144,7 +155,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Examples**
   - `examples/triangle/` — Simple triangle demo
 
-[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/gogpu/gogpu/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/gogpu/gogpu/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/gogpu/gogpu/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/gogpu/gogpu/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ---
 
-## Status: v0.5.x — Full Cross-Platform Support
+## Status: v0.6.x — Full Cross-Platform Support
 
 > **All major platforms now supported!** Windows, Linux (X11 + Wayland), macOS (Cocoa + Metal).
 >
@@ -213,7 +213,7 @@ gogpu/
 
 See **[ROADMAP.md](ROADMAP.md)** for the full roadmap.
 
-**Current:** v0.5.x — Full Linux + macOS Platform Support
+**Current:** v0.6.x — Full Linux + macOS Platform Support
 
 **Recent:**
 - ✅ **Linux X11 windowing (Pure Go, ~5K LOC) — Community Testing**
@@ -232,7 +232,7 @@ See **[ROADMAP.md](ROADMAP.md)** for the full roadmap.
 
 | Project | Description | Status |
 |---------|-------------|--------|
-| [gogpu/gogpu](https://github.com/gogpu/gogpu) | Graphics framework (this repo) | **v0.5.0** |
+| [gogpu/gogpu](https://github.com/gogpu/gogpu) | Graphics framework (this repo) | **v0.6.1** |
 | [gogpu/wgpu](https://github.com/gogpu/wgpu) | Pure Go WebGPU implementation | v0.6.0 |
 | [gogpu/naga](https://github.com/gogpu/naga) | Pure Go shader compiler (WGSL → SPIR-V, MSL) | v0.5.0 |
 | [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics library | v0.9.2 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,11 +16,11 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State (v0.5.0)
+## Current State (v0.6.1)
 
 | Component | Version | Description |
 |-----------|---------|-------------|
-| **gogpu/gogpu** | v0.5.0 | GPU abstraction, windowing, dual backend |
+| **gogpu/gogpu** | v0.6.1 | GPU abstraction, windowing, dual backend |
 | **gogpu/wgpu** | v0.6.0 | Pure Go WebGPU (Vulkan, Metal, GLES, Software) |
 | **gogpu/naga** | v0.5.0 | WGSL shader compiler (SPIR-V, MSL) |
 | **gogpu/gg** | v0.9.2 | 2D graphics library |

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	golang.org/x/sys v0.39.0
 )
 
-require github.com/go-webgpu/goffi v0.3.1
+require github.com/go-webgpu/goffi v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.3.1 h1:q1a7eG5gvMNbTOY8/YNGcBxyn5iVvtl9N8ifqJXiZRk=
-github.com/go-webgpu/goffi v0.3.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.3.2 h1:6eXPdX2R3ytadjmncVPUancCehcQviyurUTkK3aAMrE=
+github.com/go-webgpu/goffi v0.3.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.1.0 h1:+9YLyPmcnw6s3V0i11sHuqoBFvHIMQRFOL/S1BM1TP8=
 github.com/go-webgpu/webgpu v0.1.0/go.mod h1:pbHKdndiR4UdG/X78x9e/XmNH/0KCuHTEo061CKtAJA=
 github.com/gogpu/wgpu v0.6.0 h1:Km0hl+3fpDYBTOyYau+mW6Bp7CJgM3sQv3e8L2GiK7s=


### PR DESCRIPTION
## Summary

- Updates goffi v0.3.1 → v0.3.2
- Fixes runtime failure on Apple Silicon (M1/M2/M3/M4)
- goffi v0.3.2 includes HFA struct fix for ARM64 ABI

## Problem

User reported on Mac M4:
```
darwin: failed to create NSAutoreleasePool
```

## Root Cause

goffi v0.3.1 incorrectly passed HFA structs (NSRect with 4 doubles) by reference on ARM64. v0.3.2 fixes this by passing them in floating-point registers D0-D7 per AAPCS64 ABI.

## Test Plan

- [x] Build passes
- [x] Lint passes (0 issues)
- [ ] Test on real M1/M2/M3/M4 Mac

Fixes #10