### PR TITLE
fix(input): initialize input state before event callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-02-03
+
+### Fixed
+
+- **Input State Initialization** — `app.Input().Keyboard().Pressed()` now works correctly in `OnUpdate`
+  - Input state is now initialized before event callbacks are registered
+  - Fixes race condition where key events were missed on first frame
+  - Follows Ebitengine/GLFW/SDL pattern for eager initialization
+  - Thanks to @qq1792569310 for reporting ([#71](https://github.com/gogpu/gogpu/issues/71))
+
 ## [0.15.1] - 2026-02-02
 
 ### Fixed

--- a/app.go
+++ b/app.go
@@ -99,6 +99,11 @@ func (a *App) Run() error {
 	}
 	defer a.platform.Destroy()
 
+	// Initialize input state BEFORE setting up event callbacks.
+	// This ensures keyboard/mouse state is captured from the first event.
+	// (Follows Ebitengine/GLFW/SDL pattern - state must exist before callbacks)
+	a.inputState = input.New()
+
 	// Wire platform callbacks to eventSourceAdapter for input events
 	a.setupInputEvents()
 

--- a/event_source.go
+++ b/event_source.go
@@ -210,8 +210,12 @@ func (a *App) EventSource() gpucontext.EventSource {
 // Note: Input state is automatically updated each frame. The "JustPressed"
 // and "JustReleased" methods work correctly across frames.
 // All methods are thread-safe.
+//
+// Input() can be called before Run(), but the state will only be populated
+// once the main loop starts processing events.
 func (a *App) Input() *input.State {
 	if a.inputState == nil {
+		// Eager initialization for calls before Run()
 		a.inputState = input.New()
 	}
 	return a.inputState


### PR DESCRIPTION
## Summary

- Initialize input state in `Run()` before `setupInputEvents()` is called
- Fixes race condition where key events were missed on first frame
- `app.Input().Keyboard().Pressed()` and `Modifier()` now work correctly in `OnUpdate`

## Root Cause

Input state was initialized lazily in `Input()` method, but event callbacks were registered earlier in `setupInputEvents()`. Events arriving before first `Input()` call were not recorded.

## Solution

Follow Ebitengine/GLFW/SDL pattern — eager initialization before callbacks:

```go
// app.go:102-106
a.inputState = input.New()      // Initialize FIRST
a.setupInputEvents()            // Then register callbacks
```

## Test plan

- [x] Build passes
- [x] Tests pass
- [x] Linter passes
- [ ] Manual test: `Pressed(KeyControlLeft)` returns true in `OnUpdate` when Ctrl held

Fixes #71
