### PR TITLE
feat: EventFocus on all platforms (v0.28.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.1] - 2026-04-23
+
+### Added
+
+- **EventFocus** — window focus/blur events on all 4 platforms for multi-window VSync strategy (ADR-010). Win32: `WM_SETFOCUS`/`WM_KILLFOCUS`. X11: `FocusIn`/`FocusOut` with `NotifyPointer`/`NotifyNormal` filtering. Wayland: `keyboard_enter`/`keyboard_leave`. macOS: `IsKeyWindow()` polling. Events carry `WindowID` for multi-window routing. `WindowManager.setFocus()` wired on focus gain. (FEAT-MW-FOCUS-001)
+- **WindowID on all Win32 events** — `EventClose`, `EventResize` now include `WindowID` for proper multi-window event routing
+
 ## [0.28.0] - 2026-04-23
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,10 +25,11 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.28.0
+## Current State: v0.28.1
 
 ✅ **Production-ready** with full feature set:
 - **Multi-window** — `App.NewWindow()` creates additional windows with shared GPU device (ADR-010)
+- **EventFocus** — window focus/blur events on all platforms for multi-window VSync routing
 - Dual backend (Rust/Pure Go) — cross-platform (Windows, macOS, Linux)
 - **PlatformManager / PlatformWindow** — clean process-level / per-window split (Qt6 pattern)
 - Multi-thread architecture (Ebiten/Gio pattern)
@@ -53,6 +54,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.28.1** | 2026-04-23 | EventFocus on all platforms (Win32, X11, Wayland, macOS), WindowID on all events |
 | **v0.28.0** | 2026-04-23 | **Multi-window** — App.NewWindow(), PlatformManager/PlatformWindow, shared GPU device, per-window frame loop |
 | **v0.27.3** | 2026-04-23 | wgpu v0.25.3 |
 | **v0.27.2** | 2026-04-23 | Ecosystem sync: wgpu v0.25.2, gpucontext v0.14.0 (TextureView), gputypes v0.5.0 (PrimitiveState zero value) |
@@ -92,6 +94,9 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 - [x] VSync: primary window Fifo, secondary Immediate (v0.28.0)
 - [x] Multi-window frame loop with activeSurface() dispatch (v0.28.0)
 - [x] App.NewWindow() + real window creation + GPU surface (v0.28.0)
+- [x] EventFocus on all platforms — Win32, X11, Wayland, macOS (v0.28.1)
+- [x] WindowID on all events for multi-window routing (v0.28.1)
+- [ ] VSync mode switching on focus change (surface reconfigure)
 - [ ] Window types: Normal, Dialog, Tool, Popup with parent-child
 - [ ] Close-as-request (OnClose returns bool to reject)
 - [ ] Unified platform package structure (REFACTOR-PLATFORM-001)

--- a/app.go
+++ b/app.go
@@ -360,6 +360,10 @@ func (a *App) processEventsMultiThread() bool {
 			} else {
 				a.closeSecondaryWindow(event.WindowID)
 			}
+		case platform.EventFocus:
+			if event.Focused {
+				a.windowManager.setFocus(event.WindowID)
+			}
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -335,36 +335,10 @@ func (a *App) processEventsMultiThread() bool {
 		events = append(events, event)
 	}
 
-	// Process all events, but track only the last resize per window.
-	// For the primary window, we use the deferred resize pattern (RequestResize).
-	// For secondary windows, we resize the surface directly on the render thread.
+	// Classify events by type and window.
 	var secondaryResizes []platform.Event
-
 	for i := range events {
-		event := &events[i]
-		switch event.Type {
-		case platform.EventResize:
-			isPrimary := event.WindowID == 0 ||
-				(a.primaryWindow != nil && event.WindowID == a.primaryWindow.id)
-			if isPrimary {
-				lastResize = event
-			} else {
-				secondaryResizes = append(secondaryResizes, *event)
-			}
-		case platform.EventClose:
-			// Check if this is a secondary window close.
-			isPrimary := event.WindowID == 0 ||
-				(a.primaryWindow != nil && event.WindowID == a.primaryWindow.id)
-			if isPrimary {
-				a.running = false
-			} else {
-				a.closeSecondaryWindow(event.WindowID)
-			}
-		case platform.EventFocus:
-			if event.Focused {
-				a.windowManager.setFocus(event.WindowID)
-			}
-		}
+		lastResize, secondaryResizes = a.classifyEvent(&events[i], lastResize, secondaryResizes)
 	}
 
 	// Queue primary window resize for render thread (deferred pattern).
@@ -416,6 +390,32 @@ func (a *App) handleSecondaryResize(ev platform.Event) {
 // windowFrame holds a snapshot of per-window state captured on the main thread
 // for the render thread to use. This avoids accessing window/platform state
 // from the render thread.
+// classifyEvent routes a single platform event to the appropriate handler.
+func (a *App) classifyEvent(event *platform.Event, lastResize *platform.Event, secondaryResizes []platform.Event) (*platform.Event, []platform.Event) {
+	isPrimary := event.WindowID == 0 ||
+		(a.primaryWindow != nil && event.WindowID == a.primaryWindow.id)
+
+	switch event.Type {
+	case platform.EventResize:
+		if isPrimary {
+			lastResize = event
+		} else {
+			secondaryResizes = append(secondaryResizes, *event)
+		}
+	case platform.EventClose:
+		if isPrimary {
+			a.running = false
+		} else {
+			a.closeSecondaryWindow(event.WindowID)
+		}
+	case platform.EventFocus:
+		if event.Focused {
+			a.windowManager.setFocus(event.WindowID)
+		}
+	}
+	return lastResize, secondaryResizes
+}
+
 type windowFrame struct {
 	window *Window
 	onDraw func(*Context)

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -31,10 +31,11 @@ type Config struct {
 type Event struct {
 	WindowID       WindowID
 	Type           EventType
-	Width          int // for resize events: logical size (platform points/DIP)
-	Height         int // for resize events: logical size (platform points/DIP)
-	PhysicalWidth  int // for resize events: physical pixels (GPU framebuffer)
-	PhysicalHeight int // for resize events: physical pixels (GPU framebuffer)
+	Width          int  // for resize events: logical size (platform points/DIP)
+	Height         int  // for resize events: logical size (platform points/DIP)
+	PhysicalWidth  int  // for resize events: physical pixels (GPU framebuffer)
+	PhysicalHeight int  // for resize events: physical pixels (GPU framebuffer)
+	Focused        bool // for focus events: true = gained focus, false = lost focus
 }
 
 // EventType represents the type of platform event.
@@ -44,6 +45,7 @@ const (
 	EventNone EventType = iota
 	EventClose
 	EventResize
+	EventFocus
 )
 
 // PrepareFrameResult contains per-frame surface state from the platform layer.

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -46,6 +46,10 @@ type darwinWindow struct {
 
 	// Last known scale factor for change detection in PrepareFrame.
 	lastScale float64
+
+	// Focus tracking: last known key window status for change detection.
+	lastKeyWindow bool
+	focusInited   bool // true after first pollEvents call
 }
 
 // darwinPlatform implements Platform for macOS using Cocoa/AppKit.
@@ -432,6 +436,19 @@ func (w *darwinWindow) pollEvents(app *darwin.Application) Event {
 				PhysicalWidth:  physW,
 				PhysicalHeight: physH,
 			})
+		}
+	}
+
+	// Check for focus change — macOS uses key window status.
+	// NSWindow.isKeyWindow is true when the window has keyboard focus.
+	if w.window != nil {
+		isKey := w.window.IsKeyWindow()
+		if !w.focusInited {
+			w.lastKeyWindow = isKey
+			w.focusInited = true
+		} else if isKey != w.lastKeyWindow {
+			w.lastKeyWindow = isKey
+			w.events = append(w.events, Event{Type: EventFocus, Focused: isKey})
 		}
 	}
 

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -160,6 +160,8 @@ func (p *x11Platform) PollEvents() Event {
 			PhysicalWidth:  event.Width,
 			PhysicalHeight: event.Height,
 		}
+	case x11.EventTypeFocus:
+		return Event{Type: EventFocus, Focused: event.Focused}
 	default:
 		return Event{Type: EventNone}
 	}
@@ -793,11 +795,13 @@ func (p *waylandPlatform) setupInputCallbacks() {
 			w.pointerMu.Lock()
 			w.keyboardFocused = true
 			w.pointerMu.Unlock()
+			w.queueEvent(Event{Type: EventFocus, Focused: true})
 		},
 		OnKeyboardLeave: func(serial uint32) {
 			w.pointerMu.Lock()
 			w.keyboardFocused = false
 			w.pointerMu.Unlock()
+			w.queueEvent(Event{Type: EventFocus, Focused: false})
 		},
 		OnKeyboardKey: func(serial, timeMs, key, state uint32) {
 			w.pointerMu.RLock()

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -194,6 +194,8 @@ const (
 	wmDpiChanged = 0x02E0 // WM_DPICHANGED
 
 	// Focus messages
+	wmSetFocus    = 0x0007 // WM_SETFOCUS
+	wmKillFocus   = 0x0008 // WM_KILLFOCUS
 	wmActivate    = 0x0006 // WM_ACTIVATE
 	waInactive    = 0      // WA_INACTIVE
 	waActive      = 1      // WA_ACTIVE
@@ -2038,7 +2040,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 	switch message {
 	case wmClose:
 		w.shouldClose = true
-		w.queueEvent(Event{Type: EventClose})
+		w.queueEvent(Event{Type: EventClose, WindowID: w.id})
 		return 0
 
 	case wmNCUAHDrawCaption, wmNCUAHDrawFrame:
@@ -2129,6 +2131,14 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 			return hitTestResultToWin32(result)
 		}
 
+	case wmSetFocus:
+		w.queueEvent(Event{Type: EventFocus, WindowID: w.id, Focused: true})
+		return 0
+
+	case wmKillFocus:
+		w.queueEvent(Event{Type: EventFocus, WindowID: w.id, Focused: false})
+		return 0
+
 	case wmActivate:
 		// Release cursor grab on focus loss, re-grab on focus gain.
 		activationState := wParam & 0xFFFF
@@ -2171,6 +2181,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		logW, logH := w.LogicalSize()
 		w.queueEvent(Event{
 			Type:           EventResize,
+			WindowID:       w.id,
 			Width:          logW,
 			Height:         logH,
 			PhysicalWidth:  physW,
@@ -2228,6 +2239,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 			}
 			w.queueEvent(Event{
 				Type:           EventResize,
+				WindowID:       w.id,
 				Width:          logW,
 				Height:         logH,
 				PhysicalWidth:  newWidth,
@@ -2286,6 +2298,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		logW, logH := w.LogicalSize()
 		w.queueEvent(Event{
 			Type:           EventResize,
+			WindowID:       w.id,
 			Width:          logW,
 			Height:         logH,
 			PhysicalWidth:  physW,
@@ -2325,7 +2338,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		// ESC to close (convenience)
 		if wParam == vkEscape {
 			w.shouldClose = true
-			w.queueEvent(Event{Type: EventClose})
+			w.queueEvent(Event{Type: EventClose, WindowID: w.id})
 		}
 
 		// For WM_SYSKEYDOWN: let DefWindowProc handle Alt+F4, Alt+Tab

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -35,14 +35,16 @@ const (
 	EventTypeNone EventType = iota
 	EventTypeClose
 	EventTypeResize
+	EventTypeFocus
 )
 
 // PlatformEvent represents a platform event.
 // This mirrors platform.Event to avoid import cycles.
 type PlatformEvent struct {
-	Type   EventType
-	Width  int
-	Height int
+	Type    EventType
+	Width   int
+	Height  int
+	Focused bool // for focus events: true = gained, false = lost
 }
 
 // xlibHandle holds the Xlib Display* pointer required for Vulkan surface creation.
@@ -603,9 +605,21 @@ func (p *Platform) handleEvent(event Event) PlatformEvent {
 		// Re-grab pointer if cursor mode requires it
 		p.handleFocusIn(w)
 
+		// Emit focus event only for meaningful focus changes.
+		// Filter out NotifyPointer (5) and NotifyPointerRoot (6) which are noise,
+		// and only accept NotifyNormal mode (0) to avoid spurious events from grabs.
+		if e.Detail != 5 && e.Detail != 6 && e.Mode == 0 {
+			return PlatformEvent{Type: EventTypeFocus, Focused: true}
+		}
+
 	case *FocusOutEvent:
 		// Release pointer grab on focus loss
 		p.handleFocusOut(w)
+
+		// Emit focus event with same filtering as FocusIn.
+		if e.Detail != 5 && e.Detail != 6 && e.Mode == 0 {
+			return PlatformEvent{Type: EventTypeFocus, Focused: false}
+		}
 
 	case *GenericEvent:
 		p.handleGenericEvent(w, e)

--- a/window_manager.go
+++ b/window_manager.go
@@ -148,8 +148,8 @@ func (wm *WindowManager) count() int {
 
 // focusedWindow returns the currently focused window, or nil if none.
 // Used by VSync strategy: focused window = Fifo, others = Immediate (ADR-010).
-// Called when platform sends focus events (EventFocus — not yet implemented).
-func (wm *WindowManager) focusedWindow() *Window { //nolint:unused // VSync focus switching, wired when EventFocus is added
+// Will be called when VSync switching is wired into the multi-window frame loop.
+func (wm *WindowManager) focusedWindow() *Window { //nolint:unused // VSync switching will call this when surface reconfigure is wired
 	wm.mu.RLock()
 	defer wm.mu.RUnlock()
 	if wm.focused == 0 {
@@ -159,8 +159,8 @@ func (wm *WindowManager) focusedWindow() *Window { //nolint:unused // VSync focu
 }
 
 // setFocus changes the focused window and adjusts VSync strategy.
-// Called when platform sends focus events (EventFocus — not yet implemented).
-func (wm *WindowManager) setFocus(id WindowID) { //nolint:unused // VSync focus switching, wired when EventFocus is added
+// Called when platform sends focus events (EventFocus).
+func (wm *WindowManager) setFocus(id WindowID) {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
 	if _, ok := wm.windows[id]; ok {


### PR DESCRIPTION
## Summary

- EventFocus event type on all 4 platforms (Win32, X11, Wayland, macOS)
- WindowID added to all Win32 events for multi-window routing
- WindowManager.setFocus() wired on focus gain
- FEAT-MW-FOCUS-001 completed

## Test plan

- [x] Windows build + tests pass
- [x] Linux cross-compile + lint clean
- [x] macOS cross-compile + lint clean
- [x] golangci-lint 0 issues (all 3 GOOS)
- [ ] CI: all platforms