### PR TITLE
feat: render mode, macOS tabbing, AdapterInfo (v0.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **macOS: native system window tabbing** ([#206](https://github.com/gogpu/gogpu/issues/206), [#207](https://github.com/gogpu/gogpu/pull/207), @lkmavi) — `Config.WithTabbingMode()` and `Config.WithTabbingIdentifier()` for native macOS window tab grouping. Values match `NSWindowTabbingMode` directly (0=Automatic, 1=Preferred, 2=Disallowed). Default: `TabbingDisallowed` (GLFW/SDL3/Qt6 enterprise pattern). Researched winit, GLFW, SDL3, Qt6. No-op on Windows/Linux.
+- **`GOGPU_RENDER_MODE=auto|cpu|gpu`** (ADR-020) — adapter-aware 2D render mode. `auto`: CPU rasterizer on software adapter (60 FPS vs 0.65 FPS with SPIR-V interpreter), GPU on real hardware. `cpu`: force CPU rasterizer. `gpu`: force GPU path (for shader testing). `Config.WithRenderMode()` builder.
+- **`AdapterInfo()`** on gpuContextAdapter — maps wgpu `DeviceType` to gpucontext `AdapterType` (Discrete/Integrated/Software/Unknown).
+
+### Changed
+
+- **deps:** wgpu v0.27.0 (SPIR-V interpreter + blit fix), naga v0.17.11, gpucontext v0.17.0 (AdapterInfo)
 
 ## [0.31.1] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.32.0] - 2026-05-06
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ app := gogpu.NewApp(gogpu.DefaultConfig().
 | **GLES** | Windows, Linux | `gogpu.GraphicsAPIGLES` |
 | **Software** | All (no GPU needed) | `gogpu.GraphicsAPISoftware` |
 
+### Environment Variables
+
+All settings can be overridden via environment variables (no code changes needed):
+
+| Variable | Values | Default | Purpose |
+|----------|--------|---------|---------|
+| `GOGPU_GRAPHICS_API` | `vulkan`, `dx12`, `metal`, `gles`, `software` | auto | GPU backend selection |
+| `GOGPU_POWER_PREFERENCE` | `low`, `high` | none | GPU power/performance trade-off |
+| `GOGPU_RENDER_MODE` | `auto`, `cpu`, `gpu` | auto | 2D rendering path (ADR-020) |
+| `GOGPU_DEBUG_DAMAGE` | `1` | off | Show damage region overlay (ADR-021) |
+
+```bash
+# Examples:
+GOGPU_GRAPHICS_API=vulkan ./myapp        # Force Vulkan
+GOGPU_GRAPHICS_API=software ./myapp      # Force software renderer
+GOGPU_RENDER_MODE=cpu ./myapp            # Force CPU rasterizer (benchmarking)
+GOGPU_DEBUG_DAMAGE=1 ./myapp             # Show green overlay on dirty regions
+```
+
+`Config.With*()` methods in code take precedence over environment variables.
+
 ---
 
 ## Resource Management

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,9 +25,12 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.31.0
+## Current State: v0.32.0
 
 ✅ **Production-ready** with full feature set:
+- **Adapter-aware render mode** — `GOGPU_RENDER_MODE=auto|cpu|gpu` (ADR-020). CPU rasterizer on software adapter (60 FPS), GPU on real hardware
+- **macOS native window tabbing** — `Config.WithTabbingMode()` + `WithTabbingIdentifier()` (GLFW/SDL3/Qt6 pattern, @lkmavi)
+- **AdapterInfo** — `gpucontext.DeviceProvider.AdapterInfo()` exposes adapter type for render mode decisions
 - **Runtime fullscreen** — `App.SetFullscreen(bool)`, `App.ToggleFullscreen()` on all platforms (ADR-018)
 - **Multi-window** — `App.NewWindow()` creates additional windows with shared GPU device (ADR-010)
 - **EventFocus** — window focus/blur events on all platforms for multi-window VSync routing
@@ -57,6 +60,8 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.32.0** | 2026-05-06 | **Render mode** (ADR-020), **macOS tabbing** (@lkmavi), AdapterInfo, wgpu v0.27.0 |
+| **v0.31.1** | 2026-05-05 | X11 remote display auth fix (#203, @sverrehu), lint cleanup |
 | **v0.31.0** | 2026-05-01 | **Runtime fullscreen** (ADR-018) — all 4 platforms, wgpu v0.26.12, gpucontext v0.16.0 |
 | **v0.30.3** | 2026-04-30 | Multi-window deadlock + lost events fix (ADR-017), scroll accumulate+snapshot, particle sim example (@snakeru), wgpu v0.26.10 (45% validation) |
 | **v0.29.4** | 2026-04-26 | wgpu v0.26.6 — compute barriers (VAL-008/009/010) |

--- a/config.go
+++ b/config.go
@@ -259,15 +259,6 @@ func (c Config) WithPowerPreference(pref gputypes.PowerPreference) Config {
 	return c
 }
 
-// WithTabbingMode sets the macOS window tabbing mode.
-//
-// Usage for terminal-style tabbing:
-//
-//	cfg := gogpu.DefaultConfig().
-//	    WithTabbingMode(gogpu.TabbingPreferred).
-//	    WithTabbingIdentifier("com.myapp.tabs")
-//	app := gogpu.NewApp(cfg)
-//
 // WithRenderMode sets the 2D rendering path (ADR-020).
 // RenderModeAuto: CPU on software adapter, GPU on real hardware.
 // RenderModeCPU: force CPU rasterizer. RenderModeGPU: force GPU path.
@@ -276,6 +267,14 @@ func (c Config) WithRenderMode(mode RenderMode) Config {
 	return c
 }
 
+// WithTabbingMode sets the macOS window tabbing mode.
+//
+// Usage for terminal-style tabbing:
+//
+//	cfg := gogpu.DefaultConfig().
+//	    WithTabbingMode(gogpu.TabbingPreferred).
+//	    WithTabbingIdentifier("com.myapp.tabs")
+//	app := gogpu.NewApp(cfg)
 func (c Config) WithTabbingMode(mode TabbingMode) Config {
 	c.TabbingMode = mode
 	return c

--- a/config.go
+++ b/config.go
@@ -19,6 +19,20 @@ const (
 	envSoftware = "software"
 )
 
+// RenderMode controls the 2D rendering path selection (ADR-020).
+// This determines whether gg uses GPU accelerator or CPU rasterizer.
+type RenderMode int
+
+const (
+	// RenderModeAuto selects rendering path based on adapter type.
+	// Software adapter → CPU rasterizer (fast), real GPU → GPU accelerator.
+	RenderModeAuto RenderMode = iota
+	// RenderModeCPU forces CPU rasterizer even with a real GPU (for benchmarking).
+	RenderModeCPU
+	// RenderModeGPU forces GPU path even on software adapter (for shader testing).
+	RenderModeGPU
+)
+
 // Config configures the application.
 type Config struct {
 	// Title is the window title.
@@ -65,6 +79,11 @@ type Config struct {
 	// PowerPreferenceNone (default) lets the driver decide.
 	PowerPreference gputypes.PowerPreference
 
+	// RenderMode controls 2D rendering path selection (ADR-020).
+	// RenderModeAuto (default): CPU rasterizer on software adapter, GPU on real hardware.
+	// Can be overridden via GOGPU_RENDER_MODE=auto|cpu|gpu environment variable.
+	RenderMode RenderMode
+
 	// TabbingMode controls macOS system window tabbing.
 	// Default: TabbingDisallowed (set by DefaultConfig — GLFW/SDL3/Qt6 enterprise pattern).
 	// Set TabbingPreferred + TabbingIdentifier for terminal-style tabbing.
@@ -96,7 +115,13 @@ type Config struct {
 //	GOGPU_POWER_PREFERENCE=low  — prefer integrated GPU (power saving)
 //	GOGPU_POWER_PREFERENCE=high — prefer discrete GPU (performance)
 //
-// WithGraphicsAPI() and WithPowerPreference() in code take precedence
+// The 2D render mode can be overridden via the GOGPU_RENDER_MODE environment variable:
+//
+//	GOGPU_RENDER_MODE=auto — CPU rasterizer on software adapter, GPU on real hardware (default)
+//	GOGPU_RENDER_MODE=cpu  — force CPU rasterizer (for benchmarking)
+//	GOGPU_RENDER_MODE=gpu  — force GPU path even on software (for shader testing)
+//
+// WithGraphicsAPI(), WithPowerPreference(), and WithRenderMode() in code take precedence
 // over the environment variables.
 func DefaultConfig() Config {
 	return Config{
@@ -108,6 +133,7 @@ func DefaultConfig() Config {
 		ContinuousRender: true,
 		GraphicsAPI:      graphicsAPIFromEnv(),
 		PowerPreference:  powerPreferenceFromEnv(),
+		RenderMode:       renderModeFromEnv(),
 		TabbingMode:      TabbingDisallowed,
 	}
 }
@@ -140,6 +166,18 @@ func powerPreferenceFromEnv() gputypes.PowerPreference {
 		return gputypes.PowerPreferenceHighPerformance
 	default:
 		return gputypes.PowerPreferenceNone
+	}
+}
+
+// renderModeFromEnv reads GOGPU_RENDER_MODE environment variable.
+func renderModeFromEnv() RenderMode {
+	switch strings.ToLower(os.Getenv("GOGPU_RENDER_MODE")) {
+	case "cpu":
+		return RenderModeCPU
+	case "gpu":
+		return RenderModeGPU
+	default:
+		return RenderModeAuto
 	}
 }
 
@@ -227,6 +265,14 @@ func (c Config) WithPowerPreference(pref gputypes.PowerPreference) Config {
 //	    WithTabbingMode(gogpu.TabbingPreferred).
 //	    WithTabbingIdentifier("com.myapp.tabs")
 //	app := gogpu.NewApp(cfg)
+// WithRenderMode sets the 2D rendering path (ADR-020).
+// RenderModeAuto: CPU on software adapter, GPU on real hardware.
+// RenderModeCPU: force CPU rasterizer. RenderModeGPU: force GPU path.
+func (c Config) WithRenderMode(mode RenderMode) Config {
+	c.RenderMode = mode
+	return c
+}
+
 func (c Config) WithTabbingMode(mode TabbingMode) Config {
 	c.TabbingMode = mode
 	return c

--- a/config.go
+++ b/config.go
@@ -10,13 +10,15 @@ import (
 
 const defaultTitle = "GoGPU Application"
 
-// Environment variable values for GOGPU_GRAPHICS_API.
+// Environment variable values for GOGPU_GRAPHICS_API and GOGPU_RENDER_MODE.
 const (
 	envVulkan   = "vulkan"
 	envDX12     = "dx12"
 	envMetal    = "metal"
 	envGLES     = "gles"
 	envSoftware = "software"
+	envCPU      = "cpu"
+	envGPU      = "gpu"
 )
 
 // RenderMode controls the 2D rendering path selection (ADR-020).
@@ -150,7 +152,7 @@ func graphicsAPIFromEnv() types.GraphicsAPI {
 		return types.GraphicsAPIMetal
 	case envGLES, "gl", "opengl":
 		return types.GraphicsAPIGLES
-	case envSoftware, "sw", "cpu":
+	case envSoftware, "sw", envCPU:
 		return types.GraphicsAPISoftware
 	default:
 		return types.GraphicsAPIAuto
@@ -172,9 +174,9 @@ func powerPreferenceFromEnv() gputypes.PowerPreference {
 // renderModeFromEnv reads GOGPU_RENDER_MODE environment variable.
 func renderModeFromEnv() RenderMode {
 	switch strings.ToLower(os.Getenv("GOGPU_RENDER_MODE")) {
-	case "cpu":
+	case envCPU:
 		return RenderModeCPU
-	case "gpu":
+	case envGPU:
 		return RenderModeGPU
 	default:
 		return RenderModeAuto
@@ -265,6 +267,7 @@ func (c Config) WithPowerPreference(pref gputypes.PowerPreference) Config {
 //	    WithTabbingMode(gogpu.TabbingPreferred).
 //	    WithTabbingIdentifier("com.myapp.tabs")
 //	app := gogpu.NewApp(cfg)
+//
 // WithRenderMode sets the 2D rendering path (ADR-020).
 // RenderModeAuto: CPU on software adapter, GPU on real hardware.
 // RenderModeCPU: force CPU rasterizer. RenderModeGPU: force GPU path.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,7 +160,35 @@ app := gogpu.NewApp(gogpu.DefaultConfig().
 app := gogpu.NewApp(gogpu.DefaultConfig().
     WithBackend(gogpu.BackendNative).
     WithGraphicsAPI(gogpu.GraphicsAPIDX12))
+
+// 2D render mode: CPU rasterizer vs GPU accelerator (ADR-020)
+app := gogpu.NewApp(gogpu.DefaultConfig().
+    WithRenderMode(gogpu.RenderModeCPU))  // force CPU rasterizer
 ```
+
+### Environment Variables
+
+All Config options can be overridden via environment variables:
+
+| Variable | Values | Default | Purpose |
+|----------|--------|---------|---------|
+| `GOGPU_GRAPHICS_API` | `vulkan`, `dx12`, `metal`, `gles`, `software` | auto | GPU backend |
+| `GOGPU_POWER_PREFERENCE` | `low`, `high` | none | GPU selection |
+| `GOGPU_RENDER_MODE` | `auto`, `cpu`, `gpu` | auto | 2D render path (ADR-020) |
+| `GOGPU_DEBUG_DAMAGE` | `1` | off | Damage region overlay (ADR-021) |
+
+### AdapterInfo
+
+`gpucontext.DeviceProvider.AdapterInfo()` exposes GPU adapter metadata:
+
+```go
+info := provider.AdapterInfo()
+// info.Type: AdapterTypeDiscrete, AdapterTypeIntegrated, AdapterTypeSoftware, AdapterTypeUnknown
+// info.Name: "NVIDIA GeForce RTX 4090", "Software Renderer", etc.
+```
+
+Used by gg for render mode auto-selection: software adapter → CPU rasterizer (60 FPS),
+real GPU → GPU accelerator. See ADR-020.
 
 ### gg
 

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/go-webgpu/webgpu v0.4.3
-	github.com/gogpu/gpucontext v0.16.0
+	github.com/gogpu/gpucontext v0.17.0
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/wgpu v0.26.12
+	github.com/gogpu/wgpu v0.27.0
 	golang.org/x/sys v0.43.0
 )
 
-require github.com/gogpu/naga v0.17.10 // indirect
+require github.com/gogpu/naga v0.17.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,17 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gpucontext v0.16.0 h1:33PhNAtaTyOjpR/foSzW4JjgWjX1W4cuJxjofGFs74M=
 github.com/gogpu/gpucontext v0.16.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
+github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=
+github.com/gogpu/gpucontext v0.17.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.10 h1:dJjMXb7b5ybSK8XbsiCA5aUVIAvLHjJg129FB1Ocz/I=
 github.com/gogpu/naga v0.17.10/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.17.11 h1:BndN5LLj3BKSdfjJxrDibs3jdx4YstrkvYTgEoJhsWI=
+github.com/gogpu/naga v0.17.11/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 github.com/gogpu/wgpu v0.26.12 h1:lJQVycMf01010YpG4vnODtEWXVHGhAbsK7ksstnRVys=
 github.com/gogpu/wgpu v0.26.12/go.mod h1:qiJGYshbptL0nHkoDPW/j7aZw2ILADBTXDsPyPTylCU=
+github.com/gogpu/wgpu v0.27.0 h1:KpQa7REbdr21PmlJcpDNPHPsyHD5lPWHauy2qPEIRcc=
+github.com/gogpu/wgpu v0.27.0/go.mod h1:b08BKjZLYMNzF918kMnjvgKoSGUR9dTTjvrdSRjPCqk=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/gpucontext_adapter.go
+++ b/gpucontext_adapter.go
@@ -58,6 +58,31 @@ func (a *gpuContextAdapter) Adapter() gpucontext.Adapter {
 	return a.renderer.adapter
 }
 
+// AdapterInfo returns GPU adapter metadata for render mode decisions.
+func (a *gpuContextAdapter) AdapterInfo() gpucontext.AdapterInfo {
+	if a.renderer == nil || a.renderer.adapter == nil {
+		return gpucontext.AdapterInfo{Type: gpucontext.AdapterTypeUnknown}
+	}
+	info := a.renderer.adapter.Info()
+	return gpucontext.AdapterInfo{
+		Name: info.Name,
+		Type: mapAdapterType(info.DeviceType),
+	}
+}
+
+func mapAdapterType(dt gputypes.DeviceType) gpucontext.AdapterType {
+	switch dt {
+	case gputypes.DeviceTypeDiscreteGPU:
+		return gpucontext.AdapterTypeDiscrete
+	case gputypes.DeviceTypeIntegratedGPU:
+		return gpucontext.AdapterTypeIntegrated
+	case gputypes.DeviceTypeCPU:
+		return gpucontext.AdapterTypeSoftware
+	default:
+		return gpucontext.AdapterTypeUnknown
+	}
+}
+
 // Size returns the current window size in logical points (DIP).
 // Implements gpucontext.WindowProvider.
 func (a *gpuContextAdapter) Size() (width, height int) {


### PR DESCRIPTION
## Summary

- **`GOGPU_RENDER_MODE=auto|cpu|gpu`** (ADR-020) — adapter-aware 2D render mode. CPU rasterizer on software adapter (60 FPS vs 0.65 FPS), GPU on real hardware
- **macOS native window tabbing** (#206, @lkmavi) — `Config.WithTabbingMode()` + `WithTabbingIdentifier()`
- **AdapterInfo** — `gpuContextAdapter.AdapterInfo()` maps wgpu DeviceType to gpucontext AdapterType
- **deps:** wgpu v0.27.0, naga v0.17.11, gpucontext v0.17.0

## Test plan

- [x] `go build ./...` — all platforms
- [x] `golangci-lint` — 0 issues on linux/windows/darwin
- [x] CHANGELOG, README, ARCHITECTURE, ROADMAP updated
- [ ] CI green