### PR TITLE
chore: update wgpu v0.16.14 (v0.20.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.5] - 2026-02-25
+
+### Dependencies
+
+- wgpu v0.16.13 → v0.16.14 (Vulkan null surface handle guard, naga v0.14.3)
+
 ## [0.20.4] - 2026-02-24
 
 ### Dependencies
@@ -1042,7 +1048,13 @@ Window responsiveness fix for Pure Go Vulkan backend.
 - **Examples**
   - `examples/triangle/` — Simple triangle demo
 
-[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.19.2...HEAD
+[Unreleased]: https://github.com/gogpu/gogpu/compare/v0.20.5...HEAD
+[0.20.5]: https://github.com/gogpu/gogpu/compare/v0.20.4...v0.20.5
+[0.20.4]: https://github.com/gogpu/gogpu/compare/v0.20.3...v0.20.4
+[0.20.3]: https://github.com/gogpu/gogpu/compare/v0.20.2...v0.20.3
+[0.20.2]: https://github.com/gogpu/gogpu/compare/v0.20.1...v0.20.2
+[0.20.1]: https://github.com/gogpu/gogpu/compare/v0.20.0...v0.20.1
+[0.20.0]: https://github.com/gogpu/gogpu/compare/v0.19.2...v0.20.0
 [0.19.2]: https://github.com/gogpu/gogpu/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/gogpu/gogpu/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/gogpu/gogpu/compare/v0.18.2...v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/go-webgpu/webgpu v0.3.1
 	github.com/gogpu/gpucontext v0.9.0
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/wgpu v0.16.13
+	github.com/gogpu/wgpu v0.16.14
 	golang.org/x/sys v0.41.0
 )
 
-require github.com/gogpu/naga v0.14.2 // indirect
+require github.com/gogpu/naga v0.14.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,9 @@ github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Lo
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.14.2 h1:jja1gsYtJB+2gpcAXU5HYZ9OLA/sTrRMbM1dK+AIQL8=
-github.com/gogpu/naga v0.14.2/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.16.13 h1:6CQNf4YAdGWq7LzPHgbPW5dSyp7fAYhK+cfN0AMyz5M=
-github.com/gogpu/wgpu v0.16.13/go.mod h1:zgnoQiOqOIJyfKH9PXqOi7GjQF1/nAAJANmHEgcEIJg=
+github.com/gogpu/naga v0.14.3 h1:N/o/2vT+EG/1m7TZEAXjANPbIQaqP3rDAZxARZ9bJTw=
+github.com/gogpu/naga v0.14.3/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.16.14 h1:18LAZ2O+9fp0QChp3GOTOBP3yiALRONZ2zTWAsltbRk=
+github.com/gogpu/wgpu v0.16.14/go.mod h1:pcPQkEBJtQO5/Lg/0LUrQM8PQkhNbm9GpqfVCx4dNL4=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Dependencies: wgpu v0.16.13 → v0.16.14 (Vulkan null surface handle guard + naga v0.14.3)
- Prevents SIGSEGV on Linux when Vulkan surface creation fails (#106)

## Test plan

- [x] `GOWORK=off go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] `go fmt` clean
- [ ] CI green
