### PR TITLE
chore(deps): update wgpu v0.8.5 (DX12 backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.6] - 2025-12-29
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.8.4 → v0.8.5
+  - DX12 backend now auto-registers on Windows
+  - Windows backend priority: Vulkan → DX12 → GLES → Software
+
 ## [0.8.5] - 2025-12-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Contributions are welcome! This is an early-stage project, so there's lots to do
 - 🧪 **macOS testing** — Test on real macOS systems (Monterey+)
 - 🧪 **Linux X11 testing** — Test on X11 systems (Ubuntu, Fedora, etc.)
 - 🧪 **Linux Wayland testing** — Test on Wayland compositors
-- DX12 backend for Windows
+- 🧪 **DX12 testing** — Test on Windows with DirectX 12
 - Documentation and examples
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/go-webgpu/webgpu v0.1.2
-	github.com/gogpu/wgpu v0.8.4
+	github.com/gogpu/wgpu v0.8.5
 	golang.org/x/sys v0.39.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,7 @@ github.com/go-webgpu/webgpu v0.1.2 h1:Ng//VzyH1f5fIFzLMtoVQwO8HcVBuUurmqjsJ86QSa
 github.com/go-webgpu/webgpu v0.1.2/go.mod h1:HT/5iRK0QtkQjx8DrOEDl4cdDEz2Tdkaksx34UjTEew=
 github.com/gogpu/naga v0.8.1 h1:0lp9rHoWlVVJTZ/F5mH5HKRaL8GqA2bNSbN1tCQxcHA=
 github.com/gogpu/naga v0.8.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.8.4 h1:Ca6PygrEU/u5uMYiA8xMzibBqnSaL81Z/UOA7LDNUbw=
-github.com/gogpu/wgpu v0.8.4/go.mod h1:DyC3gTNzwYR6ru70iGbCNNtd+EH7cpnLELe2vVWl9cY=
+github.com/gogpu/wgpu v0.8.5 h1:fEH1n6zvwnR8hAguNTkUm2zUoxwTG6auwTJVQ3SVWSs=
+github.com/gogpu/wgpu v0.8.5/go.mod h1:DyC3gTNzwYR6ru70iGbCNNtd+EH7cpnLELe2vVWl9cY=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Update wgpu dependency v0.8.4 → v0.8.5
- DX12 backend now auto-registers on Windows
- Update README: DX12 now needs testing, not implementation

## Changes

| File | Description |
|------|-------------|
| `go.mod` | wgpu v0.8.4 → v0.8.5 |
| `CHANGELOG.md` | Add v0.8.6 entry |
| `README.md` | Update "Areas where we need help" |

## wgpu v0.8.5 Highlights

- DX12 backend auto-registers via `hal/dx12/init.go`
- Windows backend priority: Vulkan → DX12 → GLES → Software
- All 5 HAL backends now fully integrated

## Test Plan

- [x] `go build ./...` passes
- [ ] CI passes
