### PR TITLE
chore: update wgpu v0.19.6 → v0.19.7 (v0.22.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.9] - 2026-03-07
+
+### Changed
+
+- **Update wgpu v0.19.6 → v0.19.7** — Queue.WriteTexture public API
+  ([wgpu#95](https://github.com/gogpu/wgpu/pull/95) by [@Carmen-Shannon](https://github.com/Carmen-Shannon)),
+  naga v0.14.6 MSL pass-through globals fix
+  ([naga#40](https://github.com/gogpu/naga/pull/40))
+
 ## [0.22.8] - 2026-03-06
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/go-webgpu/webgpu v0.4.2
 	github.com/gogpu/gpucontext v0.9.0
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/wgpu v0.19.6
+	github.com/gogpu/wgpu v0.19.7
 	golang.org/x/sys v0.41.0
 )
 
-require github.com/gogpu/naga v0.14.5 // indirect
+require github.com/gogpu/naga v0.14.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,9 @@ github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Lo
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.14.5 h1:eT3yJjXGShNtL//+W7ir2KB40k77OWvLah62ww2HZ4c=
-github.com/gogpu/naga v0.14.5/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.19.6 h1:aSjMUb3tcSkIuljdTDl+06oE4cXbFBHYhEyzyT9ImVo=
-github.com/gogpu/wgpu v0.19.6/go.mod h1:XFwTzUxOLpAP7vqtRpFIQhHS2/ziKrdvaNDYXHW1whc=
+github.com/gogpu/naga v0.14.6 h1:zXtYxeEt1P70UDVuoa1EgMzKvted9ZsHkVcFV13qkSs=
+github.com/gogpu/naga v0.14.6/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.19.7 h1:Oymo9GOfJ5q7PiO4p1PGFgt+t+eR4V5S2ur5xJlQ5D4=
+github.com/gogpu/wgpu v0.19.7/go.mod h1:li6h9TJ/ppfg/arwAieVNrBPOFCynfzfhNfOqCXCGi8=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Update wgpu v0.19.6 → v0.19.7
  - Queue.WriteTexture public API (#95 by @Carmen-Shannon)
  - naga v0.14.6: MSL pass-through globals fix (naga#40)