### PR TITLE
chore(deps): update wgpu v0.9.1 → v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-01-05
+
+### Fixed
+
+#### CI
+- **Metal Tests on CI** — Skip Metal-dependent darwin tests on GitHub Actions ([#36])
+  - Metal unavailable in virtualized macOS runners
+  - See: https://github.com/actions/runner-images/discussions/6138
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.9.1 → v0.9.2
+  - Metal NSString double-free fix on autorelease pool drain
+
+[#36]: https://github.com/gogpu/gogpu/pull/36
+
 ## [0.9.1] - 2026-01-05
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/go-webgpu/webgpu v0.1.4
-	github.com/gogpu/wgpu v0.9.1
+	github.com/gogpu/wgpu v0.9.2
 	golang.org/x/sys v0.39.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,7 @@ github.com/go-webgpu/webgpu v0.1.4 h1:ryaKVNDXzrdE4VInxkzpgs9sLD8IDothoWVxhIltli
 github.com/go-webgpu/webgpu v0.1.4/go.mod h1:hi9vqLHfaHeTYZ/R+03WQAs5ovRu6Oi1UL7n9lRFr60=
 github.com/gogpu/naga v0.8.3 h1:HcJ1dlIzANnqGSeowDNrOv9W/96KVExxPH4iXUWxtno=
 github.com/gogpu/naga v0.8.3/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.9.1 h1:BEn+RXh+SV8ha2G2xkshmnj82YqJfxFIabyhOe4qRZ8=
-github.com/gogpu/wgpu v0.9.1/go.mod h1:YvNpvYzZnN5s3tZK/CTwbxXiJiQ6RoMagWUS9NkPthA=
+github.com/gogpu/wgpu v0.9.2 h1:IHJ9/6Rf72MDB//wOqivbyCa99atoSrYOnrFLR4wGek=
+github.com/gogpu/wgpu v0.9.2/go.mod h1:YvNpvYzZnN5s3tZK/CTwbxXiJiQ6RoMagWUS9NkPthA=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary
- Update wgpu dependency to v0.9.2
- Metal NSString double-free fix on autorelease pool drain

## Related
- gogpu/wgpu#39