### PR TITLE
fix(platform): handle Alt key events on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-02-02
+
+### Fixed
+
+- **Windows Alt Key Events** — Alt key now works correctly on Windows
+  - Added `WM_SYSKEYDOWN`/`WM_SYSKEYUP` message handlers
+  - Windows sends Alt through system key messages, not regular key messages
+  - Alt+F4 preserved, menu activation suppressed
+  - Thanks to @qq1792569310 for reporting ([#67](https://github.com/gogpu/gogpu/pull/67))
+
 ## [0.15.0] - 2026-02-01
 
 ### Added
@@ -643,7 +653,8 @@ Window responsiveness fix for Pure Go Vulkan backend.
 - **Examples**
   - `examples/triangle/` — Simple triangle demo
 
-[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/gogpu/gogpu/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/gogpu/gogpu/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/gogpu/gogpu/compare/v0.13.3...v0.14.0
 [0.13.3]: https://github.com/gogpu/gogpu/compare/v0.13.2...v0.13.3

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -25,7 +25,9 @@ const (
 	wmExitSizeMove     = 0x0232 // End of resize/move modal loop
 	wmKeydown          = 0x0100
 	wmKeyup            = 0x0101
-	htClient           = 1 // WM_SETCURSOR hit test code for client area
+	wmSysKeydown       = 0x0104 // System key down (Alt, F10)
+	wmSysKeyup         = 0x0105 // System key up (Alt, F10)
+	htClient           = 1      // WM_SETCURSOR hit test code for client area
 	idcArrow           = 32512
 	swShowNormal       = 1
 	swShow             = 5
@@ -814,7 +816,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		})
 		return 0
 
-	case wmKeydown:
+	case wmKeydown, wmSysKeydown:
 		// Convert vkCode to Key
 		key := vkCodeToKey(wParam)
 		mods := getKeyModifiers()
@@ -827,15 +829,29 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 			p.shouldClose = true
 			p.queueEvent(Event{Type: EventClose})
 		}
+
+		// For WM_SYSKEYDOWN: let DefWindowProc handle Alt+F4, Alt+Tab
+		// but suppress menu activation on Alt alone
+		if message == wmSysKeydown {
+			// Alt+F4 should still close the window
+			if wParam == vkF4 && mods&gpucontext.ModAlt != 0 {
+				ret, _, _ := procDefWindowProcW.Call(uintptr(hwnd), uintptr(message), wParam, lParam)
+				return ret
+			}
+			// Suppress other system key behavior (menu activation)
+			return 0
+		}
 		return 0
 
-	case wmKeyup:
+	case wmKeyup, wmSysKeyup:
 		// Convert vkCode to Key
 		key := vkCodeToKey(wParam)
 		mods := getKeyModifiers()
 
 		// Dispatch keyboard event
 		p.dispatchKeyEvent(key, mods, false)
+
+		// For WM_SYSKEYUP: suppress menu activation
 		return 0
 
 	case wmSetCursor:


### PR DESCRIPTION
## Summary

Fix Alt key events not working on Windows.

**Root cause:** Windows sends Alt key through `WM_SYSKEYDOWN`/`WM_SYSKEYUP` messages, not regular `WM_KEYDOWN`/`WM_KEYUP`. Our code only handled the regular messages.

**Changes:**
- Add `wmSysKeydown` (0x0104) and `wmSysKeyup` (0x0105) constants
- Handle system key messages alongside regular key messages
- Preserve Alt+F4 functionality via DefWindowProc
- Suppress menu activation on Alt press alone

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues
- [ ] Manual test: Alt key events fire on Windows

Fixes issue reported by @qq1792569310 in #67.
