### PR TITLE
fix: respect purego build tag in rust backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-01-16
+
+### Fixed
+- **Pure Go Build Tags** — `-tags purego` now correctly excludes Rust backend ([#40])
+  - `rust.go`: `windows` → `windows && !purego`
+  - `rust_stub.go`: `!windows` → `!windows || purego`
+
+### Documentation
+- Added quick start tip for `-tags purego` in README
+- Added troubleshooting note for `wgpu_native.dll` error
+
 ## [0.10.0] - 2026-01-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ go get github.com/gogpu/gogpu
 - Go 1.25+
 - For Rust backend: [wgpu-native](https://github.com/gfx-rs/wgpu-native/releases) library
 
+**Quick start without external dependencies:**
+```bash
+go run -tags purego .
+```
+
 ---
 
 ## Quick Start
@@ -112,6 +117,8 @@ app := gogpu.NewApp(gogpu.DefaultConfig().WithBackend(gogpu.BackendGo))
 |---------|---------|----------|
 | **Rust** | wgpu-native via FFI | Production apps, maximum performance |
 | **Native Go** | gogpu/wgpu | Zero dependencies, simple deployment |
+
+> **Tip:** If you see `Failed to load wgpu_native.dll`, use `-tags purego` to skip the Rust backend.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,6 +68,7 @@ All platforms use Pure Go FFI (no CGO required).
 - ✅ CI Metal test fixes (v0.8.9) — Skip Metal tests on GitHub Actions
 - ✅ DeviceProvider interface — Standardized GPU resource access for external libraries (v0.10.0)
 - ✅ Compute shader support — Full compute pipeline in both Rust and Native backends (v0.10.0)
+- ✅ Pure Go build tags fix — `-tags purego` correctly excludes Rust backend (v0.10.1)
 
 ### In Progress
 

--- a/gpu/backend/rust/rust.go
+++ b/gpu/backend/rust/rust.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build windows && !purego
 
 // Package rust provides the WebGPU backend using wgpu-native (Rust) via go-webgpu/webgpu.
 // This backend offers maximum performance and is battle-tested in production.

--- a/gpu/backend/rust/rust_stub.go
+++ b/gpu/backend/rust/rust_stub.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows || purego
 
 // Package rust provides the WebGPU backend using wgpu-native (Rust).
 // This stub is used on non-Windows platforms where go-webgpu/goffi is not yet supported.


### PR DESCRIPTION
## Summary
- Fix `-tags purego` not excluding Rust backend on Windows
- Add quick start tip and troubleshooting note to README
- Update CHANGELOG and ROADMAP for v0.10.1

## Problem
Build tags were missing `\!purego` constraint, causing rust backend to load even when `-tags purego` was specified.

## Solution
- `rust.go`: `//go:build windows` → `//go:build windows && \!purego`
- `rust_stub.go`: `//go:build \!windows` → `//go:build \!windows || purego`

Fixes #40