### PR TITLE
docs: add CHANGELOG v0.8.0, update ROADMAP gg version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2025-12-24
+
+### Fixed
+- **Metal Backend Blank Window** — Present() was a NO-OP and didn't call HAL's Queue.Present() method
+  - Properly wires gogpu's Present() to HAL Queue.Present()
+  - Added Surface→Device tracking via registry mappings for correct queue lookup
+  - Added zero-dimension guard to skip rendering when window is minimized
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.6.1 → v0.7.0
+  - WGSL→MSL shader compilation via naga
+  - CreateRenderPipeline implementation for Metal
+
 ## [0.7.2] - 2025-12-25
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 | **gogpu/gogpu** | v0.8.0 | GPU abstraction, windowing, Metal backend fixed |
 | **gogpu/wgpu** | v0.7.0 | Pure Go WebGPU (Vulkan, Metal, GLES, Software) |
 | **gogpu/naga** | v0.6.0 | WGSL shader compiler (SPIR-V, MSL, GLSL) |
-| **gogpu/gg** | v0.13.0 | 2D graphics library (47K LOC) |
+| **gogpu/gg** | v0.15.0 | 2D graphics library (53K+ LOC) |
 
 **Key Features:**
 - Zero CGO — Pure Go, easy cross-compilation


### PR DESCRIPTION
## Summary
- Add CHANGELOG v0.8.0 section (Metal backend fix)
- Update ROADMAP gg version to v0.15.0

Documentation consistency fix - aligns docs with released versions.