### PR TITLE
ci: upgrade codecov-action v4 → v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,13 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.txt
+        files: ./coverage.txt
         flags: unittests
         name: codecov-gogpu
+        fail_ci_if_error: true
 
   # Linting
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,17 @@ jobs:
       shell: bash
       run: racedetector test -v -coverprofile=coverage.txt -covermode=atomic ./...
 
+    - name: Verify coverage file
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        if [ -f coverage.txt ]; then
+          echo "coverage.txt found ($(wc -l < coverage.txt) lines)"
+        else
+          echo "coverage.txt not found, generating separately..."
+          go test -coverprofile=coverage.txt -covermode=atomic ./... || true
+        fi
+
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

- Upgrade `codecov/codecov-action` from v4 to v5
- Enable `fail_ci_if_error: true` to surface upload failures in CI
- Use `files:` parameter (v5 syntax, replaces `file:`)

Coverage uploads were silently failing with v4 (exit code 1 masked by `fail_ci_if_error: false`), resulting in "unknown" badges on all repos.

## Test plan

- [ ] CI passes with v5 action
- [ ] Codecov upload step succeeds (not just "skipped")
- [ ] Coverage badge updates from "unknown" to actual percentage
