### PR TITLE
feat(platform): HiDPI/Retina logical/physical pixel split (v0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.23.0] - 2026-03-11
+
+### Added
+
+- **`App.PhysicalSize()`** — returns GPU framebuffer size in device pixels
+- **`Context.FramebufferWidth()`/`FramebufferHeight()`/`FramebufferSize()`** — physical pixel dimensions for GPU rendering
+- **`gpuContextAdapter` implements `gpucontext.WindowProvider`** — enables ggcanvas
+  and other libraries to auto-detect HiDPI scale via standard ecosystem interface
+
+### Changed
+
+- **Platform API: logical/physical pixel split** — redesigned Platform interface
+  to properly distinguish logical points (DIP) from physical pixels (framebuffer).
+  New internal methods: `LogicalSize()`, `PhysicalSize()`, `ScaleFactor()`.
+  `App.Size()` / `Context.Width()`/`Height()` now return logical dimensions.
+  ([gg#171](https://github.com/gogpu/gg/issues/171),
+  [gg#175](https://github.com/gogpu/gg/issues/175))
+  - macOS: `Window.UpdateSize()` stores logical points (not physical pixels)
+  - macOS: new `Window.FramebufferSize()` for physical pixel dimensions
+  - Windows: real DPI awareness via `GetDpiForWindow()`
+  - Event coordinates are now consistently in logical points on all platforms
+
+### Fixed
+
+- **macOS Retina race condition** — removed `surface.Resize()` from `PollEvents()`
+  which ran on the main thread while the render thread operated on the wgpu surface.
+  Surface reconfiguration now happens exclusively on the render thread via
+  `RequestResize()`. Fixes content disappearing periodically on macOS.
+  ([gg#171](https://github.com/gogpu/gg/issues/171))
 
 ## [0.22.11] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ This eliminates the GPU→CPU→GPU round-trip when integrating with gg/ggcanvas
 
 ```go
 // Window geometry and DPI
-w, h := app.Size()              // physical pixels
+w, h := app.Size()              // logical points (DIP)
+fw, fh := app.PhysicalSize()    // physical pixels (framebuffer)
 scale := app.ScaleFactor()      // 1.0 = standard, 2.0 = Retina/HiDPI
 
 // Clipboard

--- a/app.go
+++ b/app.go
@@ -295,12 +295,13 @@ func (a *App) processEventsMultiThread() bool {
 	// Queue resize for render thread (deferred pattern)
 	// Don't apply resize during modal resize loop (Windows)
 	if lastResize != nil && !a.platform.InSizeMove() {
-		// Queue resize for render thread
-		if lastResize.Width > 0 && lastResize.Height > 0 {
-			a.renderLoop.RequestResize(uint32(lastResize.Width), uint32(lastResize.Height)) //nolint:gosec // G115: validated positive
+		// Queue PHYSICAL size for render thread (GPU surface reconfiguration)
+		physW, physH := lastResize.PhysicalWidth, lastResize.PhysicalHeight
+		if physW > 0 && physH > 0 {
+			a.renderLoop.RequestResize(uint32(physW), uint32(physH)) //nolint:gosec // G115: validated positive
 		}
 
-		// Call user callback immediately (for UI updates)
+		// Call user callback with LOGICAL size (what user expects for layout)
 		if a.onResize != nil {
 			a.onResize(lastResize.Width, lastResize.Height)
 		}
@@ -317,14 +318,15 @@ func (a *App) processEventsMultiThread() bool {
 // renderFrameMultiThread renders a frame using the render thread.
 // All GPU operations happen on the render thread to keep main thread responsive.
 func (a *App) renderFrameMultiThread() {
-	// Skip rendering if window is minimized (zero dimensions)
-	width, height := a.platform.GetSize()
+	// Skip rendering if window is minimized (zero physical dimensions)
+	width, height := a.platform.PhysicalSize()
 	if width <= 0 || height <= 0 {
 		return // Window minimized, skip frame
 	}
 
-	// Capture callback for render thread
+	// Capture callback and scale factor for render thread
 	onDraw := a.onDraw
+	scale := a.platform.ScaleFactor()
 
 	// Execute GPU operations on render thread
 	a.renderLoop.RunOnRenderThreadVoid(func() {
@@ -340,7 +342,7 @@ func (a *App) renderFrameMultiThread() {
 
 		// Create context and call draw callback
 		if onDraw != nil {
-			ctx := newContext(a.renderer)
+			ctx := newContext(a.renderer, scale)
 			onDraw(ctx)
 		}
 
@@ -375,10 +377,10 @@ func (a *App) modalFrameTick() {
 		a.onUpdate(deltaTime)
 	}
 
-	// Propagate window size to render thread for swapchain resize.
+	// Propagate PHYSICAL window size to render thread for swapchain resize.
 	// During modal loop, processEventsMultiThread doesn't run, so
 	// RequestResize wouldn't be called otherwise.
-	width, height := a.platform.GetSize()
+	width, height := a.platform.PhysicalSize()
 	if width > 0 && height > 0 {
 		a.renderLoop.RequestResize(uint32(width), uint32(height)) //nolint:gosec // G115: validated positive
 	}
@@ -412,10 +414,20 @@ func (a *App) StartAnimation() *AnimationToken {
 	return token
 }
 
-// Size returns the current window size.
+// Size returns the current window size in logical points (DIP).
+// Use this for layout, UI coordinates, and user-facing dimensions.
 func (a *App) Size() (width, height int) {
 	if a.platform != nil {
-		return a.platform.GetSize()
+		return a.platform.LogicalSize()
+	}
+	return a.config.Width, a.config.Height
+}
+
+// PhysicalSize returns the current GPU framebuffer size in device pixels.
+// On Retina/HiDPI displays this is larger than Size() by ScaleFactor().
+func (a *App) PhysicalSize() (width, height int) {
+	if a.platform != nil {
+		return a.platform.PhysicalSize()
 	}
 	return a.config.Width, a.config.Height
 }

--- a/context.go
+++ b/context.go
@@ -8,14 +8,19 @@ import (
 // Context provides drawing operations for a single frame.
 // It is only valid during the OnDraw callback and should not be stored.
 type Context struct {
-	renderer *Renderer
-	cleared  bool
+	renderer    *Renderer
+	scaleFactor float64 // DPI scale factor (1.0 = standard, 2.0 = Retina/HiDPI)
+	cleared     bool
 }
 
 // newContext creates a new drawing context for a frame.
-func newContext(renderer *Renderer) *Context {
+func newContext(renderer *Renderer, scaleFactor float64) *Context {
+	if scaleFactor <= 0 {
+		scaleFactor = 1.0
+	}
 	return &Context{
-		renderer: renderer,
+		renderer:    renderer,
+		scaleFactor: scaleFactor,
 	}
 }
 
@@ -31,26 +36,53 @@ func (c *Context) ClearColor(color gmath.Color) {
 	c.Clear(color.R, color.G, color.B, color.A)
 }
 
-// Size returns the current framebuffer dimensions in pixels.
+// Size returns the window dimensions in logical points (DIP).
+// Use this for layout, UI coordinates, and user-facing dimensions.
+// On Retina/HiDPI displays, this is smaller than FramebufferSize by ScaleFactor.
 func (c *Context) Size() (width, height int) {
+	pw, ph := c.renderer.Size()
+	return int(float64(pw) / c.scaleFactor), int(float64(ph) / c.scaleFactor)
+}
+
+// Width returns the window width in logical points (DIP).
+func (c *Context) Width() int {
+	w, _ := c.Size()
+	return w
+}
+
+// Height returns the window height in logical points (DIP).
+func (c *Context) Height() int {
+	_, h := c.Size()
+	return h
+}
+
+// FramebufferSize returns the GPU framebuffer dimensions in physical device pixels.
+// Use this for GPU operations, texture allocation, and pixel-precise rendering.
+func (c *Context) FramebufferSize() (width, height int) {
 	return c.renderer.Size()
 }
 
-// Width returns the framebuffer width in pixels.
-func (c *Context) Width() int {
+// FramebufferWidth returns the GPU framebuffer width in physical device pixels.
+func (c *Context) FramebufferWidth() int {
 	w, _ := c.renderer.Size()
 	return w
 }
 
-// Height returns the framebuffer height in pixels.
-func (c *Context) Height() int {
+// FramebufferHeight returns the GPU framebuffer height in physical device pixels.
+func (c *Context) FramebufferHeight() int {
 	_, h := c.renderer.Size()
 	return h
 }
 
-// AspectRatio returns width/height as a float32.
+// ScaleFactor returns the DPI scale factor.
+// 1.0 = standard (96 DPI on Windows), 2.0 = Retina/HiDPI.
+func (c *Context) ScaleFactor() float64 {
+	return c.scaleFactor
+}
+
+// AspectRatio returns width/height as a float32 (based on logical size).
 func (c *Context) AspectRatio() float32 {
-	w, h := c.renderer.Size()
+	w, h := c.Size()
 	if h == 0 {
 		return 1.0
 	}
@@ -115,7 +147,8 @@ func (c *Context) CheckDeviceHealth() error {
 	return nil // Backend doesn't support health check
 }
 
-// SurfaceSize returns the current surface dimensions in pixels.
+// SurfaceSize returns the current GPU surface dimensions in physical device pixels.
+// This is the same as FramebufferSize but returns uint32 for GPU API compatibility.
 func (c *Context) SurfaceSize() (width, height uint32) {
 	w, h := c.renderer.Size()
 	return uint32(w), uint32(h) //nolint:gosec // G115: renderer validates dimensions

--- a/context_test.go
+++ b/context_test.go
@@ -8,6 +8,7 @@ import (
 
 // newTestContext creates a Context with a mock Renderer for testing.
 // Only sets up the fields needed for read-only wrapper methods.
+// Uses scale=1.0 so logical == physical dimensions.
 func newTestContext(width, height uint32, format gputypes.TextureFormat, backendName string) *Context {
 	r := &Renderer{
 		width:       width,
@@ -15,7 +16,7 @@ func newTestContext(width, height uint32, format gputypes.TextureFormat, backend
 		format:      format,
 		backendName: backendName,
 	}
-	return newContext(r)
+	return newContext(r, 1.0)
 }
 
 func TestContextSize(t *testing.T) {
@@ -174,7 +175,7 @@ func TestContextCheckDeviceHealthNonChecker(t *testing.T) {
 		backendName: "test",
 		device:      &mockFenceDevice{}, // does not implement healthChecker
 	}
-	ctx := newContext(r)
+	ctx := newContext(r, 1.0)
 
 	err := ctx.CheckDeviceHealth()
 	if err != nil {
@@ -210,7 +211,7 @@ func TestContextRenderer(t *testing.T) {
 		height:      600,
 		backendName: "test",
 	}
-	ctx := newContext(r)
+	ctx := newContext(r, 1.0)
 
 	if ctx.Renderer() != r {
 		t.Error("Renderer() did not return the expected Renderer instance")
@@ -242,7 +243,7 @@ func TestNewContext(t *testing.T) {
 		format:      gputypes.TextureFormatRGBA8Unorm,
 		backendName: "native",
 	}
-	ctx := newContext(r)
+	ctx := newContext(r, 1.0)
 
 	if ctx == nil {
 		t.Fatal("newContext returned nil")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -260,6 +260,61 @@ wgpu/
     └── noop/           # No-op (testing)
 ```
 
+## HiDPI/Retina Support
+
+GoGPU properly separates logical coordinates (points/DIP) from physical pixels
+(framebuffer), following the industry-standard pattern used by GLFW, winit, SDL,
+and every enterprise graphics library.
+
+### Platform Interface
+
+```go
+type Platform interface {
+    // LogicalSize returns window size in platform points (DIP).
+    // 800x600 on Retina 2x. Use for layout and UI coordinates.
+    LogicalSize() (width, height int)
+
+    // PhysicalSize returns GPU framebuffer size in device pixels.
+    // 1600x1200 on Retina 2x. Use for surface configuration.
+    PhysicalSize() (width, height int)
+
+    // ScaleFactor returns the DPI scale factor.
+    // 2.0 on macOS Retina, 1.0-3.0 on Windows HiDPI, 1.0 on most Linux.
+    ScaleFactor() float64
+}
+```
+
+### User-Facing API
+
+```go
+app := gogpu.NewApp(gogpu.DefaultConfig().WithSize(800, 600))
+
+// In callbacks:
+w, h := app.Size()              // 800, 600 (logical points)
+fw, fh := app.PhysicalSize()    // 1600, 1200 (physical pixels on Retina 2x)
+scale := app.ScaleFactor()      // 2.0
+
+// Context also exposes both:
+ctx.Width()              // 800 (logical)
+ctx.FramebufferWidth()   // 1600 (physical)
+```
+
+### Platform Implementation
+
+| Platform | LogicalSize | PhysicalSize | ScaleFactor |
+|----------|-------------|-------------|-------------|
+| **macOS** | NSView bounds (points) | bounds × backingScaleFactor | `backingScaleFactor` |
+| **Windows** | Client rect / DPI scale | Client rect (raw pixels) | `GetDpiForWindow() / 96` |
+| **Linux X11** | Window geometry | Same (scale=1.0 baseline) | 1.0 |
+| **Linux Wayland** | Window geometry | Same (scale=1.0 baseline) | 1.0 |
+
+### Thread Safety
+
+Surface reconfiguration happens exclusively on the render thread.
+`PollEvents()` detects size changes and emits resize events, but does NOT
+resize the GPU surface directly. The render thread handles surface
+reconfiguration via `RequestResize()`.
+
 ## Multi-Thread Architecture
 
 GoGPU uses enterprise-level multi-thread architecture (Ebiten/Gio pattern):

--- a/gpucontext_adapter.go
+++ b/gpucontext_adapter.go
@@ -13,6 +13,7 @@ import (
 type gpuContextAdapter struct {
 	renderer *Renderer
 	tracker  *resourceTracker
+	app      *App
 }
 
 // Device returns the GPU device implementing gpucontext.Device.
@@ -69,6 +70,32 @@ func (a *gpuContextAdapter) HalQueue() any {
 	return a.renderer.queue
 }
 
+// Size returns the current window size in logical points (DIP).
+// Implements gpucontext.WindowProvider.
+func (a *gpuContextAdapter) Size() (width, height int) {
+	if a.app != nil {
+		return a.app.Size()
+	}
+	return 0, 0
+}
+
+// ScaleFactor returns the DPI scale factor from the platform.
+// Implements gpucontext.WindowProvider.
+func (a *gpuContextAdapter) ScaleFactor() float64 {
+	if a.app != nil {
+		return a.app.ScaleFactor()
+	}
+	return 1.0
+}
+
+// RequestRedraw requests the host to render a new frame.
+// Implements gpucontext.WindowProvider.
+func (a *gpuContextAdapter) RequestRedraw() {
+	if a.app != nil {
+		a.app.RequestRedraw()
+	}
+}
+
 // TrackResource registers an io.Closer for automatic cleanup during shutdown.
 // This forwards to the App's resourceTracker, enabling ggcanvas and other
 // libraries to auto-register via duck typing without importing gogpu.
@@ -90,6 +117,9 @@ var _ gpucontext.DeviceProvider = (*gpuContextAdapter)(nil)
 
 // Ensure gpuContextAdapter implements gpucontext.HalProvider.
 var _ gpucontext.HalProvider = (*gpuContextAdapter)(nil)
+
+// Ensure gpuContextAdapter implements gpucontext.WindowProvider.
+var _ gpucontext.WindowProvider = (*gpuContextAdapter)(nil)
 
 // deviceAdapter wraps gogpu renderer to implement gpucontext.Device.
 type deviceAdapter struct {
@@ -163,5 +193,5 @@ func (a *App) GPUContextProvider() gpucontext.DeviceProvider {
 	if a.tracker == nil {
 		a.tracker = &resourceTracker{}
 	}
-	return &gpuContextAdapter{renderer: a.renderer, tracker: a.tracker}
+	return &gpuContextAdapter{renderer: a.renderer, tracker: a.tracker, app: a}
 }

--- a/internal/platform/darwin/surface.go
+++ b/internal/platform/darwin/surface.go
@@ -286,9 +286,9 @@ func NewSurface(window *Window) (*Surface, error) {
 		layer.SetContentsScale(scale)
 	}
 
-	// Set drawable size using physical pixel dimensions from window.
-	// Window.Size() now returns physical pixels (bounds * scaleFactor).
-	width, height := window.Size()
+	// Set drawable size using physical pixel dimensions.
+	// Window.Size() returns logical points; FramebufferSize() returns physical pixels.
+	width, height := window.FramebufferSize()
 	if width > 0 && height > 0 {
 		layer.SetDrawableSize(width, height)
 	}
@@ -351,7 +351,7 @@ func (s *Surface) UpdateSize() {
 
 	// Get physical pixel dimensions and update drawable size.
 	s.window.UpdateSize()
-	width, height := s.window.Size()
+	width, height := s.window.FramebufferSize()
 	if width > 0 && height > 0 {
 		s.layer.SetDrawableSize(width, height)
 	}

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -313,8 +313,8 @@ func (w *Window) BackingScaleFactor() float64 {
 }
 
 // UpdateSize updates the cached size from the actual window size.
-// Returns physical pixel dimensions (bounds * backingScaleFactor) to
-// match the Platform.GetSize() contract of returning pixels, not points.
+// Stores LOGICAL size in platform points (not physical pixels).
+// Use FramebufferSize() for physical pixel dimensions.
 func (w *Window) UpdateSize() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -323,12 +323,25 @@ func (w *Window) UpdateSize() {
 		return
 	}
 
-	// Get bounds of content view (logical points on macOS).
+	// Get bounds of content view in logical points (macOS Cocoa points).
+	// On Retina displays, 800x600 points maps to 1600x1200 physical pixels,
+	// but we store the logical size here. Physical size is derived on demand.
 	bounds := w.contentView.GetRect(selectors.bounds)
+	w.width = int(bounds.Size.Width)
+	w.height = int(bounds.Size.Height)
+}
 
-	// Convert to physical pixels using backing scale factor.
-	// On Retina displays (2x), 800x600 points → 1600x1200 pixels.
-	// On standard displays (1x), this is a no-op multiplication.
+// FramebufferSize returns the GPU framebuffer size in physical device pixels.
+// On Retina displays this is LogicalSize * BackingScaleFactor.
+func (w *Window) FramebufferSize() (width, height int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.contentView.IsNil() {
+		return w.width, w.height
+	}
+
+	bounds := w.contentView.GetRect(selectors.bounds)
 	scale := 1.0
 	if !w.nsWindow.IsNil() {
 		s := w.nsWindow.GetDouble(selectors.backingScaleFactor)
@@ -336,8 +349,7 @@ func (w *Window) UpdateSize() {
 			scale = s
 		}
 	}
-	w.width = int(float64(bounds.Size.Width) * scale)
-	w.height = int(float64(bounds.Size.Height) * scale)
+	return int(float64(bounds.Size.Width) * scale), int(float64(bounds.Size.Height) * scale)
 }
 
 // Frame returns the window's frame rectangle (position and size).

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -16,9 +16,11 @@ type Config struct {
 
 // Event represents a platform event.
 type Event struct {
-	Type   EventType
-	Width  int // for resize events
-	Height int // for resize events
+	Type           EventType
+	Width          int // for resize events: logical size (platform points/DIP)
+	Height         int // for resize events: logical size (platform points/DIP)
+	PhysicalWidth  int // for resize events: physical pixels (GPU framebuffer)
+	PhysicalHeight int // for resize events: physical pixels (GPU framebuffer)
 }
 
 // EventType represents the type of platform event.
@@ -42,8 +44,15 @@ type Platform interface {
 	// ShouldClose returns true if window close was requested.
 	ShouldClose() bool
 
-	// GetSize returns current window size in pixels.
-	GetSize() (width, height int)
+	// LogicalSize returns the window size in platform points (DIP).
+	// On macOS these are Cocoa points, on Windows they are DIP (96 DPI base).
+	// Use this for layout, UI coordinates, and user-facing dimensions.
+	LogicalSize() (width, height int)
+
+	// PhysicalSize returns the GPU framebuffer size in device pixels.
+	// On Retina/HiDPI displays this is larger than LogicalSize by ScaleFactor.
+	// Use this for surface configuration, texture allocation, and GPU operations.
+	PhysicalSize() (width, height int)
 
 	// GetHandle returns platform-specific handles for surface creation.
 	// On Windows: (hinstance, hwnd)

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -109,25 +109,28 @@ func (p *darwinPlatform) PollEvents() Event {
 		return Event{Type: EventClose}
 	}
 
-	// Update window size and check for resize
+	// Update window size and check for resize.
+	// RETINA-002: Do NOT call p.surface.Resize() here. PollEvents runs on the
+	// main thread while the render thread operates on wgpu surface. Surface
+	// reconfiguration is handled by the render thread via RequestResize.
 	if p.window != nil {
 		oldWidth, oldHeight := p.config.Width, p.config.Height
 		p.window.UpdateSize()
-		newWidth, newHeight := p.window.Size()
+		newWidth, newHeight := p.window.Size() // logical points
 
 		if newWidth != oldWidth || newHeight != oldHeight {
 			p.config.Width = newWidth
 			p.config.Height = newHeight
 
-			// Update surface size
-			if p.surface != nil {
-				p.surface.Resize(newWidth, newHeight)
-			}
+			// Get physical pixel size for GPU surface reconfiguration
+			physW, physH := p.window.FramebufferSize()
 
 			return Event{
-				Type:   EventResize,
-				Width:  newWidth,
-				Height: newHeight,
+				Type:           EventResize,
+				Width:          newWidth,
+				Height:         newHeight,
+				PhysicalWidth:  physW,
+				PhysicalHeight: physH,
 			}
 		}
 	}
@@ -151,23 +154,12 @@ func (p *darwinPlatform) handleEvent(event darwin.ID, eventType darwin.NSEventTy
 	// Get event info
 	info := darwin.GetEventInfo(event)
 
-	// Scale factor for converting logical points to physical pixels.
-	// macOS event coordinates are in logical points; our coordinate system
-	// uses physical pixels (matching GetSize() and the GPU surface).
-	scale := 1.0
-	if p.window != nil {
-		scale = p.window.BackingScaleFactor()
-	}
+	// RETINA-001: Coordinates are in logical points (Cocoa points / DIP).
+	// p.config.Width/Height are now logical, matching NSEvent coordinates.
+	// No scaling needed — the coordinate system is consistently logical.
 
-	// Get window height for Y coordinate flip.
-	// macOS uses bottom-left origin, we need top-left.
-	// p.config.Height is in physical pixels; NSEvent coordinates are in logical
-	// points. Compute the flip in points first, then scale to physical pixels.
-	windowHeightPts := float64(p.config.Height) / scale
-	y := (windowHeightPts - info.LocationY) * scale
-
-	// Scale X coordinate to physical pixels.
-	info.LocationX *= scale
+	// Y coordinate flip: macOS uses bottom-left origin, we need top-left.
+	y := float64(p.config.Height) - info.LocationY
 
 	// Update modifiers
 	p.modifiers = extractModifiers(info.ModifierFlags)
@@ -225,8 +217,8 @@ func (p *darwinPlatform) handleEvent(event darwin.ID, eventType darwin.NSEventTy
 		p.pointerX = info.LocationX
 		p.pointerY = y
 
-		// Detect enter/leave based on position (in physical pixel coordinates).
-		// p.config.Width/Height are already in physical pixels after UpdateSize().
+		// Detect enter/leave based on position (in logical point coordinates).
+		// p.config.Width/Height are in logical points after RETINA-001.
 		inWindow := info.LocationX >= 0 && info.LocationX <= float64(p.config.Width) &&
 			y >= 0 && y <= float64(p.config.Height)
 
@@ -276,10 +268,8 @@ func (p *darwinPlatform) handleEvent(event darwin.ID, eventType darwin.NSEventTy
 		deltaY := -info.ScrollDeltaY // Invert Y: natural scrolling convention
 		if info.IsPrecise {
 			deltaMode = gpucontext.ScrollDeltaPixel
-			// Precise (trackpad) deltas are in logical points; scale to physical
-			// pixels to match position coordinates.
-			deltaX *= scale
-			deltaY *= scale
+			// Precise (trackpad) deltas are in logical points, matching our
+			// logical coordinate system. No scaling needed.
 		}
 
 		ev := gpucontext.ScrollEvent{
@@ -361,12 +351,25 @@ func (p *darwinPlatform) ShouldClose() bool {
 	return p.shouldClose
 }
 
-func (p *darwinPlatform) GetSize() (width, height int) {
+// LogicalSize returns the window size in Cocoa points (DIP).
+func (p *darwinPlatform) LogicalSize() (width, height int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	if p.window != nil {
 		return p.window.Size()
+	}
+	return p.config.Width, p.config.Height
+}
+
+// PhysicalSize returns the GPU framebuffer size in device pixels.
+// On Retina displays this is LogicalSize * BackingScaleFactor.
+func (p *darwinPlatform) PhysicalSize() (width, height int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.window != nil {
+		return p.window.FramebufferSize()
 	}
 	return p.config.Width, p.config.Height
 }
@@ -475,7 +478,9 @@ func (p *darwinPlatform) WakeUp() {
 	}
 }
 
-// checkResize checks for window size changes and updates the surface.
+// checkResize checks for window size changes and queues a resize event.
+// RETINA-002: Does NOT call p.surface.Resize(). Surface reconfiguration
+// is handled by the render thread via RequestResize to avoid race conditions.
 // Must be called with p.mu held.
 func (p *darwinPlatform) checkResize() {
 	if p.window == nil {
@@ -484,20 +489,20 @@ func (p *darwinPlatform) checkResize() {
 
 	oldWidth, oldHeight := p.config.Width, p.config.Height
 	p.window.UpdateSize()
-	newWidth, newHeight := p.window.Size()
+	newWidth, newHeight := p.window.Size() // logical points
 
 	if newWidth != oldWidth || newHeight != oldHeight {
 		p.config.Width = newWidth
 		p.config.Height = newHeight
 
-		if p.surface != nil {
-			p.surface.Resize(newWidth, newHeight)
-		}
+		physW, physH := p.window.FramebufferSize()
 
 		p.queueEvent(Event{
-			Type:   EventResize,
-			Width:  newWidth,
-			Height: newHeight,
+			Type:           EventResize,
+			Width:          newWidth,
+			Height:         newHeight,
+			PhysicalWidth:  physW,
+			PhysicalHeight: physH,
 		})
 	}
 }

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -134,7 +134,14 @@ func (p *x11Platform) PollEvents() Event {
 	case x11.EventTypeClose:
 		return Event{Type: EventClose}
 	case x11.EventTypeResize:
-		return Event{Type: EventResize, Width: event.Width, Height: event.Height}
+		// X11: scale=1.0 baseline, logical == physical
+		return Event{
+			Type:           EventResize,
+			Width:          event.Width,
+			Height:         event.Height,
+			PhysicalWidth:  event.Width,
+			PhysicalHeight: event.Height,
+		}
 	default:
 		return Event{Type: EventNone}
 	}
@@ -145,8 +152,15 @@ func (p *x11Platform) ShouldClose() bool {
 	return p.inner.ShouldClose()
 }
 
-// GetSize returns current window size in pixels.
-func (p *x11Platform) GetSize() (width, height int) {
+// LogicalSize returns the window size in platform points.
+// X11 baseline: scale=1.0, logical == physical.
+func (p *x11Platform) LogicalSize() (width, height int) {
+	return p.inner.GetSize()
+}
+
+// PhysicalSize returns the GPU framebuffer size in device pixels.
+// X11 baseline: scale=1.0, logical == physical.
+func (p *x11Platform) PhysicalSize() (width, height int) {
 	return p.inner.GetSize()
 }
 
@@ -1312,9 +1326,11 @@ func (p *waylandPlatform) PollEvents() Event {
 		p.mu.Unlock()
 
 		return Event{
-			Type:   EventResize,
-			Width:  p.pendingWidth,
-			Height: p.pendingHeight,
+			Type:           EventResize,
+			Width:          p.pendingWidth,
+			Height:         p.pendingHeight,
+			PhysicalWidth:  p.pendingWidth,
+			PhysicalHeight: p.pendingHeight,
 		}
 	}
 
@@ -1345,9 +1361,11 @@ func (p *waylandPlatform) PollEvents() Event {
 		p.height = p.pendingHeight
 		p.hasResize = false
 		return Event{
-			Type:   EventResize,
-			Width:  p.pendingWidth,
-			Height: p.pendingHeight,
+			Type:           EventResize,
+			Width:          p.pendingWidth,
+			Height:         p.pendingHeight,
+			PhysicalWidth:  p.pendingWidth,
+			PhysicalHeight: p.pendingHeight,
 		}
 	}
 
@@ -1365,8 +1383,17 @@ func (p *waylandPlatform) ShouldClose() bool {
 	return p.shouldClose
 }
 
-// GetSize returns current window size in pixels.
-func (p *waylandPlatform) GetSize() (width, height int) {
+// LogicalSize returns the window size in platform points.
+// Wayland baseline: scale=1.0, logical == physical.
+func (p *waylandPlatform) LogicalSize() (width, height int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.width, p.height
+}
+
+// PhysicalSize returns the GPU framebuffer size in device pixels.
+// Wayland baseline: scale=1.0, logical == physical.
+func (p *waylandPlatform) PhysicalSize() (width, height int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.width, p.height

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -479,10 +479,36 @@ func (p *windowsPlatform) ShouldClose() bool {
 	return p.shouldClose
 }
 
-func (p *windowsPlatform) GetSize() (width, height int) {
+// LogicalSize returns the window client area in DIP (device-independent pixels).
+// On Windows with DPI awareness, this is the client rect divided by DPI scale.
+// For most Windows apps at 100% scaling, this equals PhysicalSize.
+func (p *windowsPlatform) LogicalSize() (width, height int) {
+	p.sizeMu.RLock()
+	defer p.sizeMu.RUnlock()
+
+	scale := p.scaleFactor()
+	if scale <= 0 || scale == 1.0 {
+		return p.width, p.height
+	}
+	return int(float64(p.width) / scale), int(float64(p.height) / scale)
+}
+
+// PhysicalSize returns the GPU framebuffer size in device pixels.
+// On Windows this is the actual client rect size (GetClientRect).
+func (p *windowsPlatform) PhysicalSize() (width, height int) {
 	p.sizeMu.RLock()
 	defer p.sizeMu.RUnlock()
 	return p.width, p.height
+}
+
+// scaleFactor returns the DPI scale factor for the window.
+// Must NOT hold sizeMu (calls syscall).
+func (p *windowsPlatform) scaleFactor() float64 {
+	dpi, _, _ := procGetDpiForWindow.Call(uintptr(p.hwnd))
+	if dpi == 0 {
+		return 1.0
+	}
+	return float64(dpi) / 96.0
 }
 
 // InSizeMove returns true if the window is in a modal resize/move loop.
@@ -568,12 +594,10 @@ func (p *windowsPlatform) WakeUp() {
 
 // ScaleFactor returns the DPI scale factor for the window.
 // 1.0 = 96 DPI (standard), 2.0 = 192 DPI (HiDPI).
+// ScaleFactor returns the DPI scale factor.
+// 1.0 = 96 DPI (standard), 1.25 = 120 DPI, 1.5 = 144 DPI, 2.0 = 192 DPI.
 func (p *windowsPlatform) ScaleFactor() float64 {
-	dpi, _, _ := procGetDpiForWindow.Call(uintptr(p.hwnd))
-	if dpi == 0 {
-		return 1.0
-	}
-	return float64(dpi) / 96.0
+	return p.scaleFactor()
 }
 
 // ClipboardRead reads text from the system clipboard.
@@ -1462,10 +1486,21 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		// stretched and correctly-sized frames) because DWM stretches BEFORE our
 		// render can complete.
 		if sizeChanged && !inSizeMove {
+			// On Windows, WM_SIZE provides physical pixels (client rect).
+			// Compute logical size from DPI scale for the event.
+			logW, logH := newWidth, newHeight
+			dpi, _, _ := procGetDpiForWindow.Call(uintptr(p.hwnd))
+			if dpi > 0 && dpi != 96 {
+				scale := float64(dpi) / 96.0
+				logW = int(float64(newWidth) / scale)
+				logH = int(float64(newHeight) / scale)
+			}
 			p.queueEvent(Event{
-				Type:   EventResize,
-				Width:  newWidth,
-				Height: newHeight,
+				Type:           EventResize,
+				Width:          logW,
+				Height:         logH,
+				PhysicalWidth:  newWidth,
+				PhysicalHeight: newHeight,
 			})
 		}
 		return 0
@@ -1511,11 +1546,14 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 
 		// Queue final resize event when resize ends
 		p.updateSize()
-		width, height := p.GetSize()
+		physW, physH := p.PhysicalSize()
+		logW, logH := p.LogicalSize()
 		p.queueEvent(Event{
-			Type:   EventResize,
-			Width:  width,
-			Height: height,
+			Type:           EventResize,
+			Width:          logW,
+			Height:         logH,
+			PhysicalWidth:  physW,
+			PhysicalHeight: physH,
 		})
 		return 0
 

--- a/platform_provider_test.go
+++ b/platform_provider_test.go
@@ -21,10 +21,17 @@ type mockPlatform struct {
 	fontScale     float32
 }
 
-func (m *mockPlatform) Init(platform.Config) error                                      { return nil }
-func (m *mockPlatform) PollEvents() platform.Event                                      { return platform.Event{} }
-func (m *mockPlatform) ShouldClose() bool                                               { return false }
-func (m *mockPlatform) GetSize() (int, int)                                             { return m.width, m.height }
+func (m *mockPlatform) Init(platform.Config) error { return nil }
+func (m *mockPlatform) PollEvents() platform.Event { return platform.Event{} }
+func (m *mockPlatform) ShouldClose() bool          { return false }
+func (m *mockPlatform) LogicalSize() (int, int)    { return m.width, m.height }
+func (m *mockPlatform) PhysicalSize() (int, int) {
+	s := m.scaleFactor
+	if s <= 0 {
+		s = 1.0
+	}
+	return int(float64(m.width) * s), int(float64(m.height) * s)
+}
 func (m *mockPlatform) GetHandle() (uintptr, uintptr)                                   { return 0, 0 }
 func (m *mockPlatform) InSizeMove() bool                                                { return false }
 func (m *mockPlatform) SetPointerCallback(func(gpucontext.PointerEvent))                {}

--- a/renderer.go
+++ b/renderer.go
@@ -177,11 +177,12 @@ func (r *Renderer) init(backendType types.BackendType, graphicsAPI types.Graphic
 	// Each submission gets its own fence, enabling true non-blocking completion checks.
 	r.fencePool = NewFencePool(r.device)
 
-	// Configure surface
-	// Get current window dimensions. On some platforms (especially macOS),
-	// the window may not have valid dimensions immediately after creation.
-	// In that case, we defer surface configuration until the first Resize event.
-	width, height := r.platform.GetSize()
+	// Configure surface with PHYSICAL pixel dimensions.
+	// GPU surfaces operate in device pixels, not logical points.
+	// On some platforms (especially macOS), the window may not have valid
+	// dimensions immediately after creation. In that case, we defer surface
+	// configuration until the first Resize event.
+	width, height := r.platform.PhysicalSize()
 
 	// Use BGRA8Unorm which is common across platforms
 	r.format = gputypes.TextureFormatBGRA8Unorm


### PR DESCRIPTION
## Summary

Enterprise HiDPI/Retina support — proper logical/physical pixel split across all platforms.

- **Platform API redesign**: `LogicalSize()`, `PhysicalSize()`, `ScaleFactor()` replace `GetSize()`
- **New public API**: `App.PhysicalSize()`, `Context.FramebufferWidth()/FramebufferHeight()/FramebufferSize()`
- **`App.Size()` now returns logical points (DIP)** — breaking semantic change
- **gpuContextAdapter implements `gpucontext.WindowProvider`** — ggcanvas auto-detects HiDPI scale
- **macOS race condition fix**: `surface.Resize()` removed from PollEvents (main thread) — surface reconfiguration now exclusively on render thread
- **Windows**: real DPI awareness via `GetDpiForWindow()`

Closes RETINA-001, RETINA-002. Related: [gg#171](https://github.com/gogpu/gg/issues/171), [gg#175](https://github.com/gogpu/gg/issues/175)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] `go fmt` clean
- [x] Visual verification: gogpu examples + UI hello window
- [ ] CI green
