### PR TITLE
feat: type-safe GPU handles (ADR-018, v0.29.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.3] - 2026-04-25
+
+### Changed
+
+- **Type-safe GPU handles** (ADR-018) — `ContextRenderTarget.SurfaceView()` returns
+  `gpucontext.TextureView` (opaque struct) instead of `any`. `Texture.TextureView()`
+  returns `gpucontext.TextureView`. Compile-time type safety, zero `any` in surface API.
+  Breaking: callers must use `.IsNil()` instead of `== nil`.
+- **deps:** gpucontext v0.14.0 → v0.15.0 (type-safe TextureView/CommandEncoder handles)
+
 ## [0.29.2] - 2026-04-25
 
 ### Fixed

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package gogpu
 import (
 	"fmt"
 	"image"
+	"unsafe"
 
 	"github.com/gogpu/gogpu/gmath"
 	"github.com/gogpu/gpucontext"
@@ -210,8 +211,14 @@ func (c *Context) RenderTarget() *ContextRenderTarget {
 // ContextRenderTarget adapts *Context to ggcanvas.RenderTarget interface.
 type ContextRenderTarget struct{ ctx *Context }
 
-// SurfaceView returns the surface texture view as any.
-func (r *ContextRenderTarget) SurfaceView() any { return r.ctx.SurfaceView() }
+// SurfaceView returns the surface texture view as a type-safe opaque handle.
+func (r *ContextRenderTarget) SurfaceView() gpucontext.TextureView {
+	tv := r.ctx.SurfaceView()
+	if tv == nil {
+		return gpucontext.TextureView{}
+	}
+	return gpucontext.NewTextureView(unsafe.Pointer(tv)) //nolint:gosec // Go spec Rule 1: *T → unsafe.Pointer (ADR-018 opaque handle)
+}
 
 // SurfaceSize returns the surface dimensions.
 func (r *ContextRenderTarget) SurfaceSize() (uint32, uint32) { return r.ctx.SurfaceSize() }

--- a/context_test.go
+++ b/context_test.go
@@ -595,20 +595,11 @@ func TestContextRenderTargetSurfaceViewNil(t *testing.T) {
 	ctx := newTestContext(800, 600, gputypes.TextureFormatBGRA8Unorm, "test")
 	rt := ctx.RenderTarget()
 
-	// SurfaceView returns any wrapping a nil *wgpu.TextureView.
-	// In Go, an interface holding a typed nil is not == nil,
-	// so we check the underlying *wgpu.TextureView value.
+	// SurfaceView returns gpucontext.TextureView (opaque handle struct).
+	// When no frame is in progress, the underlying pointer is nil.
 	sv := rt.SurfaceView()
-	tvPtr, ok := sv.(*wgpu.TextureView)
-	if !ok {
-		// If the return is untyped nil, that's also acceptable
-		if sv != nil {
-			t.Errorf("RenderTarget().SurfaceView() unexpected type %T", sv)
-		}
-		return
-	}
-	if tvPtr != nil {
-		t.Errorf("RenderTarget().SurfaceView() = %v, want nil *TextureView (no frame)", tvPtr)
+	if !sv.IsNil() {
+		t.Errorf("RenderTarget().SurfaceView().IsNil() = false, want true (no frame in progress)")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/go-webgpu/webgpu v0.4.3
-	github.com/gogpu/gpucontext v0.14.0
+	github.com/gogpu/gpucontext v0.15.0
 	github.com/gogpu/gputypes v0.5.0
 	github.com/gogpu/wgpu v0.26.4
 	golang.org/x/sys v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gpucontext v0.14.0 h1:0IAkOwQFW7T5bhRqr8tSgV+bKS4rU9zpDOv5ux1QXr0=
-github.com/gogpu/gpucontext v0.14.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
+github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=
+github.com/gogpu/gpucontext v0.15.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.6 h1:Wh0MbP8wo9+eA1p8yKhDw8lvi+LykMzdJu4bGepstxg=

--- a/texture.go
+++ b/texture.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"unsafe"
 
 	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/gputypes"
@@ -104,11 +105,14 @@ func (t *Texture) View() *wgpu.TextureView {
 	return t.view
 }
 
-// TextureView returns the texture view as gpucontext.TextureView.
+// TextureView returns the texture view as gpucontext.TextureView opaque handle.
 // This enables duck-typed access from packages that cannot import gogpu
 // (e.g., gg/ggcanvas uses structural typing to call this method).
 func (t *Texture) TextureView() gpucontext.TextureView {
-	return t.view
+	if t.view == nil {
+		return gpucontext.TextureView{}
+	}
+	return gpucontext.NewTextureView(unsafe.Pointer(t.view)) //nolint:gosec // Go spec Rule 1: *T → unsafe.Pointer (ADR-018 opaque handle)
 }
 
 // Sampler returns the sampler.


### PR DESCRIPTION
## Summary
- `ContextRenderTarget.SurfaceView()` returns `gpucontext.TextureView` (opaque struct) instead of `any`
- `Texture.TextureView()` returns `gpucontext.TextureView`
- Wraps `*wgpu.TextureView` via `unsafe.Pointer` at the gogpu boundary
- Zero `any` in surface view API

## Breaking Changes
- `SurfaceView()` return type: `any` → `gpucontext.TextureView`
- Nil checks: `view == nil` → `view.IsNil()`

## Dependencies
- gpucontext v0.14.0 → v0.15.0

## Test plan
- [x] `go build ./...`
- [x] All 8 gg examples verified visually
- [x] `go test ./...`