### PR TITLE
ci: ignore GPU-dependent files from Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -28,6 +28,8 @@ ignore:
   - "renderer.go"
   - "renderer_rust.go"
   - "renderer_norust.go"
+  - "texture.go"
+  - "fence_pool.go"
 
 # Go-specific parser settings
 parsers:


### PR DESCRIPTION
Add texture.go and fence_pool.go to codecov ignore — require GPU hardware for testing.