### PR TITLE
fix: unified event queue + scroll accumulate, wgpu v0.26.10 (v0.30.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.3] - 2026-04-30
+
+### Fixed
+
+- **Multi-window: deadlock on Destroy** (BUG-MW-001, ADR-017) — `windowsPlatform.Destroy()` held write lock while calling `DestroyWindow()`, which synchronously sends WM_DESTROY to `wndProc` needing read lock. Fixed: collect+remove under lock, destroy outside lock (GLFW `RemovePropW` pattern). Researched Qt6, GTK4, SDL3, winit, Chromium, GLFW, Flutter.
+- **Multi-window: secondary window events lost** (BUG-MW-001, ADR-017) — `PollEvents()` dequeued events only from primary window. Secondary window close/resize/focus events were silently dropped. Fixed: unified platform event queue — all windows push to single queue, `PollEvents()` dequeues from it. Matches Qt6 (`WindowSystemEventList`), GTK4 (`GdkWin32EventSource`), SDL3 (`SDL_EventQ`), winit (`VecDeque<Event>`).
+- **Mouse scroll: zero in OnUpdate** ([#199](https://github.com/gogpu/gogpu/issues/199), [#200](https://github.com/gogpu/gogpu/pull/200), @k-chimi) — `UpdateFrame()` zeroed scroll before `OnUpdate` could read it. Fixed with Ebiten-style accumulate + snapshot: `SetScroll` accumulates (`+=`), `UpdateFrame` snapshots then zeros, `Scroll()` reads snapshot. Researched SDL3, winit, Qt6, GTK4, GLFW, Ebiten.
+
+### Added
+
+- **Multi-stage particle simulation example** ([#198](https://github.com/gogpu/gogpu/pull/198), @snakeru) — 3 compute shaders (interactor, bouncer, renderer) + 1 render shader. Verlet integration, mass-dependent coloring, 3200 particles @ 60 FPS. Multi-step compute pipeline showcase.
+
+### Changed
+
+- **deps:** wgpu v0.26.8 → v0.26.10 (Validation Phase A+B: 23 P0/P1 checks, coverage 22% → 45%), naga v0.17.6 → v0.17.8
+
 ## [0.30.2] - 2026-04-29
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.30.0
+## Current State: v0.30.3
 
 ✅ **Production-ready** with full feature set:
 - **Multi-window** — `App.NewWindow()` creates additional windows with shared GPU device (ADR-010)
@@ -56,6 +56,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.30.3** | 2026-04-30 | Multi-window deadlock + lost events fix (ADR-017), scroll accumulate+snapshot, particle sim example (@snakeru), wgpu v0.26.10 (45% validation) |
 | **v0.29.4** | 2026-04-26 | wgpu v0.26.6 — compute barriers (VAL-008/009/010) |
 | **v0.29.2** | 2026-04-25 | **Damage-aware presentation** + Vulkan validation fixes (uniform buffer CopyDst, PRESENT_SRC_KHR), wgpu v0.26.4 |
 | **v0.28.1** | 2026-04-23 | EventFocus on all platforms (Win32, X11, Wayland, macOS), WindowID on all events |

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/go-webgpu/webgpu v0.4.3
 	github.com/gogpu/gpucontext v0.15.0
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/wgpu v0.26.8
+	github.com/gogpu/wgpu v0.26.10
 	golang.org/x/sys v0.43.0
 )
 
-require github.com/gogpu/naga v0.17.6 // indirect
+require github.com/gogpu/naga v0.17.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,9 @@ github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E7
 github.com/gogpu/gpucontext v0.15.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.6 h1:Wh0MbP8wo9+eA1p8yKhDw8lvi+LykMzdJu4bGepstxg=
-github.com/gogpu/naga v0.17.6/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.26.8 h1:nna7WXNLIhEe7dmDISAyHwxc0Un3BF8G5doQP2QLAMs=
-github.com/gogpu/wgpu v0.26.8/go.mod h1:6T/5epK+HKgKBRl5sYwik5Q130WZiy+RA/CQP6K+qrA=
+github.com/gogpu/naga v0.17.8 h1:twxjkEMd4wL+ayIOb/U4jglQ37pHAcDv4sKAWbaXaQI=
+github.com/gogpu/naga v0.17.8/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.26.10 h1:BTwXoUiI+IWh/KWkG+lt2tqMhlqSk2wKYxrpDcXILrQ=
+github.com/gogpu/wgpu v0.26.10/go.mod h1:TL7iCn3EbuqssAkEC8Lbmi4KDctGbZtHY5HHd5cB0tI=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -416,9 +416,7 @@ type win32Window struct {
 	width       int
 	height      int
 	shouldClose bool
-	inSizeMove  bool // True during modal resize/move loop
-	events      []Event
-	eventMu     sync.Mutex
+	inSizeMove  bool         // True during modal resize/move loop
 	sizeMu      sync.RWMutex // Protects width, height, inSizeMove for thread-safe access
 
 	// Mouse state tracking
@@ -467,6 +465,12 @@ type windowsPlatform struct {
 
 	// Primary window for backward-compatible single-window API.
 	primary *win32Window
+
+	// Unified event queue for ALL windows (ADR-017).
+	// wndProc pushes events here; PollEvents dequeues.
+	// Qt6/GTK4/SDL3/winit all use this pattern.
+	eventMu sync.Mutex
+	events  []Event
 }
 
 // Global instance for window procedure callback
@@ -772,7 +776,7 @@ func (w *win32Window) updateSize() {
 }
 
 func (p *windowsPlatform) PollEvents() Event {
-	// Process all pending Windows messages
+	// Process all pending Windows messages (NULL HWND = all windows on this thread).
 	var m msg
 	for {
 		ret, _, _ := procPeekMessageW.Call(
@@ -787,20 +791,7 @@ func (p *windowsPlatform) PollEvents() Event {
 		procDispatchMessageW.Call(uintptr(unsafe.Pointer(&m)))
 	}
 
-	return p.primary.dequeueEvent()
-}
-
-func (w *win32Window) dequeueEvent() Event {
-	w.eventMu.Lock()
-	defer w.eventMu.Unlock()
-
-	if len(w.events) > 0 {
-		event := w.events[0]
-		w.events = w.events[1:]
-		return event
-	}
-
-	return Event{Type: EventNone}
+	return p.dequeueEvent()
 }
 
 func (p *windowsPlatform) ShouldClose() bool {
@@ -921,17 +912,22 @@ func (w *win32Window) setModalFrameCallback(fn func()) {
 
 // Destroy implements PlatformManager.Destroy.
 // Destroys all remaining windows and releases process-level resources.
+// Pattern: collect + remove under lock, then DestroyWindow outside lock.
+// DestroyWindow sends WM_DESTROY synchronously to wndProc, which needs
+// windowMu.RLock — holding the write lock would deadlock.
+// Same pattern as win32Window.Destroy and GLFW's RemovePropW-before-DestroyWindow.
 func (p *windowsPlatform) Destroy() {
-	// Destroy any remaining windows
 	p.windowMu.Lock()
-	for hwnd, w := range p.windows {
-		if w.hwnd != 0 {
-			procDestroyWindow.Call(uintptr(w.hwnd))
-			w.hwnd = 0
-		}
+	toDestroy := make([]windows.HWND, 0, len(p.windows))
+	for hwnd := range p.windows {
+		toDestroy = append(toDestroy, hwnd)
 		delete(p.windows, hwnd)
 	}
 	p.windowMu.Unlock()
+
+	for _, hwnd := range toDestroy {
+		procDestroyWindow.Call(uintptr(hwnd))
+	}
 	p.primary = nil
 	globalPlatform = nil
 }
@@ -1331,24 +1327,38 @@ func (p *windowsPlatform) CloseWindow() {
 	procPostMessageW.Call(uintptr(p.primary.hwnd), wmClose, 0, 0)
 }
 
-func (w *win32Window) queueEvent(event Event) {
-	w.eventMu.Lock()
-	defer w.eventMu.Unlock()
+// queueEvent pushes an event to the unified platform queue (ADR-017).
+// Called from wndProc for ALL windows. Per-WindowID resize coalescing.
+func (p *windowsPlatform) queueEvent(event Event) {
+	p.eventMu.Lock()
+	defer p.eventMu.Unlock()
 
-	// Coalesce resize events to avoid swapchain recreation storm.
+	// Coalesce resize events per-window to avoid swapchain recreation storm.
 	// During drag resize, Windows sends hundreds of WM_SIZE messages.
-	// We only care about the final size.
-	if event.Type == EventResize && len(w.events) > 0 {
-		last := &w.events[len(w.events)-1]
-		if last.Type == EventResize {
-			// Update existing resize event with new dimensions
-			last.Width = event.Width
-			last.Height = event.Height
-			return
+	if event.Type == EventResize && len(p.events) > 0 {
+		for i := len(p.events) - 1; i >= 0; i-- {
+			if p.events[i].Type == EventResize && p.events[i].WindowID == event.WindowID {
+				p.events[i] = event
+				return
+			}
 		}
 	}
 
-	w.events = append(w.events, event)
+	p.events = append(p.events, event)
+}
+
+// dequeueEvent returns the next event from the unified queue.
+func (p *windowsPlatform) dequeueEvent() Event {
+	p.eventMu.Lock()
+	defer p.eventMu.Unlock()
+
+	if len(p.events) > 0 {
+		event := p.events[0]
+		p.events = p.events[1:]
+		return event
+	}
+
+	return Event{Type: EventNone}
 }
 
 // extractMousePos extracts mouse position from lParam.
@@ -2040,7 +2050,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 	switch message {
 	case wmClose:
 		w.shouldClose = true
-		w.queueEvent(Event{Type: EventClose, WindowID: w.id})
+		p.queueEvent(Event{Type: EventClose, WindowID: w.id})
 		return 0
 
 	case wmNCUAHDrawCaption, wmNCUAHDrawFrame:
@@ -2132,11 +2142,11 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		}
 
 	case wmSetFocus:
-		w.queueEvent(Event{Type: EventFocus, WindowID: w.id, Focused: true})
+		p.queueEvent(Event{Type: EventFocus, WindowID: w.id, Focused: true})
 		return 0
 
 	case wmKillFocus:
-		w.queueEvent(Event{Type: EventFocus, WindowID: w.id, Focused: false})
+		p.queueEvent(Event{Type: EventFocus, WindowID: w.id, Focused: false})
 		return 0
 
 	case wmActivate:
@@ -2179,7 +2189,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		// Queue resize event with new DPI-adjusted dimensions.
 		physW, physH := w.PhysicalSize()
 		logW, logH := w.LogicalSize()
-		w.queueEvent(Event{
+		p.queueEvent(Event{
 			Type:           EventResize,
 			WindowID:       w.id,
 			Width:          logW,
@@ -2237,7 +2247,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 				logW = int(float64(newWidth) / scale)
 				logH = int(float64(newHeight) / scale)
 			}
-			w.queueEvent(Event{
+			p.queueEvent(Event{
 				Type:           EventResize,
 				WindowID:       w.id,
 				Width:          logW,
@@ -2296,7 +2306,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		w.updateSize()
 		physW, physH := w.PhysicalSize()
 		logW, logH := w.LogicalSize()
-		w.queueEvent(Event{
+		p.queueEvent(Event{
 			Type:           EventResize,
 			WindowID:       w.id,
 			Width:          logW,
@@ -2338,7 +2348,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		// ESC to close (convenience)
 		if wParam == vkEscape {
 			w.shouldClose = true
-			w.queueEvent(Event{Type: EventClose, WindowID: w.id})
+			p.queueEvent(Event{Type: EventClose, WindowID: w.id})
 		}
 
 		// For WM_SYSKEYDOWN: let DefWindowProc handle Alt+F4, Alt+Tab


### PR DESCRIPTION
## Summary

- **Multi-window deadlock fix** — `Destroy()` held write lock during `DestroyWindow` synchronous callback → deadlock. Fixed: collect+remove under lock, destroy outside (GLFW pattern)
- **Secondary window events fix** — `PollEvents()` read only primary queue, losing close/resize/focus from secondary windows. Fixed: unified platform event queue (ADR-017). Researched Qt6, GTK4, SDL3, winit, Chromium, GLFW, Flutter — all use single queue
- **Mouse scroll fix** — `UpdateFrame()` zeroed scroll before `OnUpdate` read it ([#199](https://github.com/gogpu/gogpu/issues/199), [#200](https://github.com/gogpu/gogpu/pull/200), @k-chimi). Fixed: Ebiten-style accumulate + snapshot
- **deps:** wgpu v0.26.10 (Validation Phase A+B, 23 checks, 22%→45%), naga v0.17.8

## Test plan

- [x] multiwindow example: close secondary → close primary (no deadlock, clean exit)
- [x] triangle, texture, particles, multistage_particle_pipeline examples
- [x] window_only example
- [x] `go test ./...` — all pass
- [x] `go fmt` clean
- [x] lint clean (excluding tmp/)
- [x] cross-compile Linux + macOS