### PR TITLE
chore(deps): update wgpu v0.9.0 → v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-01-05
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.9.0 → v0.9.1
+  - Fix vkDestroyDevice memory leak
+  - Vulkan features mapping (9 features)
+  - Vulkan limits mapping (25+ limits)
+
 ## [0.9.0] - 2026-01-05
 
 ### Changed
@@ -357,7 +365,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Examples**
   - `examples/triangle/` — Simple triangle demo
 
-[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.8.9...HEAD
+[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/gogpu/gogpu/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/gogpu/gogpu/compare/v0.8.9...v0.9.0
 [0.8.9]: https://github.com/gogpu/gogpu/compare/v0.8.8...v0.8.9
 [0.8.8]: https://github.com/gogpu/gogpu/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/gogpu/gogpu/compare/v0.8.6...v0.8.7

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/go-webgpu/webgpu v0.1.4
-	github.com/gogpu/wgpu v0.9.0
+	github.com/gogpu/wgpu v0.9.1
 	golang.org/x/sys v0.39.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,7 @@ github.com/go-webgpu/webgpu v0.1.4 h1:ryaKVNDXzrdE4VInxkzpgs9sLD8IDothoWVxhIltli
 github.com/go-webgpu/webgpu v0.1.4/go.mod h1:hi9vqLHfaHeTYZ/R+03WQAs5ovRu6Oi1UL7n9lRFr60=
 github.com/gogpu/naga v0.8.3 h1:HcJ1dlIzANnqGSeowDNrOv9W/96KVExxPH4iXUWxtno=
 github.com/gogpu/naga v0.8.3/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.9.0 h1:KuFSn81uwJOUzkf+NpnoSqzSPt+gAOILF2O4CFz1aYw=
-github.com/gogpu/wgpu v0.9.0/go.mod h1:YvNpvYzZnN5s3tZK/CTwbxXiJiQ6RoMagWUS9NkPthA=
+github.com/gogpu/wgpu v0.9.1 h1:BEn+RXh+SV8ha2G2xkshmnj82YqJfxFIabyhOe4qRZ8=
+github.com/gogpu/wgpu v0.9.1/go.mod h1:YvNpvYzZnN5s3tZK/CTwbxXiJiQ6RoMagWUS9NkPthA=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

Update wgpu dependency to v0.9.1 with Vulkan backend fixes.

## Changes

- `go.mod`: wgpu v0.9.0 → v0.9.1
- `CHANGELOG.md`: Document v0.9.1

## wgpu v0.9.1 Fixes

- **vkDestroyDevice memory leak** — Device now properly destroyed via goffi
- **Vulkan features mapping** — 9 features mapped to WebGPU
- **Vulkan limits mapping** — 25+ hardware limits mapped

## Test Plan

- [x] `go build ./...` — Pass
- [x] `go test ./...` — Pass
- [x] `golangci-lint run` — 0 issues