### PR TITLE
fix: use objc_msgSend_stret for NSRect returns on x86_64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.5] - 2026-03-04
+
+### Fixed
+
+- **x86_64 macOS: SIGSEGV in GetRect** — use `objc_msgSend_stret` for NSRect (32-byte)
+  struct returns on Intel Macs. The x86_64 SysV ABI requires `_stret` for struct returns
+  exceeding 16 bytes; ARM64 is unaffected ([#125](https://github.com/gogpu/gogpu/issues/125))
+
+### Changed
+
+- **Update webgpu v0.4.1 → v0.4.2** — goffi purego compatibility fix (nofakecgo build tag),
+  x/sys v0.41.0
+- **Update goffi v0.4.1 → v0.4.2**
+
 ## [0.22.4] - 2026-03-02
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/gogpu/gogpu
 go 1.25
 
 require (
-	github.com/go-webgpu/goffi v0.4.1
-	github.com/go-webgpu/webgpu v0.4.1
+	github.com/go-webgpu/goffi v0.4.2
+	github.com/go-webgpu/webgpu v0.4.2
 	github.com/gogpu/gpucontext v0.9.0
 	github.com/gogpu/gputypes v0.2.0
 	github.com/gogpu/wgpu v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/go-webgpu/goffi v0.4.1 h1:2hQH5XXloxTyTtIleYv+Rajlwzp6UOETURhSZ5+zJxU=
-github.com/go-webgpu/goffi v0.4.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.4.1 h1:PT9Wb2947qQY1oR5itKWXgieCG/265tUg/762WR6mrU=
-github.com/go-webgpu/webgpu v0.4.1/go.mod h1:wFLIOZByL/XYk1zs6rKUK8WgyMPRf4EIwlcwYb1/BNo=
+github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU=
+github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/webgpu v0.4.2 h1:phQCeD5zY8jTgNjkrs090JYUMpqNPO7a9DMXvnHcQ2A=
+github.com/go-webgpu/webgpu v0.4.2/go.mod h1:+gz9PjcckFCZ/Gv1vJXXEDrf7fqo7VHH6uV0nJrSuRk=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=

--- a/internal/platform/darwin/objc.go
+++ b/internal/platform/darwin/objc.go
@@ -4,6 +4,7 @@ package darwin
 
 import (
 	"errors"
+	"runtime"
 	"sync"
 	"unsafe"
 
@@ -162,10 +163,10 @@ func loadRuntime() error {
 		objcRT.objcMsgSendFpret = objcRT.objcMsgSend
 	}
 
-	// Resolve objc_msgSend_stret (for struct returns)
+	// Resolve objc_msgSend_stret (for struct returns on x86_64).
+	// On ARM64, this symbol doesn't exist — fall back to objc_msgSend.
 	objcRT.objcMsgSendStret, err = ffi.GetSymbol(objcRT.libobjc, "objc_msgSend_stret")
 	if err != nil {
-		// ARM64 doesn't use stret, fall back to objc_msgSend
 		objcRT.objcMsgSendStret = objcRT.objcMsgSend
 	}
 
@@ -208,6 +209,18 @@ func loadRuntime() error {
 	}
 
 	return nil
+}
+
+// objcMsgSendFn returns the correct objc_msgSend variant for the given return type.
+// On x86_64, struct returns > 16 bytes require objc_msgSend_stret per the SysV ABI.
+// On ARM64, objc_msgSend handles all return types directly.
+func objcMsgSendFn(retType *types.TypeDescriptor) unsafe.Pointer {
+	if retType != nil && retType.Kind == types.StructType && runtime.GOARCH == "amd64" {
+		if objcRT.objcMsgSendStret != nil && retType.Size > 16 {
+			return objcRT.objcMsgSendStret
+		}
+	}
+	return objcRT.objcMsgSend
 }
 
 // GetClass returns the Objective-C class with the given name.
@@ -721,8 +734,8 @@ func (id ID) SendRectUintUintBool(sel SEL, rect NSRect, style NSUInteger, backin
 }
 
 // GetRect receives an NSRect return value from a method like frame.
-// On x86_64, small structs may be returned in registers.
-// On ARM64, the behavior differs.
+// On x86_64, NSRect (32 bytes) exceeds the 16-byte register-return limit,
+// so objc_msgSend_stret is used. On ARM64, objc_msgSend handles all returns.
 func (id ID) GetRect(sel SEL) NSRect {
 	if id == 0 || sel == 0 {
 		return NSRect{}
@@ -765,7 +778,7 @@ func (id ID) GetRect(sel SEL) NSRect {
 	var result [4]float64
 	err = ffi.CallFunction(
 		cif,
-		objcRT.objcMsgSend,
+		objcMsgSendFn(nsRectType),
 		unsafe.Pointer(&result),
 		argPtrs,
 	)


### PR DESCRIPTION
## Summary

- **Fix SIGSEGV on Intel Mac (x86_64)**: `GetRect` called `objc_msgSend` for NSRect (32 bytes), but x86_64 SysV ABI requires `objc_msgSend_stret` for struct returns exceeding 16 bytes. Added `objcMsgSendFn()` helper that selects the correct variant based on `runtime.GOARCH` and return type size. ARM64 is unaffected.
- **Update webgpu v0.4.1 → v0.4.2**: goffi purego compatibility fix (nofakecgo build tag), x/sys v0.41.0
- **Update goffi v0.4.1 → v0.4.2**

Closes #125

## Test plan

- [x] `GOWORK=off go build ./...` passes
- [x] `GOWORK=off golangci-lint run --timeout=5m` — 0 issues
- [x] `go test ./...` — all tests pass
- [ ] Manual test on Intel MacBook Pro (x86_64) by @rcarlier
- [ ] Manual test on M3 MacBook Pro (ARM64) by @rcarlier
