### PR TITLE
fix: prevent infinite loop in PollEvents when window close is requested

### DIFF
--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -52,10 +52,11 @@ type waylandPlatform struct {
 	touch    *wayland.WlTouch
 
 	// Window state
-	width       int
-	height      int
-	shouldClose bool
-	configured  bool
+	width         int
+	height        int
+	shouldClose   bool
+	closeReturned bool // true after EventClose has been returned from PollEvents
+	configured    bool
 
 	// Pending resize from configure event
 	pendingWidth  int
@@ -1651,10 +1652,17 @@ func (p *waylandPlatform) PollEvents() Event {
 		}
 	}
 
-	// Check for close
-	if p.shouldClose {
+	// Check for close (return EventClose only once to avoid infinite loops
+	// in event drain loops that break on EventNone)
+	if p.shouldClose && !p.closeReturned {
+		p.closeReturned = true
 		p.mu.Unlock()
 		return Event{Type: EventClose}
+	}
+
+	if p.shouldClose {
+		p.mu.Unlock()
+		return Event{Type: EventNone}
 	}
 
 	p.mu.Unlock()
@@ -1686,7 +1694,8 @@ func (p *waylandPlatform) PollEvents() Event {
 		}
 	}
 
-	if p.shouldClose {
+	if p.shouldClose && !p.closeReturned {
+		p.closeReturned = true
 		return Event{Type: EventClose}
 	}
 

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -77,10 +77,11 @@ type Platform struct {
 	keymap *KeyboardMapping
 
 	// Window state
-	width       int
-	height      int
-	shouldClose bool
-	configured  bool
+	width         int
+	height        int
+	shouldClose   bool
+	closeReturned bool // true after EventTypeClose has been returned from PollEvents
+	configured    bool
 
 	// Pending resize
 	pendingWidth  int
@@ -352,13 +353,20 @@ func (p *Platform) PollEvents() PlatformEvent {
 		}
 	}
 
-	// Check for close
-	if p.shouldClose {
+	// Check for close (return EventTypeClose only once to avoid infinite loops
+	// in event drain loops that break on EventTypeNone)
+	if p.shouldClose && !p.closeReturned {
+		p.closeReturned = true
 		p.mu.Unlock()
 		return PlatformEvent{Type: EventTypeClose}
 	}
 
 	p.mu.Unlock()
+
+	// Don't poll for more events after close was requested
+	if p.shouldClose {
+		return PlatformEvent{Type: EventTypeNone}
+	}
 
 	// Process pending events
 	for {
@@ -394,7 +402,8 @@ func (p *Platform) PollEvents() PlatformEvent {
 		}
 	}
 
-	if p.shouldClose {
+	if p.shouldClose && !p.closeReturned {
+		p.closeReturned = true
 		return PlatformEvent{Type: EventTypeClose}
 	}
 


### PR DESCRIPTION
PollEvents() returned EventClose on every call once shouldClose was set, because the flag was never consumed. Event drain loops that break on EventNone spun forever, preventing the window from closing on X11 and Wayland.

Add closeReturned flag so EventClose is returned exactly once. Subsequent calls return EventNone, allowing drain loops to terminate. ShouldClose() still works as it reads shouldClose directly.

Fixes #159
