### PR TITLE
fix(x11): binary .Xauthority address matching for remote displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **X11: remote display authentication failure** ([#203](https://github.com/gogpu/gogpu/issues/203), ADR-019, @sverrehu) — `.Xauthority` stores `FamilyInternet` (IPv4) addresses as raw 4 bytes, but DISPLAY parser produced ASCII string. Binary comparison always failed for remote X11 connections (`DISPLAY=192.168.0.1:0`). Fixed with libxcb `getpeername()` pattern: extract binary IP from connected socket via `net.Conn.RemoteAddr()`, match against `.Xauthority` entries using `bytes.Equal`. Added `FamilyInternet6` (IPv6) support. First Pure Go X11 library to handle `FamilyInternet` correctly — all others (jezek/xgb, BurntSushi/xgb) have the same bug.
+
 ## [0.31.0] - 2026-05-01
 
 ### Added

--- a/config.go
+++ b/config.go
@@ -8,6 +8,17 @@ import (
 	"github.com/gogpu/gputypes"
 )
 
+const defaultTitle = "GoGPU Application"
+
+// Environment variable values for GOGPU_GRAPHICS_API.
+const (
+	envVulkan   = "vulkan"
+	envDX12     = "dx12"
+	envMetal    = "metal"
+	envGLES     = "gles"
+	envSoftware = "software"
+)
+
 // Config configures the application.
 type Config struct {
 	// Title is the window title.
@@ -77,7 +88,7 @@ type Config struct {
 // over the environment variables.
 func DefaultConfig() Config {
 	return Config{
-		Title:            "GoGPU Application",
+		Title:            defaultTitle,
 		Width:            800,
 		Height:           600,
 		Resizable:        true,
@@ -92,15 +103,15 @@ func DefaultConfig() Config {
 func graphicsAPIFromEnv() types.GraphicsAPI {
 	v := strings.ToLower(os.Getenv("GOGPU_GRAPHICS_API"))
 	switch v {
-	case "vulkan", "vk":
+	case envVulkan, "vk":
 		return types.GraphicsAPIVulkan
-	case "dx12", "d3d12", "directx":
+	case envDX12, "d3d12", "directx":
 		return types.GraphicsAPIDX12
-	case "metal":
+	case envMetal:
 		return types.GraphicsAPIMetal
-	case "gles", "gl", "opengl":
+	case envGLES, "gl", "opengl":
 		return types.GraphicsAPIGLES
-	case "software", "sw", "cpu":
+	case envSoftware, "sw", "cpu":
 		return types.GraphicsAPISoftware
 	default:
 		return types.GraphicsAPIAuto

--- a/gpu/types/enums.go
+++ b/gpu/types/enums.go
@@ -21,15 +21,22 @@ const (
 	BackendGo = BackendNative
 )
 
+// Backend display names.
+const (
+	backendNameAuto   = "Auto"
+	backendNameNative = "Native (Pure Go)"
+	backendNameRust   = "Rust (wgpu-gpu)"
+)
+
 // String returns the backend name.
 func (b BackendType) String() string {
 	switch b {
 	case BackendRust:
-		return "Rust (wgpu-gpu)"
+		return backendNameRust
 	case BackendNative:
-		return "Native (Pure Go)"
+		return backendNameNative
 	default:
-		return "Auto"
+		return backendNameAuto
 	}
 }
 
@@ -74,6 +81,6 @@ func (g GraphicsAPI) String() string {
 	case GraphicsAPISoftware:
 		return "Software"
 	default:
-		return "Auto"
+		return backendNameAuto
 	}
 }

--- a/internal/platform/wayland/libwayland.go
+++ b/internal/platform/wayland/libwayland.go
@@ -10,6 +10,9 @@ import (
 	"github.com/go-webgpu/goffi/types"
 )
 
+// wlMethodDestroy is the Wayland protocol method name for wl_proxy_destroy.
+const wlMethodDestroy = "destroy"
+
 // LibwaylandHandle holds C pointers from libwayland-client.so.0 for Vulkan surface creation.
 // Vulkan's VK_KHR_wayland_surface requires real wl_display* and wl_surface* from the C library.
 // Our pure Go Wayland speaks wire protocol directly and doesn't have C structs.
@@ -414,7 +417,7 @@ func (h *LibwaylandHandle) prepareCIFs() error {
 		// wl_proxy* wl_proxy_marshal_array_constructor_versioned(wl_proxy*, uint32_t opcode, union wl_argument*, const wl_interface*, uint32_t version)
 		{"marshal_v", &h.cifMarshalV, ptr, []*types.TypeDescriptor{ptr, types.UInt32TypeDescriptor, ptr, ptr, types.UInt32TypeDescriptor}},
 		// void wl_proxy_destroy(wl_proxy*)
-		{"destroy", &h.cifDestroy, types.VoidTypeDescriptor, []*types.TypeDescriptor{ptr}},
+		{wlMethodDestroy, &h.cifDestroy, types.VoidTypeDescriptor, []*types.TypeDescriptor{ptr}},
 		// int wl_proxy_add_listener(wl_proxy*, void(**)(void), void* data)
 		{"add_listener", &h.cifAddListener, i32, []*types.TypeDescriptor{ptr, ptr, ptr}},
 		// int wl_display_roundtrip(wl_display*)

--- a/internal/platform/x11/auth.go
+++ b/internal/platform/x11/auth.go
@@ -3,10 +3,12 @@
 package x11
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 )
@@ -16,11 +18,12 @@ const (
 	AuthMITMagicCookie = "MIT-MAGIC-COOKIE-1"
 )
 
-// Authority family values (from Xauth).
+// Authority family values (from Xauth/libXau).
 const (
 	FamilyInternet  uint16 = 0
 	FamilyDECnet    uint16 = 1
 	FamilyChaos     uint16 = 2
+	FamilyInternet6 uint16 = 6
 	FamilyLocal     uint16 = 256
 	FamilyWild      uint16 = 65535
 	FamilyNetname   uint16 = 254
@@ -36,9 +39,11 @@ var (
 )
 
 // AuthEntry represents an entry in the .Xauthority file.
+// Address is raw bytes: 4-byte IPv4 for FamilyInternet, 16-byte IPv6 for
+// FamilyInternet6, hostname string bytes for FamilyLocal.
 type AuthEntry struct {
 	Family  uint16
-	Address string
+	Address []byte
 	Number  string
 	Name    string
 	Data    []byte
@@ -114,8 +119,9 @@ func readAuthEntry(r io.Reader) (AuthEntry, error) {
 	}
 	entry.Family = binary.BigEndian.Uint16(familyBuf[:])
 
-	// Read address
-	address, err := readAuthString(r)
+	// Read address as raw bytes (binary IPv4/IPv6 for FamilyInternet/6,
+	// hostname string for FamilyLocal).
+	address, err := readAuthBytes(r)
 	if err != nil {
 		return entry, err
 	}
@@ -170,6 +176,31 @@ func readAuthString(r io.Reader) (string, error) {
 	return string(data), nil
 }
 
+// readAuthBytes reads length-prefixed binary data (big-endian length).
+// Used for address field which stores raw bytes (not necessarily valid UTF-8).
+func readAuthBytes(r io.Reader) ([]byte, error) {
+	var lenBuf [2]byte
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return nil, err
+	}
+	length := binary.BigEndian.Uint16(lenBuf[:])
+
+	if length == 0 {
+		return nil, nil
+	}
+
+	if length > 1024 {
+		return nil, ErrInvalidAuthFile
+	}
+
+	data := make([]byte, length)
+	if _, err := io.ReadFull(r, data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
 // readAuthData reads length-prefixed auth data (big-endian length).
 func readAuthData(r io.Reader) ([]byte, error) {
 	var lenBuf [2]byte
@@ -195,64 +226,65 @@ func readAuthData(r io.Reader) ([]byte, error) {
 	return data, nil
 }
 
-// getAuth returns the authentication data for the given display.
-// hostname should be empty for local connections.
+// getAuth returns the authentication data for the given connection.
+// family and address come from connAddress() (getpeername pattern, like libxcb).
 // displayNum is the display number (e.g., "0" for :0).
 // If no matching auth is found, returns empty values (some servers allow unauthenticated connections).
-func getAuth(hostname, displayNum string) (name string, data []byte, err error) {
+func getAuth(family uint16, address []byte, displayNum string) (name string, data []byte, err error) {
 	entries, readErr := readAuthFile()
 	if readErr == nil {
-		// Try to find a matching entry
 		for _, entry := range entries {
-			// Check if this entry matches our connection
-			if matchesAuthEntry(entry, hostname, displayNum) {
+			if matchesAuthEntry(entry, family, address, displayNum) {
 				return entry.Name, entry.Data, nil
 			}
 		}
 	}
-	// If no authority file exists, read failed, or no matching entry found,
-	// return empty auth - this is not an error as some servers allow
-	// unauthenticated connections.
 	return "", nil, nil
 }
 
 // matchesAuthEntry checks if an auth entry matches the connection parameters.
-func matchesAuthEntry(entry AuthEntry, hostname, displayNum string) bool {
-	// Check display number
+// Uses binary address comparison (like libXau's XauGetBestAuthByAddr).
+func matchesAuthEntry(entry AuthEntry, family uint16, address []byte, displayNum string) bool {
 	if entry.Number != displayNum {
 		return false
 	}
 
-	// Check hostname/family
-	if hostname == "" || hostname == "localhost" {
-		// Local connection - match FamilyLocal or FamilyWild
-		if entry.Family == FamilyLocal || entry.Family == FamilyWild || entry.Family == FamilyLocalHost {
-			return true
-		}
-		// Also check if the address is our hostname
-		if ourHostname, err := os.Hostname(); err == nil {
-			if entry.Address == ourHostname {
-				return true
-			}
-		}
-	} else if entry.Address == hostname {
-		// Remote connection - check address
-		return true
-	}
-
-	// Check for wildcard
 	if entry.Family == FamilyWild {
 		return true
 	}
 
-	return false
+	if family == FamilyLocal {
+		if entry.Family == FamilyLocal || entry.Family == FamilyLocalHost {
+			if len(entry.Address) == 0 {
+				return true
+			}
+			if bytes.Equal(entry.Address, address) {
+				return true
+			}
+			if ourHostname, err := os.Hostname(); err == nil {
+				if bytes.Equal(entry.Address, []byte(ourHostname)) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// TCP: binary match family + address (FamilyInternet or FamilyInternet6)
+	return entry.Family == family && bytes.Equal(entry.Address, address)
 }
 
-// localHostname returns the local hostname.
-func localHostname() string {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return ""
+// connAddress extracts the binary address and family from a connected socket.
+// This follows the libxcb getpeername() pattern — no extra DNS lookups.
+func connAddress(conn net.Conn) (family uint16, address []byte) {
+	if tcpAddr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		if v4 := tcpAddr.IP.To4(); v4 != nil {
+			return FamilyInternet, []byte(v4)
+		}
+		if v6 := tcpAddr.IP.To16(); v6 != nil {
+			return FamilyInternet6, []byte(v6)
+		}
 	}
-	return hostname
+	hostname, _ := os.Hostname()
+	return FamilyLocal, []byte(hostname)
 }

--- a/internal/platform/x11/auth_test.go
+++ b/internal/platform/x11/auth_test.go
@@ -5,17 +5,16 @@ package x11
 import (
 	"bytes"
 	"encoding/binary"
+	"net"
 	"testing"
 )
 
 func TestParseAuthFile(t *testing.T) {
-	// Create a mock .Xauthority file content
 	var buf bytes.Buffer
 
-	// Write an entry: FamilyLocal, hostname "localhost", display "0", MIT-MAGIC-COOKIE-1, 16 bytes cookie
-	writeAuthEntry(&buf, FamilyLocal, "localhost", "0", "MIT-MAGIC-COOKIE-1", make([]byte, 16))
+	// FamilyLocal entry: address is hostname string bytes
+	writeAuthEntry(&buf, FamilyLocal, []byte("localhost"), "0", "MIT-MAGIC-COOKIE-1", make([]byte, 16))
 
-	// Parse it
 	entries, err := parseAuthFile(&buf)
 	if err != nil {
 		t.Fatalf("parseAuthFile: unexpected error: %v", err)
@@ -29,7 +28,7 @@ func TestParseAuthFile(t *testing.T) {
 	if entry.Family != FamilyLocal {
 		t.Errorf("Family: got %d, want %d", entry.Family, FamilyLocal)
 	}
-	if entry.Address != "localhost" {
+	if !bytes.Equal(entry.Address, []byte("localhost")) {
 		t.Errorf("Address: got %q, want %q", entry.Address, "localhost")
 	}
 	if entry.Number != "0" {
@@ -46,10 +45,12 @@ func TestParseAuthFile(t *testing.T) {
 func TestParseAuthFile_MultipleEntries(t *testing.T) {
 	var buf bytes.Buffer
 
-	// Write multiple entries
-	writeAuthEntry(&buf, FamilyLocal, "host1", "0", "MIT-MAGIC-COOKIE-1", make([]byte, 16))
-	writeAuthEntry(&buf, FamilyWild, "", "1", "MIT-MAGIC-COOKIE-1", make([]byte, 16))
-	writeAuthEntry(&buf, FamilyInternet, "192.168.1.1", "0", "MIT-MAGIC-COOKIE-1", make([]byte, 16))
+	// FamilyLocal: hostname string bytes
+	writeAuthEntry(&buf, FamilyLocal, []byte("host1"), "0", "MIT-MAGIC-COOKIE-1", make([]byte, 16))
+	// FamilyWild: empty address
+	writeAuthEntry(&buf, FamilyWild, nil, "1", "MIT-MAGIC-COOKIE-1", make([]byte, 16))
+	// FamilyInternet: raw 4-byte IPv4 (192.168.1.1 = 0xc0, 0xa8, 0x01, 0x01)
+	writeAuthEntry(&buf, FamilyInternet, []byte{192, 168, 1, 1}, "0", "MIT-MAGIC-COOKIE-1", make([]byte, 16))
 
 	entries, err := parseAuthFile(&buf)
 	if err != nil {
@@ -60,15 +61,15 @@ func TestParseAuthFile_MultipleEntries(t *testing.T) {
 		t.Fatalf("parseAuthFile: got %d entries, want 3", len(entries))
 	}
 
-	// Verify each entry
-	if entries[0].Address != "host1" {
+	if !bytes.Equal(entries[0].Address, []byte("host1")) {
 		t.Errorf("Entry 0 Address: got %q, want %q", entries[0].Address, "host1")
 	}
 	if entries[1].Family != FamilyWild {
 		t.Errorf("Entry 1 Family: got %d, want %d", entries[1].Family, FamilyWild)
 	}
-	if entries[2].Address != "192.168.1.1" {
-		t.Errorf("Entry 2 Address: got %q, want %q", entries[2].Address, "192.168.1.1")
+	// FamilyInternet: raw bytes, NOT ASCII string
+	if !bytes.Equal(entries[2].Address, []byte{192, 168, 1, 1}) {
+		t.Errorf("Entry 2 Address: got %v, want [192 168 1 1]", entries[2].Address)
 	}
 }
 
@@ -89,57 +90,112 @@ func TestMatchesAuthEntry(t *testing.T) {
 	tests := []struct {
 		name       string
 		entry      AuthEntry
-		hostname   string
+		family     uint16
+		address    []byte
 		displayNum string
 		want       bool
 	}{
 		{
-			name:       "local match",
-			entry:      AuthEntry{Family: FamilyLocal, Address: "testhost", Number: "0"},
-			hostname:   "",
+			name:       "local match by hostname",
+			entry:      AuthEntry{Family: FamilyLocal, Address: []byte("testhost"), Number: "0"},
+			family:     FamilyLocal,
+			address:    []byte("testhost"),
 			displayNum: "0",
 			want:       true,
 		},
 		{
 			name:       "local wrong display",
-			entry:      AuthEntry{Family: FamilyLocal, Address: "testhost", Number: "0"},
-			hostname:   "",
+			entry:      AuthEntry{Family: FamilyLocal, Address: []byte("testhost"), Number: "0"},
+			family:     FamilyLocal,
+			address:    []byte("testhost"),
 			displayNum: "1",
 			want:       false,
 		},
 		{
-			name:       "wildcard match",
-			entry:      AuthEntry{Family: FamilyWild, Address: "", Number: "0"},
-			hostname:   "anyhost",
+			name:       "wildcard matches any local",
+			entry:      AuthEntry{Family: FamilyWild, Address: nil, Number: "0"},
+			family:     FamilyLocal,
+			address:    []byte("anyhost"),
 			displayNum: "0",
 			want:       true,
 		},
 		{
-			name:       "remote match",
-			entry:      AuthEntry{Family: FamilyInternet, Address: "192.168.1.1", Number: "0"},
-			hostname:   "192.168.1.1",
+			name:       "wildcard matches any TCP",
+			entry:      AuthEntry{Family: FamilyWild, Address: nil, Number: "0"},
+			family:     FamilyInternet,
+			address:    []byte{10, 0, 0, 1},
 			displayNum: "0",
 			want:       true,
 		},
 		{
-			name:       "remote wrong host",
-			entry:      AuthEntry{Family: FamilyInternet, Address: "192.168.1.1", Number: "0"},
-			hostname:   "192.168.1.2",
+			name:       "FamilyInternet binary IPv4 match",
+			entry:      AuthEntry{Family: FamilyInternet, Address: []byte{192, 168, 1, 1}, Number: "0"},
+			family:     FamilyInternet,
+			address:    []byte{192, 168, 1, 1},
+			displayNum: "0",
+			want:       true,
+		},
+		{
+			name:       "FamilyInternet binary IPv4 mismatch",
+			entry:      AuthEntry{Family: FamilyInternet, Address: []byte{192, 168, 1, 1}, Number: "0"},
+			family:     FamilyInternet,
+			address:    []byte{192, 168, 1, 2},
 			displayNum: "0",
 			want:       false,
 		},
 		{
-			name:       "localhost match local family",
-			entry:      AuthEntry{Family: FamilyLocal, Address: "", Number: "0"},
-			hostname:   "localhost",
+			name:       "FamilyInternet ASCII string does NOT match raw bytes (regression)",
+			entry:      AuthEntry{Family: FamilyInternet, Address: []byte{192, 168, 0, 1}, Number: "0"},
+			family:     FamilyInternet,
+			address:    []byte("192.168.0.1"),
+			displayNum: "0",
+			want:       false,
+		},
+		{
+			name:       "FamilyInternet6 binary IPv6 match",
+			entry:      AuthEntry{Family: FamilyInternet6, Address: net.IPv6loopback, Number: "0"},
+			family:     FamilyInternet6,
+			address:    net.IPv6loopback,
 			displayNum: "0",
 			want:       true,
+		},
+		{
+			name:       "FamilyInternet6 binary IPv6 mismatch",
+			entry:      AuthEntry{Family: FamilyInternet6, Address: net.IPv6loopback, Number: "0"},
+			family:     FamilyInternet6,
+			address:    net.IPv6zero,
+			displayNum: "0",
+			want:       false,
+		},
+		{
+			name:       "family mismatch: entry FamilyInternet vs query FamilyInternet6",
+			entry:      AuthEntry{Family: FamilyInternet, Address: []byte{127, 0, 0, 1}, Number: "0"},
+			family:     FamilyInternet6,
+			address:    net.IPv6loopback,
+			displayNum: "0",
+			want:       false,
+		},
+		{
+			name:       "FamilyLocalHost matches local connection",
+			entry:      AuthEntry{Family: FamilyLocalHost, Address: nil, Number: "0"},
+			family:     FamilyLocal,
+			address:    []byte("myhost"),
+			displayNum: "0",
+			want:       true,
+		},
+		{
+			name:       "FamilyLocal does not match TCP connection",
+			entry:      AuthEntry{Family: FamilyLocal, Address: []byte("myhost"), Number: "0"},
+			family:     FamilyInternet,
+			address:    []byte{127, 0, 0, 1},
+			displayNum: "0",
+			want:       false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := matchesAuthEntry(tt.entry, tt.hostname, tt.displayNum)
+			got := matchesAuthEntry(tt.entry, tt.family, tt.address, tt.displayNum)
 			if got != tt.want {
 				t.Errorf("matchesAuthEntry: got %v, want %v", got, tt.want)
 			}
@@ -147,24 +203,231 @@ func TestMatchesAuthEntry(t *testing.T) {
 	}
 }
 
-// Helper function to write auth entry in .Xauthority format
-func writeAuthEntry(buf *bytes.Buffer, family uint16, address, number, name string, data []byte) {
-	// Family (big-endian)
+func TestConnAddress_TCP(t *testing.T) {
+	// Create a TCP listener to get a real connection
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		c.Close()
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+	<-done
+
+	family, address := connAddress(conn)
+
+	if family != FamilyInternet {
+		t.Errorf("family: got %d, want %d (FamilyInternet)", family, FamilyInternet)
+	}
+	if !bytes.Equal(address, []byte{127, 0, 0, 1}) {
+		t.Errorf("address: got %v, want [127 0 0 1]", address)
+	}
+}
+
+func TestConnAddress_Unix(t *testing.T) {
+	family, address := connAddress(&fakeUnixConn{})
+
+	if family != FamilyLocal {
+		t.Errorf("family: got %d, want %d (FamilyLocal)", family, FamilyLocal)
+	}
+	if len(address) == 0 {
+		t.Errorf("address should be hostname, got empty")
+	}
+}
+
+// fakeUnixConn simulates a Unix domain socket connection.
+type fakeUnixConn struct{ net.Conn }
+
+func (f *fakeUnixConn) RemoteAddr() net.Addr {
+	return &net.UnixAddr{Name: "/tmp/.X11-unix/X0", Net: "unix"}
+}
+
+func TestGetAuth_EndToEnd(t *testing.T) {
+	var buf bytes.Buffer
+	cookie1 := []byte{0x74, 0xa6, 0x67, 0xbb, 0x67, 0x7d, 0x5e, 0x08, 0x0b, 0x6f, 0xee, 0x36, 0xc4, 0xc2, 0xef, 0xcf}
+	cookie2 := []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}
+
+	// Entry 1: FamilyInternet, 192.168.0.1:0
+	writeAuthEntry(&buf, FamilyInternet, []byte{192, 168, 0, 1}, "0", "MIT-MAGIC-COOKIE-1", cookie1)
+	// Entry 2: FamilyLocal, myhost:0
+	writeAuthEntry(&buf, FamilyLocal, []byte("myhost"), "0", "MIT-MAGIC-COOKIE-1", cookie2)
+
+	entries, err := parseAuthFile(&buf)
+	if err != nil {
+		t.Fatalf("parseAuthFile: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		family     uint16
+		address    []byte
+		displayNum string
+		wantCookie []byte
+		wantName   string
+	}{
+		{
+			name:       "match FamilyInternet entry by raw IPv4",
+			family:     FamilyInternet,
+			address:    []byte{192, 168, 0, 1},
+			displayNum: "0",
+			wantCookie: cookie1,
+			wantName:   "MIT-MAGIC-COOKIE-1",
+		},
+		{
+			name:       "no match for different IP",
+			family:     FamilyInternet,
+			address:    []byte{10, 0, 0, 1},
+			displayNum: "0",
+			wantCookie: nil,
+			wantName:   "",
+		},
+		{
+			name:       "no match for wrong display number",
+			family:     FamilyInternet,
+			address:    []byte{192, 168, 0, 1},
+			displayNum: "1",
+			wantCookie: nil,
+			wantName:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var foundName string
+			var foundData []byte
+			for _, entry := range entries {
+				if matchesAuthEntry(entry, tt.family, tt.address, tt.displayNum) {
+					foundName = entry.Name
+					foundData = entry.Data
+					break
+				}
+			}
+			if foundName != tt.wantName {
+				t.Errorf("name: got %q, want %q", foundName, tt.wantName)
+			}
+			if !bytes.Equal(foundData, tt.wantCookie) {
+				t.Errorf("data: got %v, want %v", foundData, tt.wantCookie)
+			}
+		})
+	}
+}
+
+func TestParseAuthFile_RealXauthorityDump(t *testing.T) {
+	// Exact bytes from issue #203 example:
+	// $ xauth -f sample.Xauthority add 192.168.0.1:0 . $(mcookie)
+	// od -tx1 output:
+	// 00 00 00 04 c0 a8 00 01 00 01 30 00 12 4d 49 54
+	// 2d 4d 41 47 49 43 2d 43 4f 4f 4b 49 45 2d 31 00
+	// 10 74 a6 67 bb 67 7d 5e 08 0b 6f ee 36 c4 c2 ef cf
+	raw := []byte{
+		0x00, 0x00, // family: FamilyInternet (0)
+		0x00, 0x04, // address length: 4
+		0xc0, 0xa8, 0x00, 0x01, // address: 192.168.0.1
+		0x00, 0x01, // number length: 1
+		0x30,       // number: "0"
+		0x00, 0x12, // name length: 18
+		0x4d, 0x49, 0x54, 0x2d, 0x4d, 0x41, 0x47, 0x49, 0x43, // "MIT-MAGIC"
+		0x2d, 0x43, 0x4f, 0x4f, 0x4b, 0x49, 0x45, 0x2d, 0x31, // "-COOKIE-1"
+		0x00, 0x10, // data length: 16
+		0x74, 0xa6, 0x67, 0xbb, 0x67, 0x7d, 0x5e, 0x08,
+		0x0b, 0x6f, 0xee, 0x36, 0xc4, 0xc2, 0xef, 0xcf,
+	}
+
+	entries, err := parseAuthFile(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("parseAuthFile real dump: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+
+	e := entries[0]
+	if e.Family != FamilyInternet {
+		t.Errorf("Family: got %d, want %d", e.Family, FamilyInternet)
+	}
+	if !bytes.Equal(e.Address, []byte{0xc0, 0xa8, 0x00, 0x01}) {
+		t.Errorf("Address: got %v, want [192 168 0 1]", e.Address)
+	}
+	if e.Number != "0" {
+		t.Errorf("Number: got %q, want %q", e.Number, "0")
+	}
+	if e.Name != "MIT-MAGIC-COOKIE-1" {
+		t.Errorf("Name: got %q, want %q", e.Name, "MIT-MAGIC-COOKIE-1")
+	}
+
+	// The key test: matching with binary IP from getpeername succeeds
+	if !matchesAuthEntry(e, FamilyInternet, []byte{192, 168, 0, 1}, "0") {
+		t.Error("binary IPv4 address should match")
+	}
+	// And ASCII string does NOT match (this was the bug)
+	if matchesAuthEntry(e, FamilyInternet, []byte("192.168.0.1"), "0") {
+		t.Error("ASCII string should NOT match binary IPv4 address")
+	}
+}
+
+func TestParseAuthFile_TruncatedFile(t *testing.T) {
+	// Family bytes present but address length missing
+	raw := []byte{0x00, 0x00, 0x00}
+	_, err := parseAuthFile(bytes.NewReader(raw))
+	if err == nil {
+		t.Error("expected error for truncated file")
+	}
+}
+
+func TestParseAuthFile_FirstMatchWins(t *testing.T) {
+	var buf bytes.Buffer
+	cookie1 := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	cookie2 := []byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+
+	// Two entries for same address — first should win
+	writeAuthEntry(&buf, FamilyInternet, []byte{10, 0, 0, 1}, "0", "MIT-MAGIC-COOKIE-1", cookie1)
+	writeAuthEntry(&buf, FamilyInternet, []byte{10, 0, 0, 1}, "0", "MIT-MAGIC-COOKIE-1", cookie2)
+
+	entries, err := parseAuthFile(&buf)
+	if err != nil {
+		t.Fatalf("parseAuthFile: %v", err)
+	}
+
+	var found []byte
+	for _, entry := range entries {
+		if matchesAuthEntry(entry, FamilyInternet, []byte{10, 0, 0, 1}, "0") {
+			found = entry.Data
+			break
+		}
+	}
+	if !bytes.Equal(found, cookie1) {
+		t.Errorf("first-match-wins: got %v, want %v", found, cookie1)
+	}
+}
+
+// writeAuthEntry writes an auth entry in .Xauthority binary format.
+func writeAuthEntry(buf *bytes.Buffer, family uint16, address []byte, number, name string, data []byte) {
 	_ = binary.Write(buf, binary.BigEndian, family)
 
-	// Address
 	_ = binary.Write(buf, binary.BigEndian, uint16(len(address)))
-	buf.WriteString(address)
+	buf.Write(address)
 
-	// Number
 	_ = binary.Write(buf, binary.BigEndian, uint16(len(number)))
 	buf.WriteString(number)
 
-	// Name
 	_ = binary.Write(buf, binary.BigEndian, uint16(len(name)))
 	buf.WriteString(name)
 
-	// Data
 	_ = binary.Write(buf, binary.BigEndian, uint16(len(data)))
 	buf.Write(data)
 }

--- a/internal/platform/x11/connection.go
+++ b/internal/platform/x11/connection.go
@@ -112,7 +112,7 @@ func ConnectTo(display string) (*Connection, error) {
 	}
 
 	// Perform connection setup
-	if err := c.performSetup(host, strconv.Itoa(displayNum)); err != nil {
+	if err := c.performSetup(strconv.Itoa(displayNum)); err != nil {
 		_ = conn.Close()
 		return nil, err
 	}
@@ -159,11 +159,13 @@ func parseDisplay(display string) (host string, displayNum int, screenNum int, e
 }
 
 // performSetup performs the X11 connection setup handshake.
-func (c *Connection) performSetup(hostname, displayNum string) error {
+func (c *Connection) performSetup(displayNum string) error {
+	// Extract binary address from connected socket (libxcb getpeername pattern)
+	family, address := connAddress(c.conn)
+
 	// Get authentication data
-	authName, authData, err := getAuth(hostname, displayNum)
+	authName, authData, err := getAuth(family, address, displayNum)
 	if err != nil {
-		// Try without auth
 		authName = ""
 		authData = nil
 	}


### PR DESCRIPTION
## Summary

- **Fix remote X11 display authentication** (#203, @sverrehu) — `.Xauthority` stores IPv4 as raw 4 bytes, but DISPLAY parser produced ASCII strings. Fixed with libxcb `getpeername()` pattern. Added IPv6 support. First Pure Go X11 library to handle `FamilyInternet` correctly.
- **Fix all goconst/gocritic lint issues** — 0 lint issues on all 3 platforms (Linux/Windows/Darwin).

## Test plan

- [x] `GOOS=linux go build ./...` — compiles
- [x] `GOOS=linux go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues on linux/windows/darwin
- [ ] CI green on all platforms
- [ ] @sverrehu: test with remote `DISPLAY=<ip>:0` setup
