### PR TITLE
fix(deps): update wgpu to v0.6.1 for ARM64 macOS fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/go-webgpu/webgpu v0.1.1
-	github.com/gogpu/wgpu v0.6.0
+	github.com/gogpu/wgpu v0.6.1
 	golang.org/x/sys v0.39.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.3.3 h1:sK4nmMYZG6zLTMtSXD8rXlz0PnqZU4y4u0bqmZVEADk
 github.com/go-webgpu/goffi v0.3.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.1.1 h1:qlG4oZqcAdewGnwBrBawZVSsKyIRiWnWsWMAYaiYEcA=
 github.com/go-webgpu/webgpu v0.1.1/go.mod h1:gdWdzyvKYWZ4cIegCGvUSaMDdD6MppY/sqgecPngHGI=
-github.com/gogpu/wgpu v0.6.0 h1:Km0hl+3fpDYBTOyYau+mW6Bp7CJgM3sQv3e8L2GiK7s=
-github.com/gogpu/wgpu v0.6.0/go.mod h1:LM+xYpxVOZ0U2D+RmMYoLQcZXu4h96LJJM0z+BpXkuE=
+github.com/gogpu/wgpu v0.6.1 h1:1PRTFbfiXIsNfo4H3xWr+a2f4Ig307y0WL4H61t+Ol0=
+github.com/gogpu/wgpu v0.6.1/go.mod h1:Cm3/7dV9WTl2+Csp+5Kn6EwAvCuZze+CnREnZxCHqGs=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary
Updates wgpu dependency to v0.6.1 which fixes the SIGBUS crash on macOS ARM64 (Apple Silicon).

## Changes
- `github.com/gogpu/wgpu` v0.6.0 → v0.6.1

## Fixes
- Resolves #10 (Build errors / SIGBUS crash on Mac M1/M2/M3/M4)

## wgpu v0.6.1 Changes
- Fixed goffi API usage in Metal backend (pointer argument passing)
- Fixed EGL surfaceless platform for CI headless testing
- Updated goffi to v0.3.2