### PR TITLE
fix(platform): re-set CAMetalLayer contentsScale every frame for Retina

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.2] - 2026-03-11
+
+### Fixed
+
+- **macOS Retina: CAMetalLayer contentsScale not maintained across frames** —
+  in layer-hosting mode (`setWantsLayer` + `setLayer`), macOS does not manage
+  the layer and may reset `contentsScale` to 1.0 during layout passes. The
+  drawable-to-screen mapping then drifts, causing progressive stretching and
+  offset of rendered content on Retina displays. Now `contentsScale` is re-set
+  from `BackingScaleFactor()` before every `nextDrawable` call, matching Gio's
+  `displayLayer:` pattern and Skia's `resize()` approach.
+  ([gg#171](https://github.com/gogpu/gg/issues/171))
+
 ## [0.23.1] - 2026-03-11
 
 ### Fixed

--- a/internal/platform/darwin/surface.go
+++ b/internal/platform/darwin/surface.go
@@ -440,9 +440,25 @@ func (s *Surface) UpdateSize() {
 }
 
 // AcquireDrawable acquires the next drawable for rendering.
+//
+// Before acquiring, contentsScale is re-set from the window's backing scale
+// factor. In layer-hosting mode (setWantsLayer + setLayer), macOS does not
+// manage the layer and may reset contentsScale during layout passes. Without
+// refreshing it every frame, the drawable-to-screen mapping drifts on Retina
+// displays. This matches Gio's approach of re-setting contentsScale in
+// displayLayer: every frame.
 func (s *Surface) AcquireDrawable() (*MetalDrawable, error) {
 	if s == nil || s.layer == nil {
 		return nil, ErrMetalLayerCreationFailed
+	}
+
+	// Re-set contentsScale before acquiring drawable to prevent Retina drift.
+	// Reference: Gio metal_macos.go (re-sets every frame),
+	// Skia GaneshMetalWindowContext_mac.mm (sets alongside drawableSize).
+	if s.window != nil {
+		if scale := s.window.BackingScaleFactor(); scale > 0 {
+			s.layer.SetContentsScale(scale)
+		}
 	}
 
 	drawableID := s.layer.NextDrawable()


### PR DESCRIPTION
## Summary

- Fix progressive drift of rendered content on macOS Retina displays (gg#171)
- In layer-hosting mode (`setWantsLayer` + `setLayer`), macOS does not manage the CAMetalLayer and may reset `contentsScale` to 1.0 during layout passes
- Re-set `contentsScale` from `BackingScaleFactor()` before every `nextDrawable` call
- Matches Gio's `displayLayer:` pattern and Skia's `resize()` approach

## Test plan

- [ ] CI green (build + lint)
- [ ] @sverrehu verifies on macOS Retina: circles stay stable without progressive drift
