### PR TITLE
chore: update go-webgpu/webgpu v0.3.1, ARM64 callback fix (v0.19.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.5] - 2026-02-18
+
+### Dependencies
+
+- go-webgpu/webgpu v0.3.0 → v0.3.1 (goffi v0.3.9 — ARM64 callback trampoline fix)
+
 ## [0.19.4] - 2026-02-18
 
 ### Dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.19.4
+## Current State: v0.19.5
 
 ✅ **Production-ready** with full feature set:
 - Dual backend (Rust/Pure Go) — **Rust backend now cross-platform** (Windows, macOS, Linux)
@@ -36,6 +36,9 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 - Cross-platform: Windows (Vulkan/DX12), Linux (Vulkan), macOS (Metal)
 - Structured logging via log/slog
 - HAL-direct architecture (no handle maps)
+
+**New in v0.19.5:**
+- go-webgpu/webgpu v0.3.1 (Rust backend: ARM64 callback trampoline fix)
 
 **New in v0.19.4:**
 - wgpu v0.16.6 (Metal debug logging, goffi v0.3.9)
@@ -137,7 +140,8 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.19.4** | 2026-02 | wgpu v0.16.6 (Metal debug logging, goffi v0.3.9) |
+| **v0.19.5** | 2026-02 | webgpu v0.3.1 (Rust backend: ARM64 callback fix) |
+| v0.19.4 | 2026-02 | wgpu v0.16.6 (Metal debug logging, goffi v0.3.9) |
 | v0.19.3 | 2026-02 | wgpu v0.16.5 (per-encoder command pools) |
 | v0.19.2 | 2026-02 | Hot-path benchmarks, wgpu v0.16.4 (timeline semaphore, FencePool) |
 | v0.19.1 | 2026-02 | WaitIdle cleanup, wgpu v0.16.3 |

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/go-webgpu/goffi v0.3.9
-	github.com/go-webgpu/webgpu v0.3.0
+	github.com/go-webgpu/webgpu v0.3.1
 	github.com/gogpu/gpucontext v0.9.0
 	github.com/gogpu/gputypes v0.2.0
 	github.com/gogpu/wgpu v0.16.6

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc=
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.3.0 h1:cAZb/FoZzflGCxBJV7Ub8GYkVGgJ1ul3IBDqqRb9RQQ=
-github.com/go-webgpu/webgpu v0.3.0/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
+github.com/go-webgpu/webgpu v0.3.1 h1:GxaJ3Cz2FGzHZ3adAYvuRFTdCMcwrENLbuilyIxSH0o=
+github.com/go-webgpu/webgpu v0.3.1/go.mod h1:lPa1+DhNDB3jb97/KI2ivW+ewK1V9x4k58fObvWBhR4=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=


### PR DESCRIPTION
## Summary

- Update go-webgpu/webgpu v0.3.0 → v0.3.1 (Rust backend gets goffi v0.3.9 ARM64 callback trampoline fix)
- Update CHANGELOG.md, ROADMAP.md

Important for gogpu#89 diagnosis — ensures Rust backend on macOS Apple Silicon has correct ARM64 callbacks.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./...` — passes
- [x] `golangci-lint run` — 0 issues