### PR TITLE
chore: update wgpu v0.16.6, goffi v0.3.9 (v0.19.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.4] - 2026-02-18
+
+### Dependencies
+
+- wgpu v0.16.5 → v0.16.6 (Metal debug logging, goffi v0.3.9)
+
 ## [0.19.3] - 2026-02-18
 
 ### Dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.19.3
+## Current State: v0.19.4
 
 ✅ **Production-ready** with full feature set:
 - Dual backend (Rust/Pure Go) — **Rust backend now cross-platform** (Windows, macOS, Linux)
@@ -36,6 +36,9 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 - Cross-platform: Windows (Vulkan/DX12), Linux (Vulkan), macOS (Metal)
 - Structured logging via log/slog
 - HAL-direct architecture (no handle maps)
+
+**New in v0.19.4:**
+- wgpu v0.16.6 (Metal debug logging, goffi v0.3.9)
 
 **New in v0.19.3:**
 - wgpu v0.16.5 (per-encoder command pools, fixes VkCommandBuffer crash)
@@ -134,7 +137,9 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.19.2** | 2026-02 | Hot-path benchmarks, wgpu v0.16.4 (timeline semaphore, FencePool) |
+| **v0.19.4** | 2026-02 | wgpu v0.16.6 (Metal debug logging, goffi v0.3.9) |
+| v0.19.3 | 2026-02 | wgpu v0.16.5 (per-encoder command pools) |
+| v0.19.2 | 2026-02 | Hot-path benchmarks, wgpu v0.16.4 (timeline semaphore, FencePool) |
 | v0.19.1 | 2026-02 | WaitIdle cleanup, wgpu v0.16.3 |
 | v0.19.0 | 2026-02 | Cross-platform Rust backend, wgpu v0.16.2 |
 | v0.18.2 | 2026-02 | Update wgpu v0.16.1 (Vulkan framebuffer cache fix) |

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/gogpu/gogpu
 go 1.25
 
 require (
-	github.com/go-webgpu/goffi v0.3.8
+	github.com/go-webgpu/goffi v0.3.9
 	github.com/go-webgpu/webgpu v0.3.0
 	github.com/gogpu/gpucontext v0.9.0
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/wgpu v0.16.5
+	github.com/gogpu/wgpu v0.16.6
 	golang.org/x/sys v0.41.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM=
-github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc=
+github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.3.0 h1:cAZb/FoZzflGCxBJV7Ub8GYkVGgJ1ul3IBDqqRb9RQQ=
 github.com/go-webgpu/webgpu v0.3.0/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
@@ -8,7 +8,7 @@ github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.13.1 h1:lqv0uIp9dseio6Jzd/a8XvQH0/LWrCimlbVWWD+utEg=
 github.com/gogpu/naga v0.13.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.16.5 h1:1sGvJmEPBw4rf1TpC2CsZBjtWqvFZbeJij6E+rJP2Y8=
-github.com/gogpu/wgpu v0.16.5/go.mod h1:YFQDWr7eaMFLaEK4vS4chtB896nv0/vJe7dnDT4cSQU=
+github.com/gogpu/wgpu v0.16.6 h1:MnhVaxcvc2XGhTyoNlxminyRsFmNucAc4/J2AdTN8L8=
+github.com/gogpu/wgpu v0.16.6/go.mod h1:sk33dl3ISPZY6zMtXXb5UAJonglIvkTkMfzFD3n5EMc=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Update wgpu v0.16.5 → v0.16.6 (Metal debug logging across rendering path)
- Update goffi v0.3.8 → v0.3.9 (transitive via wgpu)
- Update CHANGELOG.md, ROADMAP.md

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./...` — passes
- [x] `golangci-lint run` — 0 issues
- [x] `go fmt` — no changes