### PR TITLE
feat(darwin): application menu — Cmd+Q, Cmd+H, Cmd+M (#194, v0.30.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.2] - 2026-04-29
+
+### Added
+
+- **macOS application menu** (FEAT-DARWIN-002, ADR-016) — standard menu bar with Quit (Cmd+Q), Hide (Cmd+H), Hide Others (Cmd+Opt+H), Show All, Minimize (Cmd+M), Zoom. Matches GLFW/SDL3/winit menu bar pattern. Resolves Cmd+Q not working ([#194](https://github.com/gogpu/gogpu/issues/194)).
+
 ## [0.30.1] - 2026-04-29
 
 ### Fixed

--- a/internal/platform/darwin/application.go
+++ b/internal/platform/darwin/application.go
@@ -72,6 +72,9 @@ func (a *Application) Init() error {
 	// Set activation policy to regular app (with dock icon)
 	a.nsApp.SendInt(selectors.setActivationPolicy, int64(NSApplicationActivationPolicyRegular))
 
+	// Create default application menu (ADR-016: Cmd+Q, Cmd+H, Cmd+M).
+	a.createMenuBar("GoGPU")
+
 	// Finish launching (required for event processing)
 	a.nsApp.Send(selectors.finishLaunching)
 

--- a/internal/platform/darwin/menu.go
+++ b/internal/platform/darwin/menu.go
@@ -1,0 +1,213 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"unsafe"
+
+	"github.com/go-webgpu/goffi/ffi"
+	"github.com/go-webgpu/goffi/types"
+)
+
+// Menu-related selectors (initialized lazily).
+var menuSels struct {
+	initWithTitle              SEL
+	addItem                    SEL
+	setSubmenu                 SEL
+	setMainMenu                SEL
+	separatorItem              SEL
+	setKeyEquivalentModMask    SEL
+	setServicesMenu            SEL
+	initWithTitleActionKeyEquiv SEL
+	addItemWithTitleActionKey   SEL
+	setWindowsMenu             SEL
+}
+
+func initMenuSelectors() {
+	menuSels.initWithTitle = RegisterSelector("initWithTitle:")
+	menuSels.addItem = RegisterSelector("addItem:")
+	menuSels.setSubmenu = RegisterSelector("setSubmenu:")
+	menuSels.setMainMenu = RegisterSelector("setMainMenu:")
+	menuSels.separatorItem = RegisterSelector("separatorItem")
+	menuSels.setKeyEquivalentModMask = RegisterSelector("setKeyEquivalentModifierMask:")
+	menuSels.setServicesMenu = RegisterSelector("setServicesMenu:")
+	menuSels.initWithTitleActionKeyEquiv = RegisterSelector("initWithTitle:action:keyEquivalent:")
+	menuSels.addItemWithTitleActionKey = RegisterSelector("addItemWithTitle:action:keyEquivalent:")
+	menuSels.setWindowsMenu = RegisterSelector("setWindowsMenu:")
+}
+
+// createMenuBar creates the standard macOS application menu bar.
+// This enables Cmd+Q (quit), Cmd+H (hide), Cmd+M (minimize).
+// Matches GLFW createMenuBar() / SDL3 Cocoa_RegisterApp() / winit menu::initialize().
+// See ADR-016.
+func (a *Application) createMenuBar(appName string) {
+	initMenuSelectors()
+
+	nsMenuClass := GetClass("NSMenu")
+	nsMenuItemClass := GetClass("NSMenuItem")
+	if nsMenuClass == 0 || nsMenuItemClass == 0 {
+		return
+	}
+
+	// Create menu bar
+	menuBar := ID(nsMenuClass).Send(selectors.alloc)
+	menuBar = menuBar.Send(selectors.init)
+	if menuBar.IsNil() {
+		return
+	}
+
+	// === App Menu ===
+	appMenu := ID(nsMenuClass).Send(selectors.alloc)
+	appMenuTitle := NewNSString(appName)
+	if appMenuTitle != nil {
+		appMenu = appMenu.SendPtr(menuSels.initWithTitle, appMenuTitle.ID().Ptr())
+	} else {
+		appMenu = appMenu.Send(selectors.init)
+	}
+
+	// "Hide {appName}" — Cmd+H
+	hideTitle := NewNSString("Hide " + appName)
+	if hideTitle != nil {
+		addMenuItem(nsMenuItemClass, appMenu, hideTitle.ID(), RegisterSelector("hide:"), "h")
+	}
+
+	// "Hide Others" — Cmd+Opt+H
+	hideOthersTitle := NewNSString("Hide Others")
+	if hideOthersTitle != nil {
+		item := createMenuItem(nsMenuItemClass, hideOthersTitle.ID(), RegisterSelector("hideOtherApplications:"), "h")
+		if !item.IsNil() {
+			// NSEventModifierFlagCommand | NSEventModifierFlagOption
+			item.SendInt(menuSels.setKeyEquivalentModMask, int64(NSEventModifierFlagCommand|NSEventModifierFlagOption))
+			appMenu.SendPtr(menuSels.addItem, item.Ptr())
+		}
+	}
+
+	// "Show All"
+	showAllTitle := NewNSString("Show All")
+	if showAllTitle != nil {
+		addMenuItem(nsMenuItemClass, appMenu, showAllTitle.ID(), RegisterSelector("unhideAllApplications:"), "")
+	}
+
+	// Separator
+	sep := ID(nsMenuItemClass).Send(menuSels.separatorItem)
+	if !sep.IsNil() {
+		appMenu.SendPtr(menuSels.addItem, sep.Ptr())
+	}
+
+	// "Quit {appName}" — Cmd+Q
+	quitTitle := NewNSString("Quit " + appName)
+	if quitTitle != nil {
+		addMenuItem(nsMenuItemClass, appMenu, quitTitle.ID(), selectors.terminate, "q")
+	}
+
+	// Add app menu to menu bar
+	appMenuItem := ID(nsMenuItemClass).Send(selectors.alloc)
+	appMenuItem = appMenuItem.Send(selectors.init)
+	if !appMenuItem.IsNil() {
+		menuBar.SendPtr(menuSels.addItem, appMenuItem.Ptr())
+		appMenuItem.SendPtr(menuSels.setSubmenu, appMenu.Ptr())
+	}
+
+	// === Window Menu ===
+	windowMenu := ID(nsMenuClass).Send(selectors.alloc)
+	windowTitle := NewNSString("Window")
+	if windowTitle != nil {
+		windowMenu = windowMenu.SendPtr(menuSels.initWithTitle, windowTitle.ID().Ptr())
+	} else {
+		windowMenu = windowMenu.Send(selectors.init)
+	}
+
+	// "Minimize" — Cmd+M
+	minimizeTitle := NewNSString("Minimize")
+	if minimizeTitle != nil {
+		addMenuItem(nsMenuItemClass, windowMenu, minimizeTitle.ID(), RegisterSelector("performMiniaturize:"), "m")
+	}
+
+	// "Zoom"
+	zoomTitle := NewNSString("Zoom")
+	if zoomTitle != nil {
+		addMenuItem(nsMenuItemClass, windowMenu, zoomTitle.ID(), RegisterSelector("performZoom:"), "")
+	}
+
+	// Add window menu to menu bar
+	windowMenuItem := ID(nsMenuItemClass).Send(selectors.alloc)
+	windowMenuItem = windowMenuItem.Send(selectors.init)
+	if !windowMenuItem.IsNil() {
+		menuBar.SendPtr(menuSels.addItem, windowMenuItem.Ptr())
+		windowMenuItem.SendPtr(menuSels.setSubmenu, windowMenu.Ptr())
+	}
+
+	// Set as main menu + register window menu for automatic management
+	a.nsApp.SendPtr(menuSels.setMainMenu, menuBar.Ptr())
+	a.nsApp.SendPtr(menuSels.setWindowsMenu, windowMenu.Ptr())
+}
+
+// createMenuItem creates an NSMenuItem with title, action, and key equivalent.
+// Uses objc_msgSend with 3 pointer args for initWithTitle:action:keyEquivalent:.
+func createMenuItem(nsMenuItemClass Class, title ID, action SEL, keyEquiv string) ID {
+	item := ID(nsMenuItemClass).Send(selectors.alloc)
+	if item.IsNil() {
+		return 0
+	}
+
+	keyStr := NewNSString(keyEquiv)
+	var keyPtr uintptr
+	if keyStr != nil {
+		keyPtr = keyStr.ID().Ptr()
+	} else {
+		emptyStr := NewNSString("")
+		if emptyStr != nil {
+			keyPtr = emptyStr.ID().Ptr()
+		}
+	}
+
+	return msgSend3Ptr(item, menuSels.initWithTitleActionKeyEquiv, title.Ptr(), uintptr(action), keyPtr)
+}
+
+// addMenuItem is a convenience that creates and adds a menu item in one step.
+func addMenuItem(nsMenuItemClass Class, menu ID, title ID, action SEL, keyEquiv string) {
+	item := createMenuItem(nsMenuItemClass, title, action, keyEquiv)
+	if !item.IsNil() {
+		menu.SendPtr(menuSels.addItem, item.Ptr())
+	}
+}
+
+// msgSend3Ptr calls objc_msgSend with self, sel, and 3 pointer arguments.
+func msgSend3Ptr(id ID, sel SEL, arg0, arg1, arg2 uintptr) ID {
+	if err := initRuntime(); err != nil {
+		return 0
+	}
+
+	cif := &types.CallInterface{}
+	if err := ffi.PrepareCallInterface(cif, types.DefaultCall,
+		types.PointerTypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // self
+			types.PointerTypeDescriptor, // _cmd
+			types.PointerTypeDescriptor, // arg0
+			types.PointerTypeDescriptor, // arg1
+			types.PointerTypeDescriptor, // arg2
+		},
+	); err != nil {
+		return 0
+	}
+
+	self := uintptr(id)
+	cmd := uintptr(sel)
+
+	var result uintptr
+	if err := ffi.CallFunction(cif,
+		objcRT.objcMsgSend,
+		unsafe.Pointer(&result),
+		[]unsafe.Pointer{
+			unsafe.Pointer(&self),
+			unsafe.Pointer(&cmd),
+			unsafe.Pointer(&arg0),
+			unsafe.Pointer(&arg1),
+			unsafe.Pointer(&arg2),
+		},
+	); err != nil {
+		return 0
+	}
+	return ID(result)
+}

--- a/internal/platform/darwin/menu.go
+++ b/internal/platform/darwin/menu.go
@@ -11,16 +11,16 @@ import (
 
 // Menu-related selectors (initialized lazily).
 var menuSels struct {
-	initWithTitle              SEL
-	addItem                    SEL
-	setSubmenu                 SEL
-	setMainMenu                SEL
-	separatorItem              SEL
-	setKeyEquivalentModMask    SEL
-	setServicesMenu            SEL
+	initWithTitle               SEL
+	addItem                     SEL
+	setSubmenu                  SEL
+	setMainMenu                 SEL
+	separatorItem               SEL
+	setKeyEquivalentModMask     SEL
+	setServicesMenu             SEL
 	initWithTitleActionKeyEquiv SEL
 	addItemWithTitleActionKey   SEL
-	setWindowsMenu             SEL
+	setWindowsMenu              SEL
 }
 
 func initMenuSelectors() {
@@ -161,7 +161,7 @@ func createMenuItem(nsMenuItemClass Class, title ID, action SEL, keyEquiv string
 		}
 	}
 
-	return msgSend3Ptr(item, menuSels.initWithTitleActionKeyEquiv, title.Ptr(), uintptr(action), keyPtr)
+	return MsgSend3Ptr(item, menuSels.initWithTitleActionKeyEquiv, title.Ptr(), uintptr(action), keyPtr)
 }
 
 // addMenuItem is a convenience that creates and adds a menu item in one step.
@@ -172,8 +172,8 @@ func addMenuItem(nsMenuItemClass Class, menu ID, title ID, action SEL, keyEquiv 
 	}
 }
 
-// msgSend3Ptr calls objc_msgSend with self, sel, and 3 pointer arguments.
-func msgSend3Ptr(id ID, sel SEL, arg0, arg1, arg2 uintptr) ID {
+// MsgSend3Ptr calls objc_msgSend with self, sel, and 3 pointer arguments.
+func MsgSend3Ptr(id ID, sel SEL, arg0, arg1, arg2 uintptr) ID {
 	if err := initRuntime(); err != nil {
 		return 0
 	}

--- a/internal/platform/darwin/menu_test.go
+++ b/internal/platform/darwin/menu_test.go
@@ -1,0 +1,144 @@
+//go:build darwin
+
+package darwin_test
+
+import (
+	"testing"
+
+	platformdarwin "github.com/gogpu/gogpu/internal/platform/darwin"
+)
+
+// TestMenuSelectorRegistration verifies that menu-related ObjC selectors
+// can be registered without panic.
+func TestMenuSelectorRegistration(t *testing.T) {
+	runOnMainThread(t, func() {
+		sels := []string{
+			"initWithTitle:",
+			"addItem:",
+			"setSubmenu:",
+			"setMainMenu:",
+			"separatorItem",
+			"setKeyEquivalentModifierMask:",
+			"initWithTitle:action:keyEquivalent:",
+			"setWindowsMenu:",
+			"terminate:",
+			"hide:",
+			"hideOtherApplications:",
+			"unhideAllApplications:",
+			"performMiniaturize:",
+			"performZoom:",
+		}
+		for _, name := range sels {
+			sel := platformdarwin.RegisterSelector(name)
+			if sel == 0 {
+				t.Errorf("RegisterSelector(%q) returned 0", name)
+			}
+		}
+	})
+}
+
+// TestNSMenuClassExists verifies that NSMenu and NSMenuItem classes
+// are available in the ObjC runtime.
+func TestNSMenuClassExists(t *testing.T) {
+	runOnMainThread(t, func() {
+		menu := platformdarwin.GetClass("NSMenu")
+		if menu == 0 {
+			t.Fatal("NSMenu class not found")
+		}
+		menuItem := platformdarwin.GetClass("NSMenuItem")
+		if menuItem == 0 {
+			t.Fatal("NSMenuItem class not found")
+		}
+	})
+}
+
+// TestNSMenuCreation verifies that an NSMenu instance can be created
+// and initialized via the ObjC runtime.
+func TestNSMenuCreation(t *testing.T) {
+	runOnMainThread(t, func() {
+		nsMenuClass := platformdarwin.GetClass("NSMenu")
+		if nsMenuClass == 0 {
+			t.Fatal("NSMenu class not found")
+		}
+
+		alloc := platformdarwin.ID(nsMenuClass).Send(platformdarwin.RegisterSelector("alloc"))
+		if alloc.IsNil() {
+			t.Fatal("NSMenu alloc returned nil")
+		}
+
+		menu := alloc.Send(platformdarwin.RegisterSelector("init"))
+		if menu.IsNil() {
+			t.Fatal("NSMenu init returned nil")
+		}
+	})
+}
+
+// TestNSMenuItemCreation verifies that an NSMenuItem can be created
+// with the standard alloc/init pattern.
+func TestNSMenuItemCreation(t *testing.T) {
+	runOnMainThread(t, func() {
+		nsMenuItemClass := platformdarwin.GetClass("NSMenuItem")
+		if nsMenuItemClass == 0 {
+			t.Fatal("NSMenuItem class not found")
+		}
+
+		alloc := platformdarwin.ID(nsMenuItemClass).Send(platformdarwin.RegisterSelector("alloc"))
+		if alloc.IsNil() {
+			t.Fatal("NSMenuItem alloc returned nil")
+		}
+
+		item := alloc.Send(platformdarwin.RegisterSelector("init"))
+		if item.IsNil() {
+			t.Fatal("NSMenuItem init returned nil")
+		}
+	})
+}
+
+// TestNSMenuSeparatorItem verifies that the separatorItem class method works.
+func TestNSMenuSeparatorItem(t *testing.T) {
+	runOnMainThread(t, func() {
+		nsMenuItemClass := platformdarwin.GetClass("NSMenuItem")
+		if nsMenuItemClass == 0 {
+			t.Fatal("NSMenuItem class not found")
+		}
+
+		sep := platformdarwin.ID(nsMenuItemClass).Send(platformdarwin.RegisterSelector("separatorItem"))
+		if sep.IsNil() {
+			t.Fatal("separatorItem returned nil")
+		}
+	})
+}
+
+// TestMsgSend3Ptr verifies the 3-argument objc_msgSend wrapper works
+// by creating an NSMenuItem with initWithTitle:action:keyEquivalent:.
+func TestMsgSend3Ptr(t *testing.T) {
+	runOnMainThread(t, func() {
+		nsMenuItemClass := platformdarwin.GetClass("NSMenuItem")
+		if nsMenuItemClass == 0 {
+			t.Fatal("NSMenuItem class not found")
+		}
+
+		alloc := platformdarwin.ID(nsMenuItemClass).Send(platformdarwin.RegisterSelector("alloc"))
+		if alloc.IsNil() {
+			t.Fatal("NSMenuItem alloc returned nil")
+		}
+
+		title := platformdarwin.NewNSString("Test Item")
+		if title == nil {
+			t.Fatal("NewNSString returned nil")
+		}
+
+		keyEquiv := platformdarwin.NewNSString("t")
+		if keyEquiv == nil {
+			t.Fatal("NewNSString for key returned nil")
+		}
+
+		sel := platformdarwin.RegisterSelector("initWithTitle:action:keyEquivalent:")
+		action := platformdarwin.RegisterSelector("terminate:")
+
+		item := platformdarwin.MsgSend3Ptr(alloc, sel, title.ID().Ptr(), uintptr(action), keyEquiv.ID().Ptr())
+		if item.IsNil() {
+			t.Fatal("initWithTitle:action:keyEquivalent: returned nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **macOS application menu** (ADR-016) — standard menu bar: Quit (Cmd+Q), Hide (Cmd+H), Hide Others (Cmd+Opt+H), Show All, Minimize (Cmd+M), Zoom
- Matches GLFW `createMenuBar()` / SDL3 `Cocoa_RegisterApp()` / winit `menu::initialize()`
- Resolves Cmd+Q not working (reported by @sverrehu in #194)
- `MsgSend3Ptr` — 3-argument objc_msgSend for `initWithTitle:action:keyEquivalent:`
- 6 menu tests + gofmt fix

## Test plan

- [x] `GOOS=darwin go build ./...` passes
- [x] Lint clean on macOS, Windows, Linux (0 new issues)
- [x] 6 new tests (`menu_test.go`)
- [ ] **Needs macOS testing:** @sverrehu — Cmd+Q should now quit the app