### PR TITLE
fix(metal): wire Present() to HAL and add zero-dimension guard

### DIFF
--- a/app.go
+++ b/app.go
@@ -121,6 +121,12 @@ func (a *App) processEvents() {
 
 // renderFrame renders a single frame.
 func (a *App) renderFrame() {
+	// Skip rendering if window is minimized (zero dimensions)
+	width, height := a.platform.GetSize()
+	if width <= 0 || height <= 0 {
+		return // Window minimized, skip frame
+	}
+
 	// Acquire frame
 	if !a.renderer.BeginFrame() {
 		return // Frame not available


### PR DESCRIPTION
## Summary
- Wire Present() to actually call HAL Queue.Present()
- Add surface→device and SurfaceTexture tracking in registry
- Add zero-dimension guard to skip rendering when window minimized

## Root Cause
Present() in metal.go was a NO-OP - it didn't call the HAL's Queue.Present() method, causing blank windows on macOS ARM64.

## Changes
- `gpu/backend/native/registry.go` - Add surfaceDevices and currentSurfaceTextures maps
- `gpu/backend/native/metal.go` - Wire ConfigureSurface, GetCurrentTexture, and Present
- `app.go` - Add zero-dimension guard in renderFrame()

## Test plan
- [x] Build passes for darwin/arm64, linux/amd64, windows/amd64
- [x] All tests pass
- [ ] Verify triangle renders on macOS ARM64
- [ ] Verify no warnings when window minimized

Fixes #10