### PR TITLE
chore: update wgpu v0.19.8 → v0.20.0 (v0.22.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.11] - 2026-03-10
+
+### Changed
+
+- **Update wgpu v0.19.8 → v0.20.0** — enterprise-grade validation layer:
+  core validation (30+ WebGPU spec rules), 7 typed error types with `errors.As()`,
+  WebGPU deferred error pattern, HAL defense-in-depth.
+- **Update gputypes v0.2.0 → v0.3.0** — `TextureUsage.ContainsUnknownBits()`.
+
 ## [0.22.10] - 2026-03-10
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-webgpu/goffi v0.4.2
 	github.com/go-webgpu/webgpu v0.4.2
 	github.com/gogpu/gpucontext v0.9.0
-	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/wgpu v0.19.8
+	github.com/gogpu/gputypes v0.3.0
+	github.com/gogpu/wgpu v0.20.0
 	golang.org/x/sys v0.41.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,11 @@ github.com/go-webgpu/webgpu v0.4.2 h1:phQCeD5zY8jTgNjkrs090JYUMpqNPO7a9DMXvnHcQ2
 github.com/go-webgpu/webgpu v0.4.2/go.mod h1:+gz9PjcckFCZ/Gv1vJXXEDrf7fqo7VHH6uV0nJrSuRk=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
-github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
-github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=
+github.com/gogpu/gputypes v0.3.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.14.6 h1:zXtYxeEt1P70UDVuoa1EgMzKvted9ZsHkVcFV13qkSs=
 github.com/gogpu/naga v0.14.6/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.19.8 h1:lKwadihU+p+qn6YQIpGHf1qCxletAPDjwXKiGrpzrKY=
-github.com/gogpu/wgpu v0.19.8/go.mod h1:li6h9TJ/ppfg/arwAieVNrBPOFCynfzfhNfOqCXCGi8=
+github.com/gogpu/wgpu v0.20.0 h1:aqSbndAXNCuatehaAOUD6Bde0On/4Q6JDNDaaQUtCks=
+github.com/gogpu/wgpu v0.20.0/go.mod h1:Df/UU2lEx615/x0dEe1uaMv4chn0tEDi6d4wIreED3o=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Update wgpu v0.19.8 → v0.20.0 — enterprise-grade validation layer
- Update gputypes v0.2.0 → v0.3.0 (transitive)

## Test plan

- [x] `GOWORK=off go build ./...` passes
- [x] `GOWORK=off golangci-lint run --timeout=5m` — 0 issues