### PR TITLE
fix: X11 input handling — keyboard and mouse events (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.8] - 2026-03-06
+
+### Fixed
+
+- **X11 input handling** — keyboard and mouse events now work under Linux X11
+  ([#129](https://github.com/gogpu/gogpu/issues/129))
+  - Implement non-blocking `PollEvent()` via `SetReadDeadline` (was a stub returning nil)
+  - Add keyboard event handling (`KeyPress`/`KeyRelease`) with X11 keycode → evdev → `gpucontext.Key` mapping
+  - Wire `SetKeyCallback` through x11Platform to x11.Platform
+
 ## [0.22.7] - 2026-03-05
 
 ### Changed

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -182,9 +182,8 @@ func (p *x11Platform) SetScrollCallback(fn func(gpucontext.ScrollEvent)) {
 }
 
 // SetKeyCallback registers a callback for keyboard events.
-// X11 keyboard events not yet implemented - only Wayland is supported.
-func (p *x11Platform) SetKeyCallback(_ func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
-	// TODO: Implement X11 keyboard events
+func (p *x11Platform) SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
+	p.inner.SetKeyCallback(fn)
 }
 
 // SetModalFrameCallback is a no-op on X11.

--- a/internal/platform/x11/events.go
+++ b/internal/platform/x11/events.go
@@ -3,7 +3,10 @@
 package x11
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"time"
 )
 
 // Event is the interface implemented by all X11 events.
@@ -336,7 +339,7 @@ func (c *Connection) parseKeyEvent(buf []byte, press bool) (Event, error) {
 	_, _ = d.Uint8() // event type
 	detail, _ := d.Uint8()
 	seq, _ := d.Uint16()
-	time, _ := d.Uint32()
+	tstamp, _ := d.Uint32()
 	root, _ := d.Uint32()
 	event, _ := d.Uint32()
 	child, _ := d.Uint32()
@@ -350,7 +353,7 @@ func (c *Connection) parseKeyEvent(buf []byte, press bool) (Event, error) {
 	ke := KeyEvent{
 		Detail:     detail,
 		Sequence:   seq,
-		Time:       Timestamp(time),
+		Time:       Timestamp(tstamp),
 		Root:       ResourceID(root),
 		Event:      ResourceID(event),
 		Child:      ResourceID(child),
@@ -374,7 +377,7 @@ func (c *Connection) parseButtonEvent(buf []byte, press bool) (Event, error) {
 	_, _ = d.Uint8() // event type
 	detail, _ := d.Uint8()
 	seq, _ := d.Uint16()
-	time, _ := d.Uint32()
+	tstamp, _ := d.Uint32()
 	root, _ := d.Uint32()
 	event, _ := d.Uint32()
 	child, _ := d.Uint32()
@@ -388,7 +391,7 @@ func (c *Connection) parseButtonEvent(buf []byte, press bool) (Event, error) {
 	be := ButtonEvent{
 		Detail:     detail,
 		Sequence:   seq,
-		Time:       Timestamp(time),
+		Time:       Timestamp(tstamp),
 		Root:       ResourceID(root),
 		Event:      ResourceID(event),
 		Child:      ResourceID(child),
@@ -412,7 +415,7 @@ func (c *Connection) parseMotionNotifyEvent(buf []byte) (Event, error) {
 	_, _ = d.Uint8() // event type
 	detail, _ := d.Uint8()
 	seq, _ := d.Uint16()
-	time, _ := d.Uint32()
+	tstamp, _ := d.Uint32()
 	root, _ := d.Uint32()
 	event, _ := d.Uint32()
 	child, _ := d.Uint32()
@@ -426,7 +429,7 @@ func (c *Connection) parseMotionNotifyEvent(buf []byte) (Event, error) {
 	return &MotionNotifyEvent{
 		Detail:     detail,
 		Sequence:   seq,
-		Time:       Timestamp(time),
+		Time:       Timestamp(tstamp),
 		Root:       ResourceID(root),
 		Event:      ResourceID(event),
 		Child:      ResourceID(child),
@@ -445,7 +448,7 @@ func (c *Connection) parseCrossingEvent(buf []byte, enter bool) (Event, error) {
 	_, _ = d.Uint8() // event type
 	detail, _ := d.Uint8()
 	seq, _ := d.Uint16()
-	time, _ := d.Uint32()
+	tstamp, _ := d.Uint32()
 	root, _ := d.Uint32()
 	event, _ := d.Uint32()
 	child, _ := d.Uint32()
@@ -460,7 +463,7 @@ func (c *Connection) parseCrossingEvent(buf []byte, enter bool) (Event, error) {
 	ce := CrossingEvent{
 		Detail:          detail,
 		Sequence:        seq,
-		Time:            Timestamp(time),
+		Time:            Timestamp(tstamp),
 		Root:            ResourceID(root),
 		Event:           ResourceID(event),
 		Child:           ResourceID(child),
@@ -615,14 +618,14 @@ func (c *Connection) parsePropertyNotifyEvent(buf []byte) (Event, error) {
 	seq, _ := d.Uint16()
 	window, _ := d.Uint32()
 	atom, _ := d.Uint32()
-	time, _ := d.Uint32()
+	tstamp, _ := d.Uint32()
 	state, _ := d.Uint8()
 
 	return &PropertyNotifyEvent{
 		Sequence: seq,
 		Window:   ResourceID(window),
 		Atom:     Atom(atom),
-		Time:     Timestamp(time),
+		Time:     Timestamp(tstamp),
 		State:    state,
 	}, nil
 }
@@ -656,13 +659,13 @@ func (c *Connection) parseSelectionClearEvent(buf []byte) (Event, error) {
 	_, _ = d.Uint8() // event type
 	_, _ = d.Uint8() // unused
 	seq, _ := d.Uint16()
-	time, _ := d.Uint32()
+	tstamp, _ := d.Uint32()
 	owner, _ := d.Uint32()
 	selection, _ := d.Uint32()
 
 	return &SelectionClearEvent{
 		Sequence:  seq,
-		Time:      Timestamp(time),
+		Time:      Timestamp(tstamp),
 		Owner:     ResourceID(owner),
 		Selection: Atom(selection),
 	}, nil
@@ -778,20 +781,60 @@ func (c *Connection) WaitForEvent() (Event, error) {
 //
 //nolint:nilnil // nil,nil is intentional to indicate "no event available"
 func (c *Connection) PollEvent() (Event, error) {
-	// Set read deadline to avoid blocking
-	// This is a simple approach - a production implementation
-	// would use poll/epoll for proper non-blocking I/O
-
-	// For now, we'll use a non-blocking approach by checking
-	// if data is available
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.closed {
+		c.mu.Unlock()
 		return nil, ErrConnectionClosed
 	}
+	c.mu.Unlock()
 
-	// Try to read with a very short timeout
-	// This is a simplified approach - returns nil event when no data available
-	return nil, nil
+	// Set a very short read deadline so Read returns immediately if no data.
+	if err := c.conn.SetReadDeadline(time.Now().Add(time.Microsecond)); err != nil {
+		return nil, nil //nolint:nilerr // deadline not supported = no polling
+	}
+
+	buf := make([]byte, 32)
+	_, err := io.ReadFull(c.conn, buf)
+
+	// Clear deadline for subsequent blocking reads.
+	_ = c.conn.SetReadDeadline(time.Time{})
+
+	if err != nil {
+		// Timeout = no data available (normal case).
+		if isTimeoutError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("x11: poll read: %w", err)
+	}
+
+	responseType := buf[0]
+
+	// Error response
+	if responseType == 0 {
+		return nil, c.parseError(buf)
+	}
+
+	// Reply response — skip (we're looking for events).
+	if responseType == 1 {
+		if _, err := c.readAdditional(buf); err != nil {
+			return nil, fmt.Errorf("x11: failed to read reply data: %w", err)
+		}
+		return nil, nil
+	}
+
+	// GenericEvent (type 35) — variable-length, read additional payload.
+	if responseType&0x7F == EventGenericEvent {
+		buf, err = c.readAdditional(buf)
+		if err != nil {
+			return nil, fmt.Errorf("x11: failed to read generic event data: %w", err)
+		}
+	}
+
+	return c.parseEvent(buf)
+}
+
+// isTimeoutError checks if an error is a network timeout (deadline exceeded).
+func isTimeoutError(err error) bool {
+	var netErr interface{ Timeout() bool }
+	return errors.As(err, &netErr) && netErr.Timeout()
 }

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -98,10 +98,11 @@ type Platform struct {
 	primaryTouch  uint32
 	hasPrimary    bool
 
-	// Callbacks for pointer and scroll events
-	pointerCallback func(gpucontext.PointerEvent)
-	scrollCallback  func(gpucontext.ScrollEvent)
-	callbackMu      sync.RWMutex
+	// Callbacks for pointer, scroll, and keyboard events
+	pointerCallback  func(gpucontext.PointerEvent)
+	scrollCallback   func(gpucontext.ScrollEvent)
+	keyboardCallback func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)
+	callbackMu       sync.RWMutex
 
 	// Timestamp reference for event timing
 	startTime time.Time
@@ -436,6 +437,12 @@ func (p *Platform) handleEvent(event Event) PlatformEvent {
 		p.mu.Lock()
 		p.configured = true
 		p.mu.Unlock()
+
+	case *KeyPressEvent:
+		p.handleKeyEvent(e.Detail, e.State, true)
+
+	case *KeyReleaseEvent:
+		p.handleKeyEvent(e.Detail, e.State, false)
 
 	case *MotionNotifyEvent:
 		p.handleMotionNotify(e)
@@ -800,6 +807,13 @@ func (p *Platform) SetScrollCallback(fn func(gpucontext.ScrollEvent)) {
 	p.callbackMu.Unlock()
 }
 
+// SetKeyCallback registers a callback for keyboard events.
+func (p *Platform) SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
+	p.callbackMu.Lock()
+	p.keyboardCallback = fn
+	p.callbackMu.Unlock()
+}
+
 // dispatchPointerEvent dispatches a pointer event to the registered callback.
 func (p *Platform) dispatchPointerEvent(ev gpucontext.PointerEvent) {
 	p.callbackMu.RLock()
@@ -820,6 +834,274 @@ func (p *Platform) dispatchScrollEvent(ev gpucontext.ScrollEvent) {
 	if callback != nil {
 		callback(ev)
 	}
+}
+
+// dispatchKeyEvent dispatches a keyboard event to the registered callback.
+func (p *Platform) dispatchKeyEvent(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool) {
+	p.callbackMu.RLock()
+	callback := p.keyboardCallback
+	p.callbackMu.RUnlock()
+
+	if callback != nil {
+		callback(key, mods, pressed)
+	}
+}
+
+// handleKeyEvent processes a key press or release event.
+// X11 keycodes = evdev keycodes + 8.
+func (p *Platform) handleKeyEvent(keycode uint8, state uint16, pressed bool) {
+	mods := extractModifiers(state)
+
+	p.mu.Lock()
+	p.modifiers = mods
+	p.mu.Unlock()
+
+	// X11 keycodes are evdev keycodes offset by 8
+	key := x11KeycodeToKey(keycode)
+	if key == gpucontext.KeyUnknown {
+		return
+	}
+
+	p.dispatchKeyEvent(key, mods, pressed)
+}
+
+// x11KeycodeToKey converts an X11 keycode to a gpucontext.Key.
+// X11 keycodes = Linux evdev keycodes + 8.
+//
+//nolint:maintidx // large switch for keycode mapping is inherently complex
+func x11KeycodeToKey(keycode uint8) gpucontext.Key {
+	// X11 keycode offset: X11 keycode = evdev keycode + 8
+	const x11Offset = 8
+
+	if keycode < x11Offset {
+		return gpucontext.KeyUnknown
+	}
+	evdev := keycode - x11Offset
+
+	// Linux evdev keycodes from linux/input-event-codes.h
+	switch evdev {
+	// Letters (evdev 30-49, 16-25)
+	case 16:
+		return gpucontext.KeyQ
+	case 17:
+		return gpucontext.KeyW
+	case 18:
+		return gpucontext.KeyE
+	case 19:
+		return gpucontext.KeyR
+	case 20:
+		return gpucontext.KeyT
+	case 21:
+		return gpucontext.KeyY
+	case 22:
+		return gpucontext.KeyU
+	case 23:
+		return gpucontext.KeyI
+	case 24:
+		return gpucontext.KeyO
+	case 25:
+		return gpucontext.KeyP
+	case 30:
+		return gpucontext.KeyA
+	case 31:
+		return gpucontext.KeyS
+	case 32:
+		return gpucontext.KeyD
+	case 33:
+		return gpucontext.KeyF
+	case 34:
+		return gpucontext.KeyG
+	case 35:
+		return gpucontext.KeyH
+	case 36:
+		return gpucontext.KeyJ
+	case 37:
+		return gpucontext.KeyK
+	case 38:
+		return gpucontext.KeyL
+	case 44:
+		return gpucontext.KeyZ
+	case 45:
+		return gpucontext.KeyX
+	case 46:
+		return gpucontext.KeyC
+	case 47:
+		return gpucontext.KeyV
+	case 48:
+		return gpucontext.KeyB
+	case 49:
+		return gpucontext.KeyN
+	case 50:
+		return gpucontext.KeyM
+
+	// Numbers
+	case 2:
+		return gpucontext.Key1
+	case 3:
+		return gpucontext.Key2
+	case 4:
+		return gpucontext.Key3
+	case 5:
+		return gpucontext.Key4
+	case 6:
+		return gpucontext.Key5
+	case 7:
+		return gpucontext.Key6
+	case 8:
+		return gpucontext.Key7
+	case 9:
+		return gpucontext.Key8
+	case 10:
+		return gpucontext.Key9
+	case 11:
+		return gpucontext.Key0
+
+	// Function keys
+	case 59:
+		return gpucontext.KeyF1
+	case 60:
+		return gpucontext.KeyF2
+	case 61:
+		return gpucontext.KeyF3
+	case 62:
+		return gpucontext.KeyF4
+	case 63:
+		return gpucontext.KeyF5
+	case 64:
+		return gpucontext.KeyF6
+	case 65:
+		return gpucontext.KeyF7
+	case 66:
+		return gpucontext.KeyF8
+	case 67:
+		return gpucontext.KeyF9
+	case 68:
+		return gpucontext.KeyF10
+	case 87:
+		return gpucontext.KeyF11
+	case 88:
+		return gpucontext.KeyF12
+
+	// Navigation
+	case 1:
+		return gpucontext.KeyEscape
+	case 15:
+		return gpucontext.KeyTab
+	case 14:
+		return gpucontext.KeyBackspace
+	case 28:
+		return gpucontext.KeyEnter
+	case 57:
+		return gpucontext.KeySpace
+	case 110:
+		return gpucontext.KeyInsert
+	case 111:
+		return gpucontext.KeyDelete
+	case 102:
+		return gpucontext.KeyHome
+	case 107:
+		return gpucontext.KeyEnd
+	case 104:
+		return gpucontext.KeyPageUp
+	case 109:
+		return gpucontext.KeyPageDown
+	case 105:
+		return gpucontext.KeyLeft
+	case 106:
+		return gpucontext.KeyRight
+	case 103:
+		return gpucontext.KeyUp
+	case 108:
+		return gpucontext.KeyDown
+
+	// Modifiers
+	case 42:
+		return gpucontext.KeyLeftShift
+	case 54:
+		return gpucontext.KeyRightShift
+	case 29:
+		return gpucontext.KeyLeftControl
+	case 97:
+		return gpucontext.KeyRightControl
+	case 56:
+		return gpucontext.KeyLeftAlt
+	case 100:
+		return gpucontext.KeyRightAlt
+	case 125:
+		return gpucontext.KeyLeftSuper
+	case 126:
+		return gpucontext.KeyRightSuper
+
+	// Punctuation
+	case 12:
+		return gpucontext.KeyMinus
+	case 13:
+		return gpucontext.KeyEqual
+	case 26:
+		return gpucontext.KeyLeftBracket
+	case 27:
+		return gpucontext.KeyRightBracket
+	case 43:
+		return gpucontext.KeyBackslash
+	case 39:
+		return gpucontext.KeySemicolon
+	case 40:
+		return gpucontext.KeyApostrophe
+	case 41:
+		return gpucontext.KeyGrave
+	case 51:
+		return gpucontext.KeyComma
+	case 52:
+		return gpucontext.KeyPeriod
+	case 53:
+		return gpucontext.KeySlash
+
+	// Numpad
+	case 82:
+		return gpucontext.KeyNumpad0
+	case 79:
+		return gpucontext.KeyNumpad1
+	case 80:
+		return gpucontext.KeyNumpad2
+	case 81:
+		return gpucontext.KeyNumpad3
+	case 75:
+		return gpucontext.KeyNumpad4
+	case 76:
+		return gpucontext.KeyNumpad5
+	case 77:
+		return gpucontext.KeyNumpad6
+	case 71:
+		return gpucontext.KeyNumpad7
+	case 72:
+		return gpucontext.KeyNumpad8
+	case 73:
+		return gpucontext.KeyNumpad9
+	case 83:
+		return gpucontext.KeyNumpadDecimal
+	case 98:
+		return gpucontext.KeyNumpadDivide
+	case 55:
+		return gpucontext.KeyNumpadMultiply
+	case 74:
+		return gpucontext.KeyNumpadSubtract
+	case 78:
+		return gpucontext.KeyNumpadAdd
+	case 96:
+		return gpucontext.KeyEnter // KP Enter
+
+	// Lock keys
+	case 58:
+		return gpucontext.KeyCapsLock
+	case 70:
+		return gpucontext.KeyScrollLock
+	case 69:
+		return gpucontext.KeyNumLock
+	case 119:
+		return gpucontext.KeyPause
+	}
+
+	return gpucontext.KeyUnknown
 }
 
 // eventTimestamp returns the event timestamp as duration since start.


### PR DESCRIPTION
## Summary

- **X11 input handling** — keyboard and mouse events now work under Linux X11 (#129)
- `PollEvent()` was a stub always returning `nil` — implemented via `SetReadDeadline` for non-blocking reads
- Added `KeyPress`/`KeyRelease` handling with X11 keycode → evdev → `gpucontext.Key` mapping
- Wired `SetKeyCallback` through `x11Platform` to `x11.Platform`

## Changes

| File | Change |
|------|--------|
| `internal/platform/x11/events.go` | Implement `PollEvent()` with `SetReadDeadline` + `io.ReadFull`; fix pre-existing `importShadow` (`time` → `tstamp`) |
| `internal/platform/x11/platform.go` | Add `keyboardCallback` field, `SetKeyCallback()`, `dispatchKeyEvent()`, `handleKeyEvent()`, `x11KeycodeToKey()` (full keycode mapping); add `KeyPress`/`KeyRelease` cases to `handleEvent()` |
| `internal/platform/platform_linux.go` | Wire `SetKeyCallback` to `inner.SetKeyCallback(fn)` (was no-op) |
| `CHANGELOG.md` | v0.22.8 entry |

## Test plan

- [x] `go build ./...` passes (Linux, Windows, macOS)
- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues (Windows + Linux platform)
- [x] `gofmt` clean
- [ ] CI green
