### PR TITLE
chore(deps): update wgpu v0.8.3 → v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] - 2025-12-29
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.8.3 → v0.8.4
+  - Fixes missing `clamp()` WGSL built-in function (naga v0.8.1)
+- Made README version-agnostic (removed hardcoded version numbers)
+
 ## [0.8.4] - 2025-12-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,15 +22,13 @@
 
 ---
 
-## Status: v0.8.4 — Metal macOS Fix + DX12 Complete!
+## Status: Active Development
 
 > **Pure Go backend works on ALL platforms!** Windows (Vulkan/DX12), Linux (Vulkan), macOS (Metal).
 >
-> **v0.8.4** — Metal macOS blank window fix (Issue #24) — proper drawable presentation timing
+> All 5 GPU backends complete: Vulkan, Metal, DX12, GLES, Software.
 >
-> **v0.8.3** — DX12 backend complete (~12K LOC), HLSL shader backend
->
-> **🧪 Community Testing Requested** — Help us test on macOS (M1/M2/M3/M4)!
+> **Community Testing Welcome** — Help us test on your platform!
 >
 > **Star the repo to follow progress!**
 
@@ -126,7 +124,7 @@ tex, err := renderer.LoadTextureWithOptions("tile.png", opts)
 
 ---
 
-## macOS Platform (v0.5.0+)
+## macOS Platform
 
 **Pure Go Cocoa implementation** — via goffi Objective-C runtime!
 
@@ -223,17 +221,13 @@ gogpu/
 
 See **[ROADMAP.md](ROADMAP.md)** for the full roadmap.
 
-**Current:** v0.8.4 — Metal macOS Fix
+**Completed:**
+- ✅ **All 5 GPU backends** — Vulkan, Metal, DX12, GLES, Software
+- ✅ **All 4 shader backends** — SPIR-V, MSL, GLSL, HLSL
+- ✅ **Cross-platform windowing** — Win32, Cocoa, X11, Wayland
+- ✅ **Pure Go backend for ALL platforms** — Windows, Linux, macOS
 
-**Recent:**
-- ✅ **Metal macOS blank window fix** (v0.8.4) — proper drawable presentation timing
-- ✅ **DX12 backend complete** (wgpu v0.8.0, ~12K LOC)
-- ✅ **HLSL shader backend** (naga v0.8.0) — all 4 shader backends stable
-- ✅ **Pure Go backend for ALL platforms** (Windows Vulkan/DX12, Linux Vulkan, macOS Metal)
-- ✅ Metal backend for macOS (wgpu v0.7.0)
-- ✅ Linux Wayland windowing (Pure Go, 5,700 LOC)
-
-**Next:**
+**In Progress:**
 - GUI toolkit (gogpu/ui)
 - Compute shader pipeline
 - Performance optimization
@@ -257,13 +251,13 @@ See **[ROADMAP.md](ROADMAP.md)** for the full roadmap.
 
 The Pure Go WebGPU implementation (gogpu/wgpu) now includes:
 
-| Backend | Status | Lines | Features |
-|---------|--------|-------|----------|
-| **Software** | ✅ Done | ~10K | **Full rasterizer!** Triangle rendering, depth/stencil, blending, clipping, parallel |
-| OpenGL ES | ✅ Done | ~7.5K | Windows (WGL) + Linux (EGL) |
-| **Vulkan** | ✅ Done | ~27K | **Cross-platform!** Windows/Linux/macOS, goffi FFI, Vulkan 1.3, memory allocator |
-| **Metal** | ✅ Done | ~3K | **macOS/iOS!** Pure Go via goffi Objective-C bridge |
-| **DX12** | ✅ Done | ~12K | **Windows!** Pure Go COM via syscall, D3D12, DXGI |
+| Backend | Status | Features |
+|---------|--------|----------|
+| **Software** | ✅ Done | Full rasterizer, depth/stencil, blending, clipping, parallel |
+| **OpenGL ES** | ✅ Done | Windows (WGL) + Linux (EGL) |
+| **Vulkan** | ✅ Done | Cross-platform (Windows/Linux/macOS), Vulkan 1.3 |
+| **Metal** | ✅ Done | macOS/iOS via goffi Objective-C bridge |
+| **DX12** | ✅ Done | Windows via Pure Go COM syscall |
 
 **Software backend** enables headless rendering:
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,14 +16,14 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State (v0.8.4)
+## Current State
 
-| Component | Version | Description |
-|-----------|---------|-------------|
-| **gogpu/gogpu** | v0.8.4 | GPU abstraction, windowing, Metal macOS fix |
-| **gogpu/wgpu** | v0.8.3 | Pure Go WebGPU (Vulkan, Metal, DX12, GLES, Software) |
-| **gogpu/naga** | v0.8.0 | WGSL shader compiler (SPIR-V, MSL, GLSL, HLSL) |
-| **gogpu/gg** | v0.15.1 | 2D graphics library (53K+ LOC) |
+| Component | Description |
+|-----------|-------------|
+| **gogpu/gogpu** | GPU abstraction, windowing, input |
+| **gogpu/wgpu** | Pure Go WebGPU (Vulkan, Metal, DX12, GLES, Software) |
+| **gogpu/naga** | WGSL shader compiler (SPIR-V, MSL, GLSL, HLSL) |
+| **gogpu/gg** | 2D graphics library with GPU acceleration |
 
 **Key Features:**
 - Zero CGO — Pure Go, easy cross-compilation
@@ -50,38 +50,33 @@ All platforms use Pure Go FFI (no CGO required).
 
 ## Roadmap
 
-### Q4 2025 (Current) ✅
+### Completed ✅
 
 **Platform Expansion:**
-- ✅ Linux Wayland windowing (Pure Go, 5,700 LOC)
-- ✅ macOS Cocoa windowing (Pure Go, 950 LOC)
-- ✅ Metal backend for macOS (wgpu v0.7.0, ~3K LOC)
-- ✅ MSL shader backend (naga v0.5.0, ~3.6K LOC)
-- ✅ Linux X11 windowing (Pure Go, ~5K LOC)
-- ✅ Cross-platform Pure Go backend integration (v0.7.0)
-- ✅ **Metal backend fixed (v0.8.0)** — Present, WGSL→MSL, CreateRenderPipeline
-- ✅ **GLSL shader backend (naga v0.6.0, ~2.8K LOC)** — OpenGL 3.3+, ES 3.0+
-- ✅ **DX12 backend complete (wgpu v0.8.0, ~12K LOC)** — Pure Go COM via syscall
-- ✅ **HLSL shader backend (naga v0.8.0)** — DirectX 11/12
-- ✅ **Metal macOS blank window fix (gogpu v0.8.4)** — Issue #24
+- ✅ Linux Wayland windowing (Pure Go)
+- ✅ macOS Cocoa windowing (Pure Go)
+- ✅ Metal backend for macOS
+- ✅ MSL shader backend
+- ✅ Linux X11 windowing (Pure Go)
+- ✅ Cross-platform Pure Go backend integration
+- ✅ Metal backend — Present, WGSL→MSL, CreateRenderPipeline
+- ✅ GLSL shader backend — OpenGL 3.3+, ES 3.0+
+- ✅ DX12 backend complete — Pure Go COM via syscall
+- ✅ HLSL shader backend — DirectX 11/12
+- ✅ Metal macOS fixes — Issue #24
 
-### Q1 2026
+### In Progress
 
 **Performance & Stability:**
 - SIMD optimization for 2D rendering (gg)
 - Parallel rendering pipeline
 - Platform testing and bug fixes
 
-### Q2 2026
-
 **GPU Backends:**
-- ✅ ~~DX12 backend for Windows~~ — **Done in v0.8.0!** (~12K LOC)
 - GLES improvements for Linux
 - Compute shader pipeline
 
 **Shader Compiler:**
-- ✅ ~~GLSL output support in naga~~ — **Done in v0.6.0!**
-- ✅ ~~HLSL output support in naga~~ — **Done in v0.8.0!**
 - Shader optimization passes (dead code elimination, constant folding)
 - Source maps for debugging
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.25
 
 require (
 	github.com/go-webgpu/webgpu v0.1.2
-	github.com/gogpu/wgpu v0.8.3
+	github.com/gogpu/wgpu v0.8.4
 	golang.org/x/sys v0.39.0
 )
 
 require github.com/go-webgpu/goffi v0.3.5
 
-require github.com/gogpu/naga v0.8.0 // indirect
+require github.com/gogpu/naga v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,9 @@ github.com/go-webgpu/goffi v0.3.5 h1:9QFC86mGERstCGEwMmpHJvKxtHofCsoxWpl27HZoXFw
 github.com/go-webgpu/goffi v0.3.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.1.2 h1:Ng//VzyH1f5fIFzLMtoVQwO8HcVBuUurmqjsJ86QSaU=
 github.com/go-webgpu/webgpu v0.1.2/go.mod h1:HT/5iRK0QtkQjx8DrOEDl4cdDEz2Tdkaksx34UjTEew=
-github.com/gogpu/naga v0.8.0 h1:swdhwuKBfovTqDSXhuKRNCGK+ZQtJ4zlAI7VrTomoMM=
-github.com/gogpu/naga v0.8.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.8.3 h1:WBMgCvN7tPxyLTHiQtHiub+CMdIPac5afIw3qDGU538=
-github.com/gogpu/wgpu v0.8.3/go.mod h1:K7rZ9/wF9XeYEzHwgVMGeKpniDgdt/+lPaRxA2G1CHA=
+github.com/gogpu/naga v0.8.1 h1:0lp9rHoWlVVJTZ/F5mH5HKRaL8GqA2bNSbN1tCQxcHA=
+github.com/gogpu/naga v0.8.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.8.4 h1:Ca6PygrEU/u5uMYiA8xMzibBqnSaL81Z/UOA7LDNUbw=
+github.com/gogpu/wgpu v0.8.4/go.mod h1:DyC3gTNzwYR6ru70iGbCNNtd+EH7cpnLELe2vVWl9cY=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Updated `github.com/gogpu/wgpu` v0.8.3 → v0.8.4
  - Includes naga v0.8.1 fix for missing `clamp()` WGSL built-in function

## Documentation Updates

- Made README.md version-agnostic (removed hardcoded version numbers)
- Made ROADMAP.md version-agnostic
- Updated CHANGELOG.md for v0.8.5

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Pre-release script passes

**Full Changelog**: https://github.com/gogpu/gogpu/compare/v0.8.4...chore/update-wgpu-0.8.4