### PR TITLE
chore(deps): update wgpu to v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.25
 
 require (
 	github.com/go-webgpu/webgpu v0.1.1
-	github.com/gogpu/wgpu v0.6.1
+	github.com/gogpu/wgpu v0.7.0
 	golang.org/x/sys v0.39.0
 )
 
 require github.com/go-webgpu/goffi v0.3.3
+
+require github.com/gogpu/naga v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,9 @@ github.com/go-webgpu/goffi v0.3.3 h1:sK4nmMYZG6zLTMtSXD8rXlz0PnqZU4y4u0bqmZVEADk
 github.com/go-webgpu/goffi v0.3.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.1.1 h1:qlG4oZqcAdewGnwBrBawZVSsKyIRiWnWsWMAYaiYEcA=
 github.com/go-webgpu/webgpu v0.1.1/go.mod h1:gdWdzyvKYWZ4cIegCGvUSaMDdD6MppY/sqgecPngHGI=
-github.com/gogpu/wgpu v0.6.1 h1:1PRTFbfiXIsNfo4H3xWr+a2f4Ig307y0WL4H61t+Ol0=
-github.com/gogpu/wgpu v0.6.1/go.mod h1:Cm3/7dV9WTl2+Csp+5Kn6EwAvCuZze+CnREnZxCHqGs=
+github.com/gogpu/naga v0.5.0 h1:4ohXAubMXWERnp4f1Ta7Xv4ImvicKrjZUabEQzdzF0U=
+github.com/gogpu/naga v0.5.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.7.0 h1:+CodlqXb/gi8GE/HXST0e3t68tweGNsy2Y8IWsCxOy4=
+github.com/gogpu/wgpu v0.7.0/go.mod h1:MRBA/7wAukW6orOEB/8wPG3T4h7fVywF8TlgoIjKczc=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary
Update wgpu dependency to v0.7.0 which includes:
- WGSL→MSL shader compilation via naga
- CreateRenderPipeline implementation for Metal

## Changes
- `go.mod` - Updated `github.com/gogpu/wgpu` from v0.6.1 to v0.7.0
- `go.sum` - Updated checksums