### PR TITLE
feat: mouse grab / pointer lock — Win32 + X11 (v0.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.0] - 2026-04-09
+
+### Added
+
+- **Mouse grab / pointer lock** — `App.SetCursorMode()` with three modes matching SDL:
+  - `CursorModeLocked` — hidden cursor, confined to window, relative deltas in PointerEvent.DeltaX/DeltaY
+    (SDL `SDL_SetRelativeMouseMode` parity). Uses warp-to-center pattern on Win32 and X11.
+  - `CursorModeConfined` — visible cursor, confined to window bounds
+    (SDL `SDL_SetWindowMouseGrab` parity). Win32 `ClipCursor`, X11 `XGrabPointer` confine_to.
+  - `CursorModeNormal` — default behavior
+  - Focus loss auto-releases grab, focus gain re-applies
+  - Window resize updates clip rect
+  - macOS and Wayland: stubs (implementation after deep research)
+  (#173, requested by @darkliquid for ironwail-go Quake engine)
+
 ## [0.26.4] - 2026-04-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 | **Graphics API** | Runtime selection: Vulkan, DX12, Metal, GLES, Software |
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), zero-copy surface rendering |
-| **Graphics** | Windowing, input handling, texture loading, frameless windows |
+| **Graphics** | Windowing, input handling, texture loading, frameless windows, mouse grab / pointer lock (SDL parity) |
 | **Compute** | Full compute shader support |
 | **Window Chrome** | Frameless windows with custom title bars, DWM shadow, hit-test regions |
 | **HiDPI** | Per-monitor DPI, WM_DPICHANGED, logical/physical coordinate split |
@@ -280,6 +280,11 @@ app.ClipboardWrite("copied text")
 // Cursor management
 app.SetCursor(gpucontext.CursorPointer)  // hand cursor
 app.SetCursor(gpucontext.CursorText)     // I-beam for text input
+
+// Mouse grab / pointer lock (FPS games, 3D editors)
+app.SetCursorMode(gpucontext.CursorModeLocked)   // hide + capture relative deltas (SDL parity)
+app.SetCursorMode(gpucontext.CursorModeConfined)  // visible, confined to window
+app.SetCursorMode(gpucontext.CursorModeNormal)    // release
 
 // System preferences
 if app.DarkMode() { /* switch to dark theme */ }

--- a/app.go
+++ b/app.go
@@ -486,6 +486,38 @@ func (a *App) SetCursor(cursor gpucontext.CursorShape) {
 	}
 }
 
+// SetCursorMode sets the cursor confinement and visibility mode.
+//
+// Three modes are available:
+//   - CursorModeNormal (0): Default — cursor is visible and moves freely.
+//   - CursorModeLocked (1): Cursor is hidden and confined to the window.
+//     Mouse movement is reported as relative deltas (DeltaX/DeltaY on PointerEvent).
+//     Equivalent to SDL_SetRelativeMouseMode(SDL_TRUE).
+//   - CursorModeConfined (2): Cursor is visible but confined to the window bounds.
+//     Equivalent to SDL_SetWindowMouseGrab(SDL_TRUE).
+//
+// On focus loss, the cursor grab is temporarily released and re-applied on focus gain.
+// On window resize while locked/confined, the clip rect is updated automatically.
+//
+// Platform support:
+//   - Windows: Full support (ClipCursor + ShowCursor + SetCursorPos).
+//   - Linux/X11: Full support (XGrabPointer + XWarpPointer + invisible cursor).
+//   - Linux/Wayland: Stub (not yet implemented, requires pointer constraints protocol).
+//   - macOS: Stub (not yet implemented, requires CGAssociateMouseAndMouseCursorPosition).
+func (a *App) SetCursorMode(mode gpucontext.CursorMode) {
+	if a.platform != nil {
+		a.platform.SetCursorMode(int(mode))
+	}
+}
+
+// CursorMode returns the current cursor confinement mode.
+func (a *App) CursorMode() gpucontext.CursorMode {
+	if a.platform != nil {
+		return gpucontext.CursorMode(a.platform.CursorMode())
+	}
+	return gpucontext.CursorModeNormal
+}
+
 // DarkMode returns true if the system dark mode is active.
 // Implements gpucontext.PlatformProvider.
 func (a *App) DarkMode() bool {

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/go-webgpu/webgpu v0.4.3
-	github.com/gogpu/gpucontext v0.11.0
+	github.com/gogpu/gpucontext v0.12.0
 	github.com/gogpu/gputypes v0.4.0
 	github.com/gogpu/wgpu v0.24.4
 	golang.org/x/sys v0.42.0
 )
 
-require github.com/gogpu/naga v0.17.0 // indirect
+require github.com/gogpu/naga v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gpucontext v0.11.0 h1:dm+u3+Sl0Xgh7iZiRRUb36GDpSi8RpNk8n3NPmd5sGw=
-github.com/gogpu/gpucontext v0.11.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
+github.com/gogpu/gpucontext v0.12.0 h1:9stgEAuNDhqHkHUx76SRxxYsSvLA4aDFwTb8zcwLlHw=
+github.com/gogpu/gpucontext v0.12.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.4.0 h1:nPFn77na71K4gkyObbXgpYywy9lIKz/U1x/2+4EAZ3Y=
 github.com/gogpu/gputypes v0.4.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.0 h1:lr3oQbcxNzu7dEv34+VXKFEVth4RzSkx+KF2pvJHtVM=

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -178,6 +178,15 @@ type Platform interface {
 	// On other platforms, this is a no-op.
 	SyncFrame()
 
+	// SetCursorMode sets the cursor confinement/lock mode.
+	// mode: 0=normal (free movement), 1=locked (hidden, confined, relative deltas),
+	// 2=confined (visible, confined to window).
+	SetCursorMode(mode int)
+
+	// CursorMode returns the current cursor mode.
+	// 0=normal, 1=locked, 2=confined.
+	CursorMode() int
+
 	// DarkMode returns true if system dark mode is active.
 	DarkMode() bool
 

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -1091,6 +1091,13 @@ func (p *darwinPlatform) SetCursor(cursorID int) {
 	}
 }
 
+// SetCursorMode is a stub on macOS. Full implementation requires
+// CGAssociateMouseAndMouseCursorPosition and CGWarpMouseCursorPosition.
+func (p *darwinPlatform) SetCursorMode(int) {}
+
+// CursorMode returns 0 (normal) — cursor mode not yet implemented on macOS.
+func (p *darwinPlatform) CursorMode() int { return 0 }
+
 // DarkMode returns true if the system dark mode is active.
 // Checks NSApplication.effectiveAppearance.name for "Dark" substring.
 func (p *darwinPlatform) DarkMode() bool {

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -1783,6 +1783,13 @@ func (p *waylandPlatform) ClipboardWrite(string) error { return nil }
 // attach via wl_pointer.set_cursor. Both approaches are significant effort.
 func (p *waylandPlatform) SetCursor(int) {}
 
+// SetCursorMode is a stub on Wayland. Full implementation requires
+// zwp_pointer_constraints_v1 and zwp_relative_pointer_v1 protocols.
+func (p *waylandPlatform) SetCursorMode(int) {}
+
+// CursorMode returns 0 (normal) — cursor mode not yet implemented on Wayland.
+func (p *waylandPlatform) CursorMode() int { return 0 }
+
 // DarkMode returns true if the system dark mode is active.
 // Checks GTK_THEME environment variable and KDE kdeglobals config.
 // For full support, org.freedesktop.portal.Settings D-Bus interface is needed.
@@ -1837,6 +1844,12 @@ func (p *x11Platform) ClipboardWrite(string) error { return nil }
 // SetCursor changes the mouse cursor shape using the standard X11 cursor font.
 // cursorID maps to gpucontext.CursorShape values (0-11).
 func (p *x11Platform) SetCursor(cursorID int) { p.inner.SetCursor(cursorID) }
+
+// SetCursorMode sets cursor confinement/lock mode.
+func (p *x11Platform) SetCursorMode(mode int) { p.inner.SetCursorMode(mode) }
+
+// CursorMode returns the current cursor mode.
+func (p *x11Platform) CursorMode() int { return p.inner.GetCursorMode() }
 
 // DarkMode returns true if the system dark mode is active.
 // Checks GTK_THEME environment variable and KDE kdeglobals config.

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -193,6 +193,12 @@ const (
 	// DPI change message (Windows 8.1+)
 	wmDpiChanged = 0x02E0 // WM_DPICHANGED
 
+	// Focus messages
+	wmActivate    = 0x0006 // WM_ACTIVATE
+	waInactive    = 0      // WA_INACTIVE
+	waActive      = 1      // WA_ACTIVE
+	waClickActive = 2      // WA_CLICKACTIVE
+
 	// WaitEvents / WakeUp constants
 	wmWakeUp       = 0x0401     // WM_USER + 1 (custom wakeup message)
 	qsAllinput     = 0x04FF     // QS_ALLINPUT
@@ -278,6 +284,12 @@ var (
 	// Mouse capture (for drag tracking across window boundaries)
 	procSetCapture     = user32.NewProc("SetCapture")
 	procReleaseCapture = user32.NewProc("ReleaseCapture")
+
+	// Cursor confinement and positioning (for CursorMode locked/confined)
+	procClipCursor   = user32.NewProc("ClipCursor")
+	procShowCursorW  = user32.NewProc("ShowCursor")
+	procSetCursorPos = user32.NewProc("SetCursorPos")
+	procGetCursorPos = user32.NewProc("GetCursorPos")
 
 	// Pointer input (WM_POINTER*, Windows 8+)
 	procGetPointerType    = user32.NewProc("GetPointerType")
@@ -428,6 +440,14 @@ type windowsPlatform struct {
 
 	// Timestamp reference for event timing
 	startTime time.Time
+
+	// Cursor mode state (0=normal, 1=locked, 2=confined)
+	cursorMode    int
+	savedCursorX  int32 // saved cursor position before locking
+	savedCursorY  int32
+	cursorCenterX int32 // window center in screen coords (for warp-back)
+	cursorCenterY int32
+	cursorHidden  bool // tracks ShowCursor balance
 }
 
 // Global instance for window procedure callback
@@ -927,6 +947,107 @@ func (p *windowsPlatform) HighContrast() bool {
 // On Windows, font scale is derived from the DPI scale factor.
 func (p *windowsPlatform) FontScale() float32 {
 	return float32(p.ScaleFactor())
+}
+
+// SetCursorMode sets cursor confinement/lock mode.
+// 0=normal, 1=locked (hidden + confined + relative deltas), 2=confined (visible + confined).
+func (p *windowsPlatform) SetCursorMode(mode int) {
+	if mode == p.cursorMode {
+		return
+	}
+
+	oldMode := p.cursorMode
+	p.cursorMode = mode
+
+	switch mode {
+	case 1: // Locked
+		// Save current cursor position for restoration
+		var pt point
+		procGetCursorPos.Call(uintptr(unsafe.Pointer(&pt)))
+		p.savedCursorX = pt.x
+		p.savedCursorY = pt.y
+
+		// Compute window center in screen coordinates
+		p.updateCursorClipRect()
+
+		// Clip cursor to window
+		var r rect
+		procGetClientRect.Call(uintptr(p.hwnd), uintptr(unsafe.Pointer(&r)))
+		var origin point
+		procClientToScreen.Call(uintptr(p.hwnd), uintptr(unsafe.Pointer(&origin)))
+		clipRect := rect{
+			left:   origin.x + r.left,
+			top:    origin.y + r.top,
+			right:  origin.x + r.right,
+			bottom: origin.y + r.bottom,
+		}
+		procClipCursor.Call(uintptr(unsafe.Pointer(&clipRect)))
+
+		// Hide cursor
+		if !p.cursorHidden {
+			procShowCursorW.Call(0) // FALSE = hide
+			p.cursorHidden = true
+		}
+
+		// Warp to center
+		procSetCursorPos.Call(uintptr(p.cursorCenterX), uintptr(p.cursorCenterY))
+
+	case 2: // Confined
+		// Clip cursor to window
+		var r rect
+		procGetClientRect.Call(uintptr(p.hwnd), uintptr(unsafe.Pointer(&r)))
+		var origin point
+		procClientToScreen.Call(uintptr(p.hwnd), uintptr(unsafe.Pointer(&origin)))
+		clipRect := rect{
+			left:   origin.x + r.left,
+			top:    origin.y + r.top,
+			right:  origin.x + r.right,
+			bottom: origin.y + r.bottom,
+		}
+		procClipCursor.Call(uintptr(unsafe.Pointer(&clipRect)))
+
+		// Show cursor if it was hidden
+		if p.cursorHidden {
+			procShowCursorW.Call(1) // TRUE = show
+			p.cursorHidden = false
+		}
+
+		// Restore cursor position if coming from locked mode
+		if oldMode == 1 {
+			procSetCursorPos.Call(uintptr(p.savedCursorX), uintptr(p.savedCursorY))
+		}
+
+	default: // Normal (0)
+		// Release clip
+		procClipCursor.Call(0)
+
+		// Show cursor if hidden
+		if p.cursorHidden {
+			procShowCursorW.Call(1) // TRUE = show
+			p.cursorHidden = false
+		}
+
+		// Restore cursor position if coming from locked mode
+		if oldMode == 1 {
+			procSetCursorPos.Call(uintptr(p.savedCursorX), uintptr(p.savedCursorY))
+		}
+	}
+}
+
+// CursorMode returns the current cursor mode.
+func (p *windowsPlatform) CursorMode() int {
+	return p.cursorMode
+}
+
+// updateCursorClipRect computes the window center in screen coordinates.
+// Called when entering locked mode or when the window moves/resizes while locked.
+func (p *windowsPlatform) updateCursorClipRect() {
+	var r rect
+	procGetClientRect.Call(uintptr(p.hwnd), uintptr(unsafe.Pointer(&r)))
+	var origin point
+	procClientToScreen.Call(uintptr(p.hwnd), uintptr(unsafe.Pointer(&origin)))
+	p.cursorCenterX = origin.x + (r.right-r.left)/2
+	p.cursorCenterY = origin.y + (r.bottom-r.top)/2
 }
 
 func (p *windowsPlatform) SetFrameless(frameless bool) {
@@ -1804,6 +1925,25 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 			return hitTestResultToWin32(result)
 		}
 
+	case wmActivate:
+		// Release cursor grab on focus loss, re-grab on focus gain.
+		activationState := wParam & 0xFFFF
+		if activationState == waInactive {
+			// Window lost focus — temporarily release cursor constraints
+			if p.cursorMode != 0 {
+				procClipCursor.Call(0)
+				if p.cursorHidden {
+					procShowCursorW.Call(1)
+					p.cursorHidden = false
+				}
+			}
+		} else {
+			// Window gained focus — re-apply cursor mode
+			if p.cursorMode != 0 {
+				p.SetCursorMode(p.cursorMode)
+			}
+		}
+
 	case wmWakeUp:
 		// No-op: sole purpose is to unblock MsgWaitForMultipleObjectsEx in WaitEvents.
 		return 0
@@ -1889,6 +2029,11 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 				PhysicalWidth:  newWidth,
 				PhysicalHeight: newHeight,
 			})
+
+			// Update cursor clip rect if locked or confined
+			if p.cursorMode != 0 {
+				p.SetCursorMode(p.cursorMode)
+			}
 		}
 		return 0
 
@@ -2099,6 +2244,40 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 	// Mouse movement
 	case wmMouseMove:
 		x, y := extractMousePos(lParam)
+
+		// In locked mode, compute delta from center and warp back
+		if p.cursorMode == 1 {
+			// Convert client coords to screen coords to compare with center
+			var screenPt point
+			screenPt.x = int32(x)
+			screenPt.y = int32(y)
+			procClientToScreen.Call(uintptr(p.hwnd), uintptr(unsafe.Pointer(&screenPt)))
+
+			deltaX := float64(screenPt.x - p.cursorCenterX)
+			deltaY := float64(screenPt.y - p.cursorCenterY)
+
+			// Skip the warp-back event (delta=0 means cursor is at center)
+			if deltaX == 0 && deltaY == 0 {
+				return 0
+			}
+
+			// Warp cursor back to center
+			procSetCursorPos.Call(uintptr(p.cursorCenterX), uintptr(p.cursorCenterY))
+
+			// Update mouse state
+			p.mouseMu.Lock()
+			p.buttons = extractButtons(wParam)
+			p.modifiers = extractModifiers(wParam)
+			p.mouseInWindow = true
+			p.mouseMu.Unlock()
+
+			// Emit move event with relative deltas
+			ev := p.createPointerEvent(gpucontext.PointerMove, gpucontext.ButtonNone, x, y, wParam)
+			ev.DeltaX = deltaX
+			ev.DeltaY = deltaY
+			p.dispatchPointerEvent(ev)
+			return 0
+		}
 
 		// Track mouse enter/leave
 		p.mouseMu.Lock()

--- a/internal/platform/x11/cursor.go
+++ b/internal/platform/x11/cursor.go
@@ -107,6 +107,152 @@ func (c *Connection) FreeCursor(cursorID ResourceID) error {
 	return nil
 }
 
+// CreatePixmap creates a pixmap with the given depth and dimensions.
+// X11 opcode 53: CreatePixmap(depth, pid, drawable, width, height).
+func (c *Connection) CreatePixmap(depth uint8, drawable ResourceID, width, height uint16) (ResourceID, error) {
+	pixmapID := c.GenerateID()
+
+	e := NewEncoder(c.byteOrder)
+	e.PutUint8(OpcodeCreatePixmap)
+	e.PutUint8(depth)
+	e.PutUint16(4) // length = 4 4-byte units
+	e.PutUint32(uint32(pixmapID))
+	e.PutUint32(uint32(drawable))
+	e.PutUint16(width)
+	e.PutUint16(height)
+
+	if _, err := c.sendRequest(e.Bytes()); err != nil {
+		return 0, fmt.Errorf("x11: CreatePixmap failed: %w", err)
+	}
+	return pixmapID, nil
+}
+
+// FreePixmap frees a pixmap resource.
+// X11 opcode 54: FreePixmap(pixmap).
+func (c *Connection) FreePixmap(pixmapID ResourceID) error {
+	e := NewEncoder(c.byteOrder)
+	e.PutUint8(OpcodeFreePixmap)
+	e.PutUint8(0)  // unused
+	e.PutUint16(2) // length
+	e.PutUint32(uint32(pixmapID))
+
+	if _, err := c.sendRequest(e.Bytes()); err != nil {
+		return fmt.Errorf("x11: FreePixmap failed: %w", err)
+	}
+	return nil
+}
+
+// CreateCursor creates a cursor from source and mask pixmaps.
+// X11 opcode 93: CreateCursor(cid, source, mask, fore_r, fore_g, fore_b,
+//
+//	back_r, back_g, back_b, x, y).
+//
+// Pass mask=0 for no mask (all pixels are displayed).
+func (c *Connection) CreateCursor(source, mask ResourceID,
+	foreR, foreG, foreB, backR, backG, backB uint16, x, y uint16) (ResourceID, error) {
+	cursorID := c.GenerateID()
+
+	e := NewEncoder(c.byteOrder)
+	e.PutUint8(OpcodeCreateCursor)
+	e.PutUint8(0)  // unused
+	e.PutUint16(8) // length = 8 4-byte units
+	e.PutUint32(uint32(cursorID))
+	e.PutUint32(uint32(source))
+	e.PutUint32(uint32(mask))
+	e.PutUint16(foreR)
+	e.PutUint16(foreG)
+	e.PutUint16(foreB)
+	e.PutUint16(backR)
+	e.PutUint16(backG)
+	e.PutUint16(backB)
+	e.PutUint16(x)
+	e.PutUint16(y)
+
+	if _, err := c.sendRequest(e.Bytes()); err != nil {
+		return 0, fmt.Errorf("x11: CreateCursor failed: %w", err)
+	}
+	return cursorID, nil
+}
+
+// GrabPointer grabs the pointer device.
+// X11 opcode 26: GrabPointer(owner_events, grab_window, event_mask,
+//
+//	pointer_mode, keyboard_mode, confine_to, cursor, time).
+//
+// Returns 0 (GrabSuccess) on success, or an error status.
+func (c *Connection) GrabPointer(ownerEvents bool, grabWindow ResourceID,
+	eventMask uint16, pointerMode, keyboardMode uint8,
+	confineTo, cursor ResourceID, timestamp Timestamp) (uint8, error) {
+	var oe uint8
+	if ownerEvents {
+		oe = 1
+	}
+
+	e := NewEncoder(c.byteOrder)
+	e.PutUint8(OpcodeGrabPointer)
+	e.PutUint8(oe)
+	e.PutUint16(6) // length = 6 4-byte units
+	e.PutUint32(uint32(grabWindow))
+	e.PutUint16(eventMask)
+	e.PutUint8(pointerMode)
+	e.PutUint8(keyboardMode)
+	e.PutUint32(uint32(confineTo))
+	e.PutUint32(uint32(cursor))
+	e.PutUint32(uint32(timestamp))
+
+	reply, err := c.sendRequestWithReply(e.Bytes())
+	if err != nil {
+		return 0, fmt.Errorf("x11: GrabPointer failed: %w", err)
+	}
+	if len(reply) < 2 {
+		return 0, fmt.Errorf("x11: GrabPointer reply too short")
+	}
+	// Reply byte 1 is the status: 0=Success, 1=AlreadyGrabbed, etc.
+	return reply[1], nil
+}
+
+// UngrabPointer releases a pointer grab.
+// X11 opcode 27: UngrabPointer(time).
+func (c *Connection) UngrabPointer(timestamp Timestamp) error {
+	e := NewEncoder(c.byteOrder)
+	e.PutUint8(OpcodeUngrabPointer)
+	e.PutUint8(0)  // unused
+	e.PutUint16(2) // length = 2 4-byte units
+	e.PutUint32(uint32(timestamp))
+
+	if _, err := c.sendRequest(e.Bytes()); err != nil {
+		return fmt.Errorf("x11: UngrabPointer failed: %w", err)
+	}
+	return nil
+}
+
+// WarpPointer warps the pointer to a position relative to a destination window.
+// X11 opcode 41: WarpPointer(src_window, dst_window, src_x, src_y,
+//
+//	src_width, src_height, dst_x, dst_y).
+//
+// Pass srcWindow=0 to warp regardless of current position.
+func (c *Connection) WarpPointer(srcWindow, dstWindow ResourceID,
+	srcX, srcY int16, srcWidth, srcHeight uint16, dstX, dstY int16) error {
+	e := NewEncoder(c.byteOrder)
+	e.PutUint8(OpcodeWarpPointer)
+	e.PutUint8(0)  // unused
+	e.PutUint16(6) // length = 6 4-byte units
+	e.PutUint32(uint32(srcWindow))
+	e.PutUint32(uint32(dstWindow))
+	e.PutInt16(srcX)
+	e.PutInt16(srcY)
+	e.PutUint16(srcWidth)
+	e.PutUint16(srcHeight)
+	e.PutInt16(dstX)
+	e.PutInt16(dstY)
+
+	if _, err := c.sendRequest(e.Bytes()); err != nil {
+		return fmt.Errorf("x11: WarpPointer failed: %w", err)
+	}
+	return nil
+}
+
 // ChangeWindowCursor changes the cursor attribute of a window.
 // X11 opcode 2: ChangeWindowAttributes with CWCursor value mask.
 // Pass cursorID=0 to revert to parent window's cursor.

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -127,13 +127,13 @@ type Platform struct {
 	startTime time.Time
 
 	// Cursor mode state (0=normal, 1=locked, 2=confined)
-	cursorMode      int
-	blankCursorID   ResourceID // 1x1 transparent cursor for locked mode
-	savedMouseX     float64    // saved position before locking
-	savedMouseY     float64
-	cursorCenterX   int16 // window center for warp-back in locked mode
-	cursorCenterY   int16
-	cursorGrabbed   bool // whether XGrabPointer is active
+	cursorMode    int
+	blankCursorID ResourceID // 1x1 transparent cursor for locked mode
+	savedMouseX   float64    // saved position before locking
+	savedMouseY   float64
+	cursorCenterX int16 // window center for warp-back in locked mode
+	cursorCenterY int16
+	cursorGrabbed bool // whether XGrabPointer is active
 }
 
 // NewPlatform creates a new X11 platform instance.

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -125,6 +125,15 @@ type Platform struct {
 
 	// Timestamp reference for event timing
 	startTime time.Time
+
+	// Cursor mode state (0=normal, 1=locked, 2=confined)
+	cursorMode      int
+	blankCursorID   ResourceID // 1x1 transparent cursor for locked mode
+	savedMouseX     float64    // saved position before locking
+	savedMouseY     float64
+	cursorCenterX   int16 // window center for warp-back in locked mode
+	cursorCenterY   int16
+	cursorGrabbed   bool // whether XGrabPointer is active
 }
 
 // NewPlatform creates a new X11 platform instance.
@@ -542,6 +551,14 @@ func (p *Platform) handleEvent(event Event) PlatformEvent {
 	case *LeaveNotifyEvent:
 		p.handleLeaveNotify(e)
 
+	case *FocusInEvent:
+		// Re-grab pointer if cursor mode requires it
+		p.handleFocusIn()
+
+	case *FocusOutEvent:
+		// Release pointer grab on focus loss
+		p.handleFocusOut()
+
 	case *GenericEvent:
 		p.handleGenericEvent(e)
 	}
@@ -555,11 +572,36 @@ func (p *Platform) handleMotionNotify(e *MotionNotifyEvent) {
 	y := float64(e.EventY)
 
 	p.mu.Lock()
+	cursorMode := p.cursorMode
+	centerX := float64(p.cursorCenterX)
+	centerY := float64(p.cursorCenterY)
 	p.mouseX = x
 	p.mouseY = y
 	p.buttons = extractButtons(e.State)
 	p.modifiers = extractModifiers(e.State)
 	p.mu.Unlock()
+
+	// In locked mode, compute delta from center and warp back
+	if cursorMode == 1 {
+		deltaX := x - centerX
+		deltaY := y - centerY
+
+		// Skip the warp-back event (delta=0)
+		if deltaX == 0 && deltaY == 0 {
+			return
+		}
+
+		// Warp cursor back to center
+		_ = p.conn.WarpPointer(0, p.window, 0, 0, 0, 0,
+			int16(centerX), int16(centerY))
+
+		// Emit event with relative deltas
+		ev := p.createPointerEvent(gpucontext.PointerMove, gpucontext.ButtonNone, x, y, e.State)
+		ev.DeltaX = deltaX
+		ev.DeltaY = deltaY
+		p.dispatchPointerEvent(ev)
+		return
+	}
 
 	ev := p.createPointerEvent(gpucontext.PointerMove, gpucontext.ButtonNone, x, y, e.State)
 	p.dispatchPointerEvent(ev)
@@ -1529,6 +1571,142 @@ func cursorShapeToGlyph(cursorID int) uint16 {
 	default:
 		return XCursorLeftPtr
 	}
+}
+
+// SetCursorMode sets cursor confinement/lock mode.
+// 0=normal, 1=locked (hidden, confined, relative deltas), 2=confined (visible, confined).
+func (p *Platform) SetCursorMode(mode int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.conn == nil || p.window == 0 {
+		return
+	}
+
+	if mode == p.cursorMode {
+		return
+	}
+
+	oldMode := p.cursorMode
+	p.cursorMode = mode
+
+	switch mode {
+	case 1: // Locked
+		// Save current mouse position
+		if oldMode == 0 {
+			p.savedMouseX = p.mouseX
+			p.savedMouseY = p.mouseY
+		}
+
+		// Compute window center
+		p.cursorCenterX = int16(p.width / 2)
+		p.cursorCenterY = int16(p.height / 2)
+
+		// Create invisible cursor if not already created
+		if p.blankCursorID == 0 {
+			p.createBlankCursor()
+		}
+
+		// Grab pointer with invisible cursor, confined to our window
+		grabMask := uint16(EventMaskPointerMotion | EventMaskButtonPress | EventMaskButtonRelease)
+		_, _ = p.conn.GrabPointer(true, p.window, grabMask,
+			GrabModeAsync, GrabModeAsync, p.window, p.blankCursorID, 0)
+		p.cursorGrabbed = true
+
+		// Warp to center
+		_ = p.conn.WarpPointer(0, p.window, 0, 0, 0, 0, p.cursorCenterX, p.cursorCenterY)
+
+	case 2: // Confined
+		// Grab pointer with normal cursor, confined to window
+		grabMask := uint16(EventMaskPointerMotion | EventMaskButtonPress | EventMaskButtonRelease)
+		_, _ = p.conn.GrabPointer(true, p.window, grabMask,
+			GrabModeAsync, GrabModeAsync, p.window, 0, 0)
+		p.cursorGrabbed = true
+
+		// Restore cursor position if coming from locked mode
+		if oldMode == 1 {
+			_ = p.conn.WarpPointer(0, p.window, 0, 0, 0, 0,
+				int16(p.savedMouseX), int16(p.savedMouseY))
+		}
+
+	default: // Normal (0)
+		// Release pointer grab
+		if p.cursorGrabbed {
+			_ = p.conn.UngrabPointer(0)
+			p.cursorGrabbed = false
+		}
+
+		// Restore cursor (revert to normal)
+		_ = p.conn.ChangeWindowCursor(p.window, 0)
+
+		// Restore mouse position if coming from locked mode
+		if oldMode == 1 {
+			_ = p.conn.WarpPointer(0, p.window, 0, 0, 0, 0,
+				int16(p.savedMouseX), int16(p.savedMouseY))
+		}
+	}
+}
+
+// GetCursorMode returns the current cursor mode.
+func (p *Platform) GetCursorMode() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.cursorMode
+}
+
+// handleFocusIn re-applies cursor grab when window regains focus.
+func (p *Platform) handleFocusIn() {
+	p.mu.Lock()
+	mode := p.cursorMode
+	// Reset cursorMode temporarily so SetCursorMode doesn't early-return
+	if mode != 0 {
+		p.cursorMode = 0
+	}
+	p.mu.Unlock()
+
+	if mode != 0 {
+		p.SetCursorMode(mode)
+	}
+}
+
+// handleFocusOut releases cursor grab when window loses focus.
+func (p *Platform) handleFocusOut() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cursorGrabbed && p.conn != nil {
+		_ = p.conn.UngrabPointer(0)
+		p.cursorGrabbed = false
+	}
+}
+
+// createBlankCursor creates a 1x1 transparent cursor for hiding the pointer.
+// Must be called with p.mu held.
+func (p *Platform) createBlankCursor() {
+	if p.conn == nil || p.window == 0 {
+		return
+	}
+
+	// Create 1x1 pixmap (depth 1 for cursor source/mask)
+	pixmap, err := p.conn.CreatePixmap(1, p.window, 1, 1)
+	if err != nil {
+		return
+	}
+
+	// Create cursor from the pixmap (both source and mask = same 1x1 pixmap)
+	// With a 1-bit depth source of all zeros and mask of all zeros,
+	// the cursor is fully transparent.
+	cursor, err := p.conn.CreateCursor(pixmap, pixmap,
+		0, 0, 0, // foreground RGB
+		0, 0, 0, // background RGB
+		0, 0) // hotspot
+	if err != nil {
+		_ = p.conn.FreePixmap(pixmap)
+		return
+	}
+
+	_ = p.conn.FreePixmap(pixmap)
+	p.blankCursorID = cursor
 }
 
 // BlitPixels copies RGBA pixel data to the window using X11 PutImage.

--- a/internal/platform/x11/wire.go
+++ b/internal/platform/x11/wire.go
@@ -350,6 +350,12 @@ const (
 	CWCursor           = 1 << 14
 )
 
+// Grab modes for GrabPointer/GrabKeyboard.
+const (
+	GrabModeSync  = 0
+	GrabModeAsync = 1
+)
+
 // Property mode values.
 const (
 	PropModeReplace = 0

--- a/platform_provider_test.go
+++ b/platform_provider_test.go
@@ -61,6 +61,8 @@ func (m *mockPlatform) PrepareFrame() platform.PrepareFrameResult {
 func (m *mockPlatform) ClipboardRead() (string, error)   { return m.clipboardText, nil }
 func (m *mockPlatform) ClipboardWrite(text string) error { m.clipboardText = text; return nil }
 func (m *mockPlatform) SetCursor(cursorID int)           { m.cursorID = cursorID }
+func (m *mockPlatform) SetCursorMode(int)                {}
+func (m *mockPlatform) CursorMode() int                  { return 0 }
 func (m *mockPlatform) DarkMode() bool                   { return m.darkMode }
 func (m *mockPlatform) ReduceMotion() bool               { return m.reduceMotion }
 func (m *mockPlatform) HighContrast() bool               { return m.highContrast }


### PR DESCRIPTION
## Summary

- `App.SetCursorMode()` with 3 modes matching SDL:
  - `CursorModeLocked` — hidden, confined, relative deltas (FPS mouselook)
  - `CursorModeConfined` — visible, confined to window
  - `CursorModeNormal` — default
- Win32: ClipCursor + ShowCursor + SetCursorPos warp-to-center
- X11: XGrabPointer + invisible cursor + XWarpPointer
- Focus loss/gain auto-release/re-grab
- macOS/Wayland: stubs (pending research)
- gpucontext v0.11.0 → v0.12.0

Closes #173. Requested by @darkliquid for ironwail-go Quake engine.

## Test plan
- [x] Build passes (Windows, cross-compile Linux/macOS)
- [x] All tests pass
- [x] Lint 0 issues
- [ ] @darkliquid tests on X11 with ironwail-go