### PR TITLE
chore(deps): update wgpu v0.7.2, naga v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2025-12-26
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.7.1 → v0.7.2
+  - Fixes Metal CommandEncoder state bug (wgpu Issue #24)
+  - Metal backend now properly tracks recording state via `cmdBuffer != 0`
+- Updated dependency: `github.com/gogpu/naga` v0.5.0 → v0.6.0
+  - Latest shader compiler with GLSL backend support
+
+### Notes
+- This is a maintenance release to pick up critical Metal backend fix
+- No API changes, drop-in replacement for v0.8.1
+
 ## [0.8.1] - 2025-12-26
 
 ### Fixed
@@ -237,7 +250,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Examples**
   - `examples/triangle/` — Simple triangle demo
 
-[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/gogpu/gogpu/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/gogpu/gogpu/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/gogpu/gogpu/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/gogpu/gogpu/compare/v0.7.1...v0.7.2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-## Status: v0.8.1 — Metal Backend Complete!
+## Status: v0.8.2 — Metal Backend Complete!
 
 > **Pure Go backend works on ALL platforms!** Windows (Vulkan), Linux (Vulkan), macOS (Metal).
 >
@@ -231,7 +231,7 @@ See **[ROADMAP.md](ROADMAP.md)** for the full roadmap.
 - ✅ Linux X11 windowing (Pure Go, ~5K LOC)
 - ✅ macOS Cocoa windowing (Pure Go, ~1K LOC)
 - ✅ Linux Wayland windowing (Pure Go, 5,700 LOC)
-- ✅ Metal backend for macOS (wgpu v0.6.0)
+- ✅ Metal backend for macOS (wgpu v0.7.2)
 
 **Next:**
 - DX12 backend for Windows

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.25
 
 require (
 	github.com/go-webgpu/webgpu v0.1.1
-	github.com/gogpu/wgpu v0.7.1
+	github.com/gogpu/wgpu v0.7.2
 	golang.org/x/sys v0.39.0
 )
 
 require github.com/go-webgpu/goffi v0.3.3
 
-require github.com/gogpu/naga v0.5.0 // indirect
+require github.com/gogpu/naga v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,9 @@ github.com/go-webgpu/goffi v0.3.3 h1:sK4nmMYZG6zLTMtSXD8rXlz0PnqZU4y4u0bqmZVEADk
 github.com/go-webgpu/goffi v0.3.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.1.1 h1:qlG4oZqcAdewGnwBrBawZVSsKyIRiWnWsWMAYaiYEcA=
 github.com/go-webgpu/webgpu v0.1.1/go.mod h1:gdWdzyvKYWZ4cIegCGvUSaMDdD6MppY/sqgecPngHGI=
-github.com/gogpu/naga v0.5.0 h1:4ohXAubMXWERnp4f1Ta7Xv4ImvicKrjZUabEQzdzF0U=
-github.com/gogpu/naga v0.5.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.7.1 h1:V9d0H0P3TkK1Wgeanl7Ksca9ePToxno9E7epdUeogJ4=
-github.com/gogpu/wgpu v0.7.1/go.mod h1:MRBA/7wAukW6orOEB/8wPG3T4h7fVywF8TlgoIjKczc=
+github.com/gogpu/naga v0.6.0 h1:hGfNo1F9e+r6eqZDuEl6Y9TgB7jvhLz0ii2wML7ERnw=
+github.com/gogpu/naga v0.6.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.7.2 h1:KZkCiIqcM0mlFHHC4jhVbViQiT1EoSOESoqFHkVfbm0=
+github.com/gogpu/wgpu v0.7.2/go.mod h1:cvliTk43ayrSOB1C40t9C6gY9XoWV0vE/+wcPJEyj6M=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

Dependency update to pick up critical Metal backend fix.

## Changes

- **wgpu** v0.7.1 → v0.7.2
  - Fixes Metal CommandEncoder state bug (wgpu Issue #24)
  - `isRecording` flag removed, uses `cmdBuffer != 0` pattern
- **naga** v0.5.0 → v0.6.0
  - GLSL backend support

## Documentation

- CHANGELOG.md: Added v0.8.2 entry
- README.md: Updated version badge to v0.8.2

## Test Plan

- [x] `go build ./...` — PASS

## Release

After merge, tag as **v0.8.2**