### PR TITLE
chore: docs update + X11 FamilyLocal auth tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **macOS: native system window tabbing** ([#206](https://github.com/gogpu/gogpu/issues/206), [#207](https://github.com/gogpu/gogpu/pull/207), @lkmavi) — `Config.WithTabbingMode()` and `Config.WithTabbingIdentifier()` for native macOS window tab grouping. Values match `NSWindowTabbingMode` directly (0=Automatic, 1=Preferred, 2=Disallowed). Default: `TabbingDisallowed` (GLFW/SDL3/Qt6 enterprise pattern). Researched winit, GLFW, SDL3, Qt6. No-op on Windows/Linux.
+
 ## [0.31.1] - 2026-05-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 | **Graphics API** | Runtime selection: Vulkan, DX12, Metal, GLES, Software |
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), zero-copy surface rendering, damage-aware presentation |
-| **Graphics** | Windowing, input handling, texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference |
+| **Graphics** | Windowing, input handling, texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference, native macOS window tabbing |
 | **Compute** | Full compute shader support |
 | **Window Chrome** | Frameless windows with custom title bars, DWM shadow, hit-test regions |
 | **HiDPI** | Per-monitor DPI, WM_DPICHANGED, logical/physical coordinate split |
@@ -522,6 +522,8 @@ internal/platform/darwin/
 └── objc.go          # Objective-C runtime via goffi
 ```
 
+Native system window tabbing supported via `Config.WithTabbingMode(gogpu.TabbingPreferred)` — windows with the same `TabbingIdentifier` group into macOS system tabs automatically.
+
 **Note:** macOS Cocoa requires UI operations on the main thread. GoGPU handles this automatically.
 
 ---
@@ -589,6 +591,8 @@ go test ./...
 | Contributor | Contributions |
 |-------------|---------------|
 | [@ppoage](https://github.com/ppoage) | macOS ARM64 (Apple Silicon) support — 3 merged PRs across gogpu, wgpu, and naga with ~3,500 lines of code. Made Metal backend work on M1/M4 |
+| [@lkmavi](https://github.com/lkmavi) | macOS native window tabbing (`NSWindow.tabbingMode`) — Config API, selectors, multi-window propagation, example |
+| [@sverrehu](https://github.com/sverrehu) | X11 remote display auth fix — found `.Xauthority` binary address mismatch ([#203](https://github.com/gogpu/gogpu/issues/203)), confirmed fix. macOS key event fix ([#194](https://github.com/gogpu/gogpu/issues/194)) |
 | [@JanGordon](https://github.com/JanGordon) | Documentation fix (wgpu) |
 
 ### Community Champions

--- a/internal/platform/x11/auth_test.go
+++ b/internal/platform/x11/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"net"
+	"os"
 	"testing"
 )
 
@@ -191,6 +192,49 @@ func TestMatchesAuthEntry(t *testing.T) {
 			displayNum: "0",
 			want:       false,
 		},
+		{
+			name:       "FamilyLocal hostname mismatch FAILS (FQDN vs short)",
+			entry:      AuthEntry{Family: FamilyLocal, Address: []byte("myhost.local"), Number: "0"},
+			family:     FamilyLocal,
+			address:    []byte("myhost"),
+			displayNum: "0",
+			want:       false,
+		},
+		{
+			name:       "FamilyLocal hostname mismatch FAILS (short vs FQDN)",
+			entry:      AuthEntry{Family: FamilyLocal, Address: []byte("myhost"), Number: "0"},
+			family:     FamilyLocal,
+			address:    []byte("myhost.local"),
+			displayNum: "0",
+			want:       false,
+		},
+		{
+			name:       "FamilyLocal empty entry address matches any local",
+			entry:      AuthEntry{Family: FamilyLocal, Address: nil, Number: "0"},
+			family:     FamilyLocal,
+			address:    []byte("anyhost"),
+			displayNum: "0",
+			want:       true,
+		},
+	}
+
+	// Add os.Hostname() fallback test dynamically (hostname varies per machine).
+	if hostname, err := os.Hostname(); err == nil {
+		tests = append(tests, struct {
+			name       string
+			entry      AuthEntry
+			family     uint16
+			address    []byte
+			displayNum string
+			want       bool
+		}{
+			name:       "FamilyLocal os.Hostname() fallback matches even with different address",
+			entry:      AuthEntry{Family: FamilyLocal, Address: []byte(hostname), Number: "0"},
+			family:     FamilyLocal,
+			address:    []byte("wrong-address-but-entry-matches-hostname"),
+			displayNum: "0",
+			want:       true,
+		})
 	}
 
 	for _, tt := range tests {
@@ -244,8 +288,13 @@ func TestConnAddress_Unix(t *testing.T) {
 	if family != FamilyLocal {
 		t.Errorf("family: got %d, want %d (FamilyLocal)", family, FamilyLocal)
 	}
-	if len(address) == 0 {
-		t.Errorf("address should be hostname, got empty")
+
+	expectedHostname, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("os.Hostname: %v", err)
+	}
+	if !bytes.Equal(address, []byte(expectedHostname)) {
+		t.Errorf("address: got %q, want %q (os.Hostname)", string(address), expectedHostname)
 	}
 }
 
@@ -300,6 +349,30 @@ func TestGetAuth_EndToEnd(t *testing.T) {
 			family:     FamilyInternet,
 			address:    []byte{192, 168, 0, 1},
 			displayNum: "1",
+			wantCookie: nil,
+			wantName:   "",
+		},
+		{
+			name:       "FamilyLocal exact hostname match returns cookie",
+			family:     FamilyLocal,
+			address:    []byte("myhost"),
+			displayNum: "0",
+			wantCookie: cookie2,
+			wantName:   "MIT-MAGIC-COOKIE-1",
+		},
+		{
+			name:       "FamilyLocal hostname mismatch returns nothing",
+			family:     FamilyLocal,
+			address:    []byte("otherhost"),
+			displayNum: "0",
+			wantCookie: nil,
+			wantName:   "",
+		},
+		{
+			name:       "FamilyLocal FQDN vs short hostname returns nothing",
+			family:     FamilyLocal,
+			address:    []byte("myhost.localdomain"),
+			displayNum: "0",
 			wantCookie: nil,
 			wantName:   "",
 		},


### PR DESCRIPTION
## Summary

- **README**: add macOS tabbing to features, @lkmavi + @sverrehu to contributors
- **CHANGELOG**: add tabbingMode feature to Unreleased
- **X11 auth tests**: 7 new edge cases for FamilyLocal — hostname mismatch (FQDN vs short), os.Hostname() fallback, connAddress Unix verification, E2E local auth matching. Found during ui#92 investigation.