### PR TITLE
fix: centralized input event dispatch for multi-window (#210, ADR-021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.1] - 2026-05-07
+
+### Fixed
+
+- **Multi-window: secondary windows receive no input events** ([#210](https://github.com/gogpu/gogpu/issues/210), ADR-021, @lkmavi) — `setupInputEvents()` wired keyboard/pointer/scroll/char callbacks only on the primary window. Secondary windows created via `NewWindow()` were deaf to all input. Refactored to centralized event dispatch: all input events now flow through `PollEvents()` with `WindowID` tagging (same path as close/resize/focus). Removed per-window callback registration from `PlatformWindow` interface. Matches winit, SDL3, Qt6 enterprise pattern. Researched 6 frameworks (winit, SDL3, Qt6, GTK4, GLFW, Wails 3).
+
+### Added
+
+- **Per-window input callbacks** — `Window.SetOnKeyPress()`, `SetOnKeyRelease()`, `SetOnTextInput()`, `SetOnPointer()`, `SetOnScroll()`. Each window can have its own input handlers. `App.EventSource()` receives events from whichever window is focused.
+- **54 new tests** — centralized dispatch routing, multi-window event isolation, per-window callback setters, WindowManager operations.
+
 ## [0.32.0] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -342,6 +342,32 @@ app.OnUpdate(func(dt float64) {
 
 All input methods are thread-safe and work with the frame-based update loop.
 
+### Multi-Window Input
+
+Each window can have its own input handlers. `App.EventSource()` receives events from whichever window is focused:
+
+```go
+// Create secondary window
+w2, _ := app.NewWindow(gogpu.DefaultConfig().WithTitle("Inspector"))
+
+// Per-window input
+w2.SetOnKeyPress(func(key gpucontext.Key, mods gpucontext.Modifiers) {
+    // fires only when w2 is focused
+})
+w2.SetOnPointer(func(ev gpucontext.PointerEvent) {
+    // pointer events for this window
+})
+
+// App-level: receives from ANY focused window
+app.EventSource().OnKeyPress(func(key gpucontext.Key, mods gpucontext.Modifiers) {
+    if key == gpucontext.KeyN && mods.HasControl() {
+        // Ctrl+N works regardless of which window is focused
+    }
+})
+```
+
+All input events flow through centralized dispatch with `WindowID` routing (winit/SDL3/Qt6 pattern).
+
 ### Event-Driven Rendering
 
 GoGPU uses a three-state rendering model for optimal power efficiency:
@@ -468,8 +494,10 @@ Log levels: `Debug` (texture creation, pipeline state), `Info` (backend selected
 ## Architecture
 
 GoGPU uses **multi-thread architecture** (Ebiten/Gio pattern) for professional responsiveness:
-- **Main thread:** Window events only (Win32/Cocoa/X11 message pump)
+- **Main thread:** Window events only (Win32/Cocoa/X11 message pump), centralized input dispatch
 - **Render thread:** All GPU operations (device, swapchain, commands)
+
+All input events (keyboard, pointer, scroll, text) flow through a single centralized event queue with `WindowID` tagging — the same pattern used by winit, SDL3, and Qt6.
 
 This ensures windows never show "Not Responding" during heavy GPU operations.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,6 +60,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.32.1** | 2026-05-07 | **Centralized input dispatch** (ADR-021, #210, @lkmavi) — multi-window input fix, per-window callbacks, 54 tests |
 | **v0.32.0** | 2026-05-06 | **Render mode** (ADR-020), **macOS tabbing** (@lkmavi), AdapterInfo, wgpu v0.27.0 |
 | **v0.31.1** | 2026-05-05 | X11 remote display auth fix (#203, @sverrehu), lint cleanup |
 | **v0.31.0** | 2026-05-01 | **Runtime fullscreen** (ADR-018) — all 4 platforms, wgpu v0.26.12, gpucontext v0.16.0 |
@@ -109,6 +110,8 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 - [x] App.NewWindow() + real window creation + GPU surface (v0.28.0)
 - [x] EventFocus on all platforms — Win32, X11, Wayland, macOS (v0.28.1)
 - [x] WindowID on all events for multi-window routing (v0.28.1)
+- [x] Centralized input dispatch — all input through PollEvents() with WindowID (ADR-021, v0.32.1)
+- [x] Per-window input callbacks — SetOnKeyPress, SetOnPointer, SetOnScroll, etc. (v0.32.1)
 - [ ] VSync mode switching on focus change (surface reconfigure)
 - [ ] Window types: Normal, Dialog, Tool, Popup with parent-child
 - [ ] Close-as-request (OnClose returns bool to reject)

--- a/app.go
+++ b/app.go
@@ -188,8 +188,8 @@ func (a *App) Run() error {
 	// (Follows Ebitengine/GLFW/SDL pattern - state must exist before callbacks)
 	a.inputState = input.New()
 
-	// Wire platform callbacks to eventSourceAdapter for input events
-	a.setupInputEvents()
+	// Initialize eventSourceAdapter for input event dispatch.
+	a.eventSource = &eventSourceAdapter{app: a}
 
 	// Enable rendering during Win32 modal drag/resize loop.
 	//
@@ -368,8 +368,8 @@ func (a *App) processEventsMultiThread() {
 	}
 
 	// Handle secondary window resize events.
-	for _, ev := range secondaryResizes {
-		a.handleSecondaryResize(ev)
+	for i := range secondaryResizes {
+		a.handleSecondaryResize(secondaryResizes[i])
 	}
 
 	// Dispatch end-of-frame events (gestures computed from pointer events)
@@ -423,8 +423,98 @@ func (a *App) classifyEvent(event *platform.Event, lastResize *platform.Event, s
 			a.windowManager.setFocus(event.WindowID)
 		}
 		a.RequestRedraw()
+
+	case platform.EventKeyDown:
+		a.dispatchKeyEvent(event, true)
+	case platform.EventKeyUp:
+		a.dispatchKeyEvent(event, false)
+	case platform.EventChar:
+		a.dispatchCharEvent(event)
+	case platform.EventPointerDown, platform.EventPointerUp, platform.EventPointerMove,
+		platform.EventPointerEnter, platform.EventPointerLeave:
+		a.dispatchPointerEvent(event)
+	case platform.EventScroll:
+		a.dispatchScrollEvent(event)
 	}
 	return lastResize, secondaryResizes
+}
+
+// dispatchKeyEvent handles EventKeyDown and EventKeyUp from the platform.
+func (a *App) dispatchKeyEvent(event *platform.Event, pressed bool) {
+	w := a.windowManager.get(event.WindowID)
+	a.dispatchKeyToWindow(w, event.Key, event.Mods, pressed)
+	a.dispatchKeyToEventSource(event.Key, event.Mods, pressed)
+	a.dispatchKeyToInputState(event.Key, pressed)
+}
+
+func (a *App) dispatchKeyToWindow(w *Window, key gpucontext.Key, mods gpucontext.Modifiers, pressed bool) {
+	if w == nil {
+		return
+	}
+	if pressed && w.onKeyPress != nil {
+		w.onKeyPress(key, mods)
+	}
+	if !pressed && w.onKeyRelease != nil {
+		w.onKeyRelease(key, mods)
+	}
+}
+
+func (a *App) dispatchKeyToEventSource(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool) {
+	if a.eventSource == nil {
+		return
+	}
+	if pressed {
+		a.eventSource.dispatchKeyPress(key, mods)
+	} else {
+		a.eventSource.dispatchKeyRelease(key, mods)
+	}
+}
+
+func (a *App) dispatchKeyToInputState(key gpucontext.Key, pressed bool) {
+	if a.inputState == nil {
+		return
+	}
+	inputKey := gpucontextKeyToInputKey(key)
+	if inputKey != input.KeyUnknown {
+		a.inputState.Keyboard().SetKey(inputKey, pressed)
+	}
+}
+
+// dispatchCharEvent handles EventChar from the platform.
+func (a *App) dispatchCharEvent(event *platform.Event) {
+	w := a.windowManager.get(event.WindowID)
+	if w != nil && w.onTextInput != nil {
+		w.onTextInput(string(event.Char))
+	}
+	if a.eventSource != nil {
+		a.eventSource.dispatchTextInput(string(event.Char))
+	}
+}
+
+// dispatchPointerEvent handles pointer events (down/up/move/enter/leave) from the platform.
+func (a *App) dispatchPointerEvent(event *platform.Event) {
+	w := a.windowManager.get(event.WindowID)
+	if w != nil && w.onPointer != nil {
+		w.onPointer(event.Pointer)
+	}
+	if a.eventSource != nil {
+		a.eventSource.dispatchPointerEvent(event.Pointer)
+	}
+	a.updateMouseStateFromPointer(event.Pointer)
+}
+
+// dispatchScrollEvent handles EventScroll from the platform.
+func (a *App) dispatchScrollEvent(event *platform.Event) {
+	w := a.windowManager.get(event.WindowID)
+	if w != nil && w.onScroll != nil {
+		w.onScroll(event.Scroll)
+	}
+	if a.eventSource != nil {
+		a.eventSource.dispatchScrollEventDetailed(event.Scroll)
+	}
+	if a.inputState != nil {
+		a.inputState.Mouse().SetScroll(float32(event.Scroll.DeltaX), float32(event.Scroll.DeltaY))
+	}
 }
 
 type windowFrame struct {
@@ -852,55 +942,6 @@ func (a *App) updateMouseStateFromPointer(ev gpucontext.PointerEvent) {
 	case gpucontext.PointerUp:
 		a.inputState.Mouse().SetButton(button, false)
 	}
-}
-
-// setupInputEvents wires platform callbacks to eventSourceAdapter.
-// This enables W3C Pointer Events, detailed scroll events, and keyboard events
-// to flow from the platform layer to the gpucontext event system.
-func (a *App) setupInputEvents() {
-	// Ensure eventSource exists
-	if a.eventSource == nil {
-		a.eventSource = &eventSourceAdapter{app: a}
-	}
-
-	// Wire pointer events from platform to eventSource
-	a.platWindow.SetPointerCallback(func(ev gpucontext.PointerEvent) {
-		a.eventSource.dispatchPointerEvent(ev)
-		a.updateMouseStateFromPointer(ev)
-	})
-
-	// Wire scroll events from platform to eventSource
-	a.platWindow.SetScrollCallback(func(ev gpucontext.ScrollEvent) {
-		a.eventSource.dispatchScrollEventDetailed(ev)
-
-		// Update input state for Ebiten-style polling
-		if a.inputState != nil {
-			a.inputState.Mouse().SetScroll(float32(ev.DeltaX), float32(ev.DeltaY))
-		}
-	})
-
-	// Wire keyboard events from platform to eventSource
-	a.platWindow.SetKeyCallback(func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool) {
-		// Dispatch to callbacks (gpucontext.EventSource interface)
-		if pressed {
-			a.eventSource.dispatchKeyPress(key, mods)
-		} else {
-			a.eventSource.dispatchKeyRelease(key, mods)
-		}
-
-		// Update input state for Ebiten-style polling
-		if a.inputState != nil {
-			inputKey := gpucontextKeyToInputKey(key)
-			if inputKey != input.KeyUnknown {
-				a.inputState.Keyboard().SetKey(inputKey, pressed)
-			}
-		}
-	})
-
-	// Wire character input from platform to eventSource
-	a.platWindow.SetCharCallback(func(char rune) {
-		a.eventSource.dispatchTextInput(string(char))
-	})
 }
 
 // gpucontextKeyToInputKey converts gpucontext.Key to input.Key.

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -1,0 +1,788 @@
+package gogpu
+
+import (
+	"testing"
+
+	"github.com/gogpu/gogpu/input"
+	"github.com/gogpu/gogpu/internal/platform"
+	"github.com/gogpu/gpucontext"
+)
+
+// newTestApp creates an App with WindowManager, EventSource, and InputState
+// initialized for dispatch testing. No GPU or platform resources are needed.
+func newTestApp() *App {
+	app := NewApp(DefaultConfig())
+	app.windowManager = newWindowManager()
+	app.eventSource = &eventSourceAdapter{app: app}
+	app.inputState = input.New()
+	return app
+}
+
+// addTestWindow creates a Window with the given ID, registers it in the manager,
+// and returns it for callback registration.
+func addTestWindow(app *App, id platform.WindowID) *Window {
+	w := &Window{id: id}
+	app.windowManager.add(w)
+	return w
+}
+
+// --- Key event dispatch tests ---
+
+func TestDispatchKeyEvent_RoutesToCorrectWindow(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	var receivedKey gpucontext.Key
+	w.SetOnKeyPress(func(key gpucontext.Key, mods gpucontext.Modifiers) {
+		receivedKey = key
+	})
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyA,
+		Mods:     gpucontext.ModShift,
+	}, true)
+
+	if receivedKey != gpucontext.KeyA {
+		t.Errorf("window callback key = %v, want KeyA", receivedKey)
+	}
+}
+
+func TestDispatchKeyEvent_UnknownWindowID(t *testing.T) {
+	app := newTestApp()
+
+	// Must not panic when window is not found.
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: platform.NewWindowID(),
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyA,
+	}, true)
+}
+
+func TestDispatchKeyEvent_ReachesEventSource(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	addTestWindow(app, id)
+
+	var esKey gpucontext.Key
+	app.eventSource.onKeyPress = func(key gpucontext.Key, mods gpucontext.Modifiers) {
+		esKey = key
+	}
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeySpace,
+	}, true)
+
+	if esKey != gpucontext.KeySpace {
+		t.Errorf("EventSource key = %v, want KeySpace", esKey)
+	}
+}
+
+func TestDispatchKeyEvent_ReachesBothWindowAndEventSource(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	windowCalled := false
+	esCalled := false
+
+	w.SetOnKeyPress(func(gpucontext.Key, gpucontext.Modifiers) {
+		windowCalled = true
+	})
+	app.eventSource.onKeyPress = func(gpucontext.Key, gpucontext.Modifiers) {
+		esCalled = true
+	}
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyEnter,
+	}, true)
+
+	if !windowCalled {
+		t.Error("per-window callback was not called")
+	}
+	if !esCalled {
+		t.Error("EventSource callback was not called")
+	}
+}
+
+func TestDispatchKeyEvent_UpdatesInputState(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	addTestWindow(app, id)
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyA,
+	}, true)
+
+	if !app.inputState.Keyboard().Pressed(input.KeyA) {
+		t.Error("InputState should report KeyA pressed after key down dispatch")
+	}
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventKeyUp,
+		Key:      gpucontext.KeyA,
+	}, false)
+
+	if app.inputState.Keyboard().Pressed(input.KeyA) {
+		t.Error("InputState should report KeyA released after key up dispatch")
+	}
+}
+
+func TestDispatchKeyEvent_ReleaseRoutesToWindow(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	var releasedKey gpucontext.Key
+	w.SetOnKeyRelease(func(key gpucontext.Key, mods gpucontext.Modifiers) {
+		releasedKey = key
+	})
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventKeyUp,
+		Key:      gpucontext.KeyEscape,
+	}, false)
+
+	if releasedKey != gpucontext.KeyEscape {
+		t.Errorf("release key = %v, want KeyEscape", releasedKey)
+	}
+}
+
+func TestDispatchKeyEvent_NilEventSourceSafe(t *testing.T) {
+	app := newTestApp()
+	app.eventSource = nil
+
+	// Must not panic when eventSource is nil.
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: platform.NewWindowID(),
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyA,
+	}, true)
+}
+
+func TestDispatchKeyEvent_NilInputStateSafe(t *testing.T) {
+	app := newTestApp()
+	app.inputState = nil
+
+	// Must not panic when inputState is nil.
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: platform.NewWindowID(),
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyA,
+	}, true)
+}
+
+// --- Char event dispatch tests ---
+
+func TestDispatchCharEvent_RoutesToCorrectWindow(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	var received string
+	w.SetOnTextInput(func(text string) {
+		received = text
+	})
+
+	app.dispatchCharEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventChar,
+		Char:     'W',
+	})
+
+	if received != "W" {
+		t.Errorf("text = %q, want %q", received, "W")
+	}
+}
+
+func TestDispatchCharEvent_UnknownWindowID(t *testing.T) {
+	app := newTestApp()
+
+	// Must not panic.
+	app.dispatchCharEvent(&platform.Event{
+		WindowID: platform.NewWindowID(),
+		Type:     platform.EventChar,
+		Char:     'A',
+	})
+}
+
+func TestDispatchCharEvent_ReachesEventSource(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	addTestWindow(app, id)
+
+	var esText string
+	app.eventSource.onTextInput = func(text string) {
+		esText = text
+	}
+
+	app.dispatchCharEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventChar,
+		Char:     'Z',
+	})
+
+	if esText != "Z" {
+		t.Errorf("EventSource text = %q, want %q", esText, "Z")
+	}
+}
+
+func TestDispatchCharEvent_Unicode(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	var received string
+	w.SetOnTextInput(func(text string) {
+		received = text
+	})
+
+	app.dispatchCharEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventChar,
+		Char:     0x4E16, // '世' in Chinese
+	})
+
+	if received != "世" {
+		t.Errorf("text = %q, want %q", received, "世")
+	}
+}
+
+// --- Pointer event dispatch tests ---
+
+func TestDispatchPointerEvent_RoutesToCorrectWindow(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	var received gpucontext.PointerEvent
+	w.SetOnPointer(func(ev gpucontext.PointerEvent) {
+		received = ev
+	})
+
+	app.dispatchPointerEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventPointerMove,
+		Pointer: gpucontext.PointerEvent{
+			Type: gpucontext.PointerMove,
+			X:    150,
+			Y:    250,
+		},
+	})
+
+	if received.X != 150 || received.Y != 250 {
+		t.Errorf("pointer = (%f, %f), want (150, 250)", received.X, received.Y)
+	}
+}
+
+func TestDispatchPointerEvent_UnknownWindowID(t *testing.T) {
+	app := newTestApp()
+
+	// Must not panic.
+	app.dispatchPointerEvent(&platform.Event{
+		WindowID: platform.NewWindowID(),
+		Type:     platform.EventPointerDown,
+		Pointer: gpucontext.PointerEvent{
+			Type: gpucontext.PointerDown,
+		},
+	})
+}
+
+func TestDispatchPointerEvent_ReachesEventSource(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	addTestWindow(app, id)
+
+	var esReceived gpucontext.PointerEvent
+	app.eventSource.onPointer = func(ev gpucontext.PointerEvent) {
+		esReceived = ev
+	}
+
+	app.dispatchPointerEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventPointerDown,
+		Pointer: gpucontext.PointerEvent{
+			Type:   gpucontext.PointerDown,
+			Button: gpucontext.ButtonLeft,
+			X:      10,
+			Y:      20,
+		},
+	})
+
+	if esReceived.X != 10 || esReceived.Y != 20 {
+		t.Errorf("EventSource pointer = (%f, %f), want (10, 20)", esReceived.X, esReceived.Y)
+	}
+}
+
+func TestDispatchPointerEvent_UpdatesMouseState(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	addTestWindow(app, id)
+
+	app.dispatchPointerEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventPointerMove,
+		Pointer: gpucontext.PointerEvent{
+			Type:        gpucontext.PointerMove,
+			PointerType: gpucontext.PointerTypeMouse,
+			X:           300,
+			Y:           400,
+		},
+	})
+
+	mx, my := app.inputState.Mouse().Position()
+	if mx != 300 || my != 400 {
+		t.Errorf("mouse position = (%f, %f), want (300, 400)", mx, my)
+	}
+}
+
+// --- Scroll event dispatch tests ---
+
+func TestDispatchScrollEvent_RoutesToCorrectWindow(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	var received gpucontext.ScrollEvent
+	w.SetOnScroll(func(ev gpucontext.ScrollEvent) {
+		received = ev
+	})
+
+	app.dispatchScrollEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventScroll,
+		Scroll: gpucontext.ScrollEvent{
+			DeltaX: 3.5,
+			DeltaY: -7.0,
+		},
+	})
+
+	if received.DeltaX != 3.5 || received.DeltaY != -7.0 {
+		t.Errorf("scroll = (%f, %f), want (3.5, -7.0)", received.DeltaX, received.DeltaY)
+	}
+}
+
+func TestDispatchScrollEvent_UnknownWindowID(t *testing.T) {
+	app := newTestApp()
+
+	// Must not panic.
+	app.dispatchScrollEvent(&platform.Event{
+		WindowID: platform.NewWindowID(),
+		Type:     platform.EventScroll,
+		Scroll: gpucontext.ScrollEvent{
+			DeltaX: 1,
+			DeltaY: 2,
+		},
+	})
+}
+
+func TestDispatchScrollEvent_ReachesEventSource(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	addTestWindow(app, id)
+
+	var esReceived gpucontext.ScrollEvent
+	app.eventSource.onScrollEvent = func(ev gpucontext.ScrollEvent) {
+		esReceived = ev
+	}
+
+	app.dispatchScrollEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventScroll,
+		Scroll: gpucontext.ScrollEvent{
+			DeltaX: 8.0,
+			DeltaY: -4.0,
+		},
+	})
+
+	if esReceived.DeltaX != 8.0 || esReceived.DeltaY != -4.0 {
+		t.Errorf("EventSource scroll = (%f, %f), want (8.0, -4.0)", esReceived.DeltaX, esReceived.DeltaY)
+	}
+}
+
+func TestDispatchScrollEvent_UpdatesInputState(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	addTestWindow(app, id)
+
+	app.dispatchScrollEvent(&platform.Event{
+		WindowID: id,
+		Type:     platform.EventScroll,
+		Scroll: gpucontext.ScrollEvent{
+			DeltaX: 5.5,
+			DeltaY: -12.0,
+		},
+	})
+
+	// Mouse.Scroll() reads frame-latched values; UpdateFrame must be called
+	// to transfer accumulated scroll into the frame snapshot (game-loop pattern).
+	app.inputState.Mouse().UpdateFrame()
+
+	sx, sy := app.inputState.Mouse().Scroll()
+	if sx != 5.5 || sy != -12.0 {
+		t.Errorf("scroll delta = (%f, %f), want (5.5, -12.0)", sx, sy)
+	}
+}
+
+// --- Multi-window routing tests ---
+
+func TestDispatch_MultiWindow_RoutesToCorrectWindow(t *testing.T) {
+	app := newTestApp()
+
+	id1 := platform.NewWindowID()
+	id2 := platform.NewWindowID()
+	w1 := addTestWindow(app, id1)
+	w2 := addTestWindow(app, id2)
+
+	var w1Keys []gpucontext.Key
+	var w2Keys []gpucontext.Key
+
+	w1.SetOnKeyPress(func(key gpucontext.Key, mods gpucontext.Modifiers) {
+		w1Keys = append(w1Keys, key)
+	})
+	w2.SetOnKeyPress(func(key gpucontext.Key, mods gpucontext.Modifiers) {
+		w2Keys = append(w2Keys, key)
+	})
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id1,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyA,
+	}, true)
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id2,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyB,
+	}, true)
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id1,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyC,
+	}, true)
+
+	if len(w1Keys) != 2 {
+		t.Fatalf("window1 received %d keys, want 2", len(w1Keys))
+	}
+	if w1Keys[0] != gpucontext.KeyA || w1Keys[1] != gpucontext.KeyC {
+		t.Errorf("window1 keys = %v, want [KeyA, KeyC]", w1Keys)
+	}
+
+	if len(w2Keys) != 1 {
+		t.Fatalf("window2 received %d keys, want 1", len(w2Keys))
+	}
+	if w2Keys[0] != gpucontext.KeyB {
+		t.Errorf("window2 keys = %v, want [KeyB]", w2Keys)
+	}
+}
+
+func TestDispatch_MultiWindow_EventSourceReceivesAll(t *testing.T) {
+	app := newTestApp()
+
+	id1 := platform.NewWindowID()
+	id2 := platform.NewWindowID()
+	addTestWindow(app, id1)
+	addTestWindow(app, id2)
+
+	var esKeys []gpucontext.Key
+	app.eventSource.onKeyPress = func(key gpucontext.Key, mods gpucontext.Modifiers) {
+		esKeys = append(esKeys, key)
+	}
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id1,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyA,
+	}, true)
+
+	app.dispatchKeyEvent(&platform.Event{
+		WindowID: id2,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyB,
+	}, true)
+
+	if len(esKeys) != 2 {
+		t.Fatalf("EventSource received %d keys, want 2", len(esKeys))
+	}
+	if esKeys[0] != gpucontext.KeyA || esKeys[1] != gpucontext.KeyB {
+		t.Errorf("EventSource keys = %v, want [KeyA, KeyB]", esKeys)
+	}
+}
+
+func TestDispatch_MultiWindow_PointerIsolation(t *testing.T) {
+	app := newTestApp()
+
+	id1 := platform.NewWindowID()
+	id2 := platform.NewWindowID()
+	w1 := addTestWindow(app, id1)
+	w2 := addTestWindow(app, id2)
+
+	var w1Pointers []gpucontext.PointerEvent
+	var w2Pointers []gpucontext.PointerEvent
+
+	w1.SetOnPointer(func(ev gpucontext.PointerEvent) {
+		w1Pointers = append(w1Pointers, ev)
+	})
+	w2.SetOnPointer(func(ev gpucontext.PointerEvent) {
+		w2Pointers = append(w2Pointers, ev)
+	})
+
+	app.dispatchPointerEvent(&platform.Event{
+		WindowID: id1,
+		Type:     platform.EventPointerMove,
+		Pointer:  gpucontext.PointerEvent{Type: gpucontext.PointerMove, X: 10, Y: 20},
+	})
+
+	app.dispatchPointerEvent(&platform.Event{
+		WindowID: id2,
+		Type:     platform.EventPointerDown,
+		Pointer:  gpucontext.PointerEvent{Type: gpucontext.PointerDown, X: 30, Y: 40},
+	})
+
+	if len(w1Pointers) != 1 {
+		t.Fatalf("window1 received %d pointer events, want 1", len(w1Pointers))
+	}
+	if w1Pointers[0].X != 10 || w1Pointers[0].Y != 20 {
+		t.Errorf("window1 pointer = (%f, %f), want (10, 20)", w1Pointers[0].X, w1Pointers[0].Y)
+	}
+
+	if len(w2Pointers) != 1 {
+		t.Fatalf("window2 received %d pointer events, want 1", len(w2Pointers))
+	}
+	if w2Pointers[0].X != 30 || w2Pointers[0].Y != 40 {
+		t.Errorf("window2 pointer = (%f, %f), want (30, 40)", w2Pointers[0].X, w2Pointers[0].Y)
+	}
+}
+
+func TestDispatch_MultiWindow_ScrollIsolation(t *testing.T) {
+	app := newTestApp()
+
+	id1 := platform.NewWindowID()
+	id2 := platform.NewWindowID()
+	w1 := addTestWindow(app, id1)
+	w2 := addTestWindow(app, id2)
+
+	var w1Scrolls []gpucontext.ScrollEvent
+	var w2Scrolls []gpucontext.ScrollEvent
+
+	w1.SetOnScroll(func(ev gpucontext.ScrollEvent) {
+		w1Scrolls = append(w1Scrolls, ev)
+	})
+	w2.SetOnScroll(func(ev gpucontext.ScrollEvent) {
+		w2Scrolls = append(w2Scrolls, ev)
+	})
+
+	app.dispatchScrollEvent(&platform.Event{
+		WindowID: id1,
+		Type:     platform.EventScroll,
+		Scroll:   gpucontext.ScrollEvent{DeltaX: 1, DeltaY: 2},
+	})
+
+	app.dispatchScrollEvent(&platform.Event{
+		WindowID: id2,
+		Type:     platform.EventScroll,
+		Scroll:   gpucontext.ScrollEvent{DeltaX: 3, DeltaY: 4},
+	})
+
+	if len(w1Scrolls) != 1 {
+		t.Fatalf("window1 received %d scroll events, want 1", len(w1Scrolls))
+	}
+	if w1Scrolls[0].DeltaY != 2 {
+		t.Errorf("window1 scroll DeltaY = %f, want 2", w1Scrolls[0].DeltaY)
+	}
+
+	if len(w2Scrolls) != 1 {
+		t.Fatalf("window2 received %d scroll events, want 1", len(w2Scrolls))
+	}
+	if w2Scrolls[0].DeltaY != 4 {
+		t.Errorf("window2 scroll DeltaY = %f, want 4", w2Scrolls[0].DeltaY)
+	}
+}
+
+func TestDispatch_MultiWindow_CharIsolation(t *testing.T) {
+	app := newTestApp()
+
+	id1 := platform.NewWindowID()
+	id2 := platform.NewWindowID()
+	w1 := addTestWindow(app, id1)
+	w2 := addTestWindow(app, id2)
+
+	var w1Texts []string
+	var w2Texts []string
+
+	w1.SetOnTextInput(func(text string) {
+		w1Texts = append(w1Texts, text)
+	})
+	w2.SetOnTextInput(func(text string) {
+		w2Texts = append(w2Texts, text)
+	})
+
+	app.dispatchCharEvent(&platform.Event{
+		WindowID: id1,
+		Type:     platform.EventChar,
+		Char:     'A',
+	})
+
+	app.dispatchCharEvent(&platform.Event{
+		WindowID: id2,
+		Type:     platform.EventChar,
+		Char:     'B',
+	})
+
+	if len(w1Texts) != 1 || w1Texts[0] != "A" {
+		t.Errorf("window1 texts = %v, want [A]", w1Texts)
+	}
+	if len(w2Texts) != 1 || w2Texts[0] != "B" {
+		t.Errorf("window2 texts = %v, want [B]", w2Texts)
+	}
+}
+
+// --- Integration: full dispatch chain via classifyEvent ---
+
+func TestClassifyEvent_KeyDownIntegration(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	windowCalled := false
+	esCalled := false
+
+	w.SetOnKeyPress(func(gpucontext.Key, gpucontext.Modifiers) {
+		windowCalled = true
+	})
+	app.eventSource.onKeyPress = func(gpucontext.Key, gpucontext.Modifiers) {
+		esCalled = true
+	}
+
+	event := &platform.Event{
+		WindowID: id,
+		Type:     platform.EventKeyDown,
+		Key:      gpucontext.KeyW,
+		Mods:     gpucontext.ModControl,
+	}
+	app.classifyEvent(event, nil, nil)
+
+	if !windowCalled {
+		t.Error("per-window key press callback not called via classifyEvent")
+	}
+	if !esCalled {
+		t.Error("EventSource key press callback not called via classifyEvent")
+	}
+	if !app.inputState.Keyboard().Pressed(input.KeyW) {
+		t.Error("InputState should report KeyW pressed via classifyEvent")
+	}
+}
+
+func TestClassifyEvent_ScrollIntegration(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	windowCalled := false
+	w.SetOnScroll(func(ev gpucontext.ScrollEvent) {
+		windowCalled = true
+	})
+
+	event := &platform.Event{
+		WindowID: id,
+		Type:     platform.EventScroll,
+		Scroll: gpucontext.ScrollEvent{
+			DeltaX: 1.0,
+			DeltaY: -2.0,
+		},
+	}
+	app.classifyEvent(event, nil, nil)
+
+	if !windowCalled {
+		t.Error("per-window scroll callback not called via classifyEvent")
+	}
+
+	// Mouse.Scroll() reads frame-latched values; UpdateFrame must be called first.
+	app.inputState.Mouse().UpdateFrame()
+
+	sx, sy := app.inputState.Mouse().Scroll()
+	if sx != 1.0 || sy != -2.0 {
+		t.Errorf("InputState scroll = (%f, %f), want (1.0, -2.0)", sx, sy)
+	}
+}
+
+func TestClassifyEvent_PointerIntegration(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	windowCalled := false
+	esCalled := false
+
+	w.SetOnPointer(func(ev gpucontext.PointerEvent) {
+		windowCalled = true
+	})
+	app.eventSource.onPointer = func(ev gpucontext.PointerEvent) {
+		esCalled = true
+	}
+
+	event := &platform.Event{
+		WindowID: id,
+		Type:     platform.EventPointerMove,
+		Pointer: gpucontext.PointerEvent{
+			Type:        gpucontext.PointerMove,
+			PointerType: gpucontext.PointerTypeMouse,
+			X:           55,
+			Y:           66,
+		},
+	}
+	app.classifyEvent(event, nil, nil)
+
+	if !windowCalled {
+		t.Error("per-window pointer callback not called via classifyEvent")
+	}
+	if !esCalled {
+		t.Error("EventSource pointer callback not called via classifyEvent")
+	}
+
+	mx, my := app.inputState.Mouse().Position()
+	if mx != 55 || my != 66 {
+		t.Errorf("InputState mouse = (%f, %f), want (55, 66)", mx, my)
+	}
+}
+
+func TestClassifyEvent_CharIntegration(t *testing.T) {
+	app := newTestApp()
+	id := platform.NewWindowID()
+	w := addTestWindow(app, id)
+
+	var received string
+	w.SetOnTextInput(func(text string) {
+		received = text
+	})
+
+	var esReceived string
+	app.eventSource.onTextInput = func(text string) {
+		esReceived = text
+	}
+
+	event := &platform.Event{
+		WindowID: id,
+		Type:     platform.EventChar,
+		Char:     'Q',
+	}
+	app.classifyEvent(event, nil, nil)
+
+	if received != "Q" {
+		t.Errorf("window text = %q, want %q", received, "Q")
+	}
+	if esReceived != "Q" {
+		t.Errorf("EventSource text = %q, want %q", esReceived, "Q")
+	}
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -38,6 +38,19 @@ type Event struct {
 	PhysicalWidth  int  // for resize events: physical pixels (GPU framebuffer)
 	PhysicalHeight int  // for resize events: physical pixels (GPU framebuffer)
 	Focused        bool // for focus events: true = gained focus, false = lost focus
+
+	// Keyboard (EventKeyDown, EventKeyUp)
+	Key  gpucontext.Key
+	Mods gpucontext.Modifiers
+
+	// Character input (EventChar)
+	Char rune
+
+	// Pointer (EventPointer*)
+	Pointer gpucontext.PointerEvent
+
+	// Scroll (EventScroll)
+	Scroll gpucontext.ScrollEvent
 }
 
 // EventType represents the type of platform event.
@@ -48,6 +61,15 @@ const (
 	EventClose
 	EventResize
 	EventFocus
+	EventKeyDown
+	EventKeyUp
+	EventChar
+	EventPointerDown
+	EventPointerUp
+	EventPointerMove
+	EventPointerEnter
+	EventPointerLeave
+	EventScroll
 )
 
 // PrepareFrameResult contains per-frame surface state from the platform layer.
@@ -188,18 +210,6 @@ type PlatformWindow interface {
 
 	// CursorMode returns the current cursor mode.
 	CursorMode() int
-
-	// SetPointerCallback registers a callback for pointer events.
-	SetPointerCallback(fn func(gpucontext.PointerEvent))
-
-	// SetScrollCallback registers a callback for scroll events.
-	SetScrollCallback(fn func(gpucontext.ScrollEvent))
-
-	// SetKeyCallback registers a callback for keyboard events.
-	SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool))
-
-	// SetCharCallback registers a callback for Unicode character input.
-	SetCharCallback(fn func(char rune))
 
 	// SetModalFrameCallback registers a callback for platform modal operations.
 	SetModalFrameCallback(fn func())

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -34,12 +34,7 @@ type darwinWindow struct {
 	frameless       bool
 	hitTestCallback func(x, y float64) gpucontext.HitTestResult
 
-	// Callbacks for pointer, scroll, keyboard, and character input events
-	pointerCallback  func(gpucontext.PointerEvent)
-	scrollCallback   func(gpucontext.ScrollEvent)
-	keyboardCallback func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)
-	charCallback     func(rune)
-	callbackMu       sync.RWMutex
+	callbackMu sync.RWMutex
 
 	// Timestamp reference for event timing
 	startTime time.Time
@@ -353,34 +348,6 @@ func (dw *darwinPlatformWindow) IsFullscreen() bool {
 	return false
 }
 
-func (dw *darwinPlatformWindow) SetPointerCallback(fn func(gpucontext.PointerEvent)) {
-	w := dw.platform.primary
-	w.callbackMu.Lock()
-	w.pointerCallback = fn
-	w.callbackMu.Unlock()
-}
-
-func (dw *darwinPlatformWindow) SetScrollCallback(fn func(gpucontext.ScrollEvent)) {
-	w := dw.platform.primary
-	w.callbackMu.Lock()
-	w.scrollCallback = fn
-	w.callbackMu.Unlock()
-}
-
-func (dw *darwinPlatformWindow) SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
-	w := dw.platform.primary
-	w.callbackMu.Lock()
-	w.keyboardCallback = fn
-	w.callbackMu.Unlock()
-}
-
-func (dw *darwinPlatformWindow) SetCharCallback(fn func(rune)) {
-	w := dw.platform.primary
-	w.callbackMu.Lock()
-	w.charCallback = fn
-	w.callbackMu.Unlock()
-}
-
 func (dw *darwinPlatformWindow) SetModalFrameCallback(_ func()) {}
 
 func (dw *darwinPlatformWindow) BlitPixels(pixels []byte, width, height int) error {
@@ -652,60 +619,46 @@ func (w *darwinWindow) handleEvent(event darwin.ID, eventType darwin.NSEventType
 	return true
 }
 
-// dispatchPointerEvent dispatches a pointer event to the registered callback.
-// Called from handleEvent with w.eventMu held. Releases eventMu during callback
-// to avoid deadlocks if the callback calls back into platform methods.
+// dispatchPointerEvent pushes a pointer event to the event queue.
+// Called from handleEvent with w.eventMu held.
 func (w *darwinWindow) dispatchPointerEvent(ev gpucontext.PointerEvent) {
-	w.callbackMu.RLock()
-	callback := w.pointerCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		w.eventMu.Unlock()
-		callback(ev)
-		w.eventMu.Lock()
+	var evType EventType
+	switch ev.Type {
+	case gpucontext.PointerDown:
+		evType = EventPointerDown
+	case gpucontext.PointerUp:
+		evType = EventPointerUp
+	case gpucontext.PointerMove:
+		evType = EventPointerMove
+	case gpucontext.PointerEnter:
+		evType = EventPointerEnter
+	case gpucontext.PointerLeave:
+		evType = EventPointerLeave
+	default:
+		evType = EventPointerMove
 	}
+	w.events = append(w.events, Event{Type: evType, Pointer: ev})
 }
 
-// dispatchScrollEvent dispatches a scroll event to the registered callback.
+// dispatchScrollEvent pushes a scroll event to the event queue.
 // Called from handleEvent with w.eventMu held.
 func (w *darwinWindow) dispatchScrollEvent(ev gpucontext.ScrollEvent) {
-	w.callbackMu.RLock()
-	callback := w.scrollCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		w.eventMu.Unlock()
-		callback(ev)
-		w.eventMu.Lock()
-	}
+	w.events = append(w.events, Event{Type: EventScroll, Scroll: ev})
 }
 
-// dispatchKeyEvent dispatches a keyboard event to the registered callback.
+// dispatchKeyEvent pushes a keyboard event to the event queue.
 // Called from handleEvent with w.eventMu held.
 func (w *darwinWindow) dispatchKeyEvent(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool) {
-	w.callbackMu.RLock()
-	callback := w.keyboardCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		w.eventMu.Unlock()
-		callback(key, mods, pressed)
-		w.eventMu.Lock()
+	evType := EventKeyDown
+	if !pressed {
+		evType = EventKeyUp
 	}
+	w.events = append(w.events, Event{Type: evType, Key: key, Mods: mods})
 }
 
 // dispatchCharFromEvent extracts characters from an NSEvent and dispatches them.
 // Called from handleEvent with w.eventMu held.
 func (w *darwinWindow) dispatchCharFromEvent(event darwin.ID) {
-	w.callbackMu.RLock()
-	callback := w.charCallback
-	w.callbackMu.RUnlock()
-
-	if callback == nil {
-		return
-	}
-
 	// Get [NSEvent characters] → NSString
 	nsstr := darwin.GetCharacters(event)
 	if nsstr.IsNil() {
@@ -727,22 +680,17 @@ func (w *darwinWindow) dispatchCharFromEvent(event darwin.ID) {
 	// Convert to Go byte slice (safe: pointer valid within this autorelease pool scope)
 	data := unsafe.Slice((*byte)(unsafe.Pointer(utf8Ptr)), length*4) //nolint:govet // ObjC UTF8String pointer, bounded by NSString length
 
-	// Release lock before calling user callback to avoid deadlocks
-	w.eventMu.Unlock()
-
-	// Decode UTF-8 runes and dispatch each non-control character
+	// Decode UTF-8 runes and push each non-control character to event queue
 	for i := 0; i < len(data); {
 		r, size := utf8.DecodeRune(data[i:])
 		if r == utf8.RuneError && size <= 1 {
 			break // end of valid UTF-8
 		}
 		if r >= 32 && r != 127 {
-			callback(r)
+			w.events = append(w.events, Event{Type: EventChar, Char: r})
 		}
 		i += size
 	}
-
-	w.eventMu.Lock()
 }
 
 // setCursorImpl changes the mouse cursor shape using NSCursor.

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -52,12 +52,7 @@ type waylandWindow struct {
 	// Keyboard focus tracking
 	keyboardFocused bool
 
-	// Callbacks for pointer, scroll, and keyboard events
-	pointerCallback  func(gpucontext.PointerEvent)
-	scrollCallback   func(gpucontext.ScrollEvent)
-	keyboardCallback func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)
-	charCallback     func(rune)
-	callbackMu       sync.RWMutex
+	callbackMu sync.RWMutex
 }
 
 // waylandPlatform implements the Platform interface using Wayland.
@@ -163,6 +158,24 @@ func (p *x11Platform) PollEvents() Event {
 		}
 	case x11.EventTypeFocus:
 		return Event{Type: EventFocus, Focused: event.Focused}
+	case x11.EventTypeKeyDown:
+		return Event{Type: EventKeyDown, Key: event.Key, Mods: event.Mods}
+	case x11.EventTypeKeyUp:
+		return Event{Type: EventKeyUp, Key: event.Key, Mods: event.Mods}
+	case x11.EventTypeChar:
+		return Event{Type: EventChar, Char: event.Char}
+	case x11.EventTypePointerDown:
+		return Event{Type: EventPointerDown, Pointer: event.Pointer}
+	case x11.EventTypePointerUp:
+		return Event{Type: EventPointerUp, Pointer: event.Pointer}
+	case x11.EventTypePointerMove:
+		return Event{Type: EventPointerMove, Pointer: event.Pointer}
+	case x11.EventTypePointerEnter:
+		return Event{Type: EventPointerEnter, Pointer: event.Pointer}
+	case x11.EventTypePointerLeave:
+		return Event{Type: EventPointerLeave, Pointer: event.Pointer}
+	case x11.EventTypeScroll:
+		return Event{Type: EventScroll, Scroll: event.Scroll}
 	default:
 		return Event{Type: EventNone}
 	}
@@ -284,22 +297,6 @@ func (w *x11PlatformWindow) IsFullscreen() bool {
 
 func (w *x11PlatformWindow) Close() { w.platform.inner.CloseWindow() }
 
-func (w *x11PlatformWindow) SetPointerCallback(fn func(gpucontext.PointerEvent)) {
-	w.platform.inner.SetPointerCallback(fn)
-}
-
-func (w *x11PlatformWindow) SetScrollCallback(fn func(gpucontext.ScrollEvent)) {
-	w.platform.inner.SetScrollCallback(fn)
-}
-
-func (w *x11PlatformWindow) SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
-	w.platform.inner.SetKeyCallback(fn)
-}
-
-func (w *x11PlatformWindow) SetCharCallback(fn func(rune)) {
-	w.platform.inner.SetCharCallback(fn)
-}
-
 // BlitPixels copies RGBA pixel data to the window using X11 PutImage.
 func (w *x11PlatformWindow) BlitPixels(pixels []byte, width, height int) error {
 	return w.platform.inner.BlitPixels(pixels, width, height)
@@ -401,22 +398,6 @@ func (w *waylandPlatformWindow) IsFullscreen() bool {
 }
 
 func (w *waylandPlatformWindow) Close() { w.platform.CloseWindow() }
-
-func (w *waylandPlatformWindow) SetPointerCallback(fn func(gpucontext.PointerEvent)) {
-	w.platform.SetPointerCallback(fn)
-}
-
-func (w *waylandPlatformWindow) SetScrollCallback(fn func(gpucontext.ScrollEvent)) {
-	w.platform.SetScrollCallback(fn)
-}
-
-func (w *waylandPlatformWindow) SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
-	w.platform.SetKeyCallback(fn)
-}
-
-func (w *waylandPlatformWindow) SetCharCallback(fn func(rune)) {
-	w.platform.SetCharCallback(fn)
-}
 
 func (w *waylandPlatformWindow) SetModalFrameCallback(_ func()) {}
 
@@ -841,12 +822,7 @@ func (p *waylandPlatform) setupInputCallbacks() {
 				shift := mods&gpucontext.ModShift != 0
 				capsLock := mods&gpucontext.ModCapsLock != 0
 				if r := evdevKeycodeToRune(key, shift, capsLock); r != 0 {
-					w.callbackMu.RLock()
-					cb := w.charCallback
-					w.callbackMu.RUnlock()
-					if cb != nil {
-						cb(r)
-					}
+					w.queueEvent(Event{Type: EventChar, Char: r})
 				}
 			}
 		},
@@ -1092,37 +1068,38 @@ func (w *waylandWindow) eventTimestamp() time.Duration {
 	return time.Since(w.startTime)
 }
 
-// dispatchPointerEvent dispatches a pointer event to the registered callback.
+// dispatchPointerEvent pushes a pointer event to the event queue.
 func (w *waylandWindow) dispatchPointerEvent(ev gpucontext.PointerEvent) {
-	w.callbackMu.RLock()
-	callback := w.pointerCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		callback(ev)
+	var evType EventType
+	switch ev.Type {
+	case gpucontext.PointerDown:
+		evType = EventPointerDown
+	case gpucontext.PointerUp:
+		evType = EventPointerUp
+	case gpucontext.PointerMove:
+		evType = EventPointerMove
+	case gpucontext.PointerEnter:
+		evType = EventPointerEnter
+	case gpucontext.PointerLeave:
+		evType = EventPointerLeave
+	default:
+		evType = EventPointerMove
 	}
+	w.queueEvent(Event{Type: evType, Pointer: ev})
 }
 
-// dispatchScrollEvent dispatches a scroll event to the registered callback.
+// dispatchScrollEvent pushes a scroll event to the event queue.
 func (w *waylandWindow) dispatchScrollEvent(ev gpucontext.ScrollEvent) {
-	w.callbackMu.RLock()
-	callback := w.scrollCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		callback(ev)
-	}
+	w.queueEvent(Event{Type: EventScroll, Scroll: ev})
 }
 
-// dispatchKeyEvent dispatches a keyboard event to the registered callback.
+// dispatchKeyEvent pushes a keyboard event to the event queue.
 func (w *waylandWindow) dispatchKeyEvent(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool) {
-	w.callbackMu.RLock()
-	callback := w.keyboardCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		callback(key, mods, pressed)
+	evType := EventKeyDown
+	if !pressed {
+		evType = EventKeyUp
 	}
+	w.queueEvent(Event{Type: evType, Key: key, Mods: mods})
 }
 
 // queueEvent appends a platform event to the window's event queue.
@@ -1887,39 +1864,6 @@ func (p *waylandPlatform) Destroy() {
 // Wayland uses async configure events, so resize is never blocking.
 func (p *waylandPlatform) InSizeMove() bool {
 	return false
-}
-
-// SetPointerCallback registers a callback for pointer events.
-func (p *waylandPlatform) SetPointerCallback(fn func(gpucontext.PointerEvent)) {
-	w := p.primary
-	w.callbackMu.Lock()
-	w.pointerCallback = fn
-	w.callbackMu.Unlock()
-}
-
-// SetScrollCallback registers a callback for scroll events.
-func (p *waylandPlatform) SetScrollCallback(fn func(gpucontext.ScrollEvent)) {
-	w := p.primary
-	w.callbackMu.Lock()
-	w.scrollCallback = fn
-	w.callbackMu.Unlock()
-}
-
-// SetKeyCallback registers a callback for keyboard events.
-func (p *waylandPlatform) SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
-	w := p.primary
-	w.callbackMu.Lock()
-	w.keyboardCallback = fn
-	w.callbackMu.Unlock()
-}
-
-// SetCharCallback registers a callback for Unicode character input.
-// TODO: Implement via libxkbcommon xkb_state_key_get_utf8 for full Unicode support.
-func (p *waylandPlatform) SetCharCallback(fn func(rune)) {
-	w := p.primary
-	w.callbackMu.Lock()
-	w.charCallback = fn
-	w.callbackMu.Unlock()
 }
 
 // SetModalFrameCallback is a no-op on Wayland.

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,117 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/gogpu/gpucontext"
+)
+
+func TestEventTypeConstants_Distinct(t *testing.T) {
+	types := []EventType{
+		EventNone,
+		EventClose,
+		EventResize,
+		EventFocus,
+		EventKeyDown,
+		EventKeyUp,
+		EventChar,
+		EventPointerDown,
+		EventPointerUp,
+		EventPointerMove,
+		EventPointerEnter,
+		EventPointerLeave,
+		EventScroll,
+	}
+
+	seen := make(map[EventType]string, len(types))
+	names := []string{
+		"EventNone",
+		"EventClose",
+		"EventResize",
+		"EventFocus",
+		"EventKeyDown",
+		"EventKeyUp",
+		"EventChar",
+		"EventPointerDown",
+		"EventPointerUp",
+		"EventPointerMove",
+		"EventPointerEnter",
+		"EventPointerLeave",
+		"EventScroll",
+	}
+
+	for i, et := range types {
+		if prev, ok := seen[et]; ok {
+			t.Errorf("EventType %s has same value (%d) as %s", names[i], et, prev)
+		}
+		seen[et] = names[i]
+	}
+}
+
+func TestEventTypeConstants_Sequential(t *testing.T) {
+	if EventNone != 0 {
+		t.Errorf("EventNone = %d, want 0", EventNone)
+	}
+	if EventScroll != 12 {
+		t.Errorf("EventScroll = %d, want 12 (last constant)", EventScroll)
+	}
+}
+
+func TestEvent_AllPayloadsCoexist(t *testing.T) {
+	ev := Event{
+		WindowID:       42,
+		Type:           EventKeyDown,
+		Width:          800,
+		Height:         600,
+		PhysicalWidth:  1600,
+		PhysicalHeight: 1200,
+		Focused:        true,
+		Key:            gpucontext.KeyA,
+		Mods:           gpucontext.ModShift | gpucontext.ModControl,
+		Char:           'X',
+		Pointer: gpucontext.PointerEvent{
+			Type:        gpucontext.PointerMove,
+			PointerID:   1,
+			PointerType: gpucontext.PointerTypeMouse,
+			X:           100.5,
+			Y:           200.5,
+		},
+		Scroll: gpucontext.ScrollEvent{
+			DeltaX: 10.0,
+			DeltaY: -20.0,
+		},
+	}
+
+	if ev.WindowID != 42 {
+		t.Errorf("WindowID = %d, want 42", ev.WindowID)
+	}
+	if ev.Key != gpucontext.KeyA {
+		t.Errorf("Key = %v, want KeyA", ev.Key)
+	}
+	if ev.Mods != gpucontext.ModShift|gpucontext.ModControl {
+		t.Errorf("Mods = %v, want Shift|Control", ev.Mods)
+	}
+	if ev.Char != 'X' {
+		t.Errorf("Char = %c, want X", ev.Char)
+	}
+	if ev.Pointer.X != 100.5 || ev.Pointer.Y != 200.5 {
+		t.Errorf("Pointer = (%f, %f), want (100.5, 200.5)", ev.Pointer.X, ev.Pointer.Y)
+	}
+	if ev.Scroll.DeltaX != 10.0 || ev.Scroll.DeltaY != -20.0 {
+		t.Errorf("Scroll = (%f, %f), want (10.0, -20.0)", ev.Scroll.DeltaX, ev.Scroll.DeltaY)
+	}
+}
+
+func TestNewWindowID_Unique(t *testing.T) {
+	ids := make(map[WindowID]bool, 100)
+	for range 100 {
+		id := NewWindowID()
+		if id == 0 {
+			t.Fatal("NewWindowID returned zero (invalid)")
+		}
+		if ids[id] {
+			t.Fatalf("NewWindowID returned duplicate ID %d", id)
+		}
+		ids[id] = true
+	}
+}

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -465,11 +465,6 @@ type win32Window struct {
 	savedPlacement windowPlacement
 	savedStyle     uint32
 
-	// Callbacks for pointer, scroll, keyboard, and character input events
-	pointerCallback    func(gpucontext.PointerEvent)
-	scrollCallback     func(gpucontext.ScrollEvent)
-	keyboardCallback   func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)
-	charCallback       func(rune)
 	highSurrogate      uint16 // UTF-16 high surrogate for emoji/CJK supplementary chars
 	modalFrameCallback func() // Called on WM_TIMER during modal drag/resize
 	callbackMu         sync.RWMutex
@@ -800,22 +795,6 @@ func (w *win32Window) CursorMode() int {
 	return w.cursorMode
 }
 
-func (w *win32Window) SetPointerCallback(fn func(gpucontext.PointerEvent)) {
-	w.setPointerCallback(fn)
-}
-
-func (w *win32Window) SetScrollCallback(fn func(gpucontext.ScrollEvent)) {
-	w.setScrollCallback(fn)
-}
-
-func (w *win32Window) SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
-	w.setKeyCallback(fn)
-}
-
-func (w *win32Window) SetCharCallback(fn func(char rune)) {
-	w.setCharCallback(fn)
-}
-
 func (w *win32Window) SetModalFrameCallback(fn func()) {
 	w.setModalFrameCallback(fn)
 }
@@ -925,46 +904,6 @@ func (w *win32Window) InSizeMove() bool {
 
 func (p *windowsPlatform) GetHandle() (instance, window uintptr) {
 	return uintptr(p.hinstance), uintptr(p.primary.hwnd)
-}
-
-func (p *windowsPlatform) SetPointerCallback(fn func(gpucontext.PointerEvent)) {
-	p.primary.setPointerCallback(fn)
-}
-
-func (w *win32Window) setPointerCallback(fn func(gpucontext.PointerEvent)) {
-	w.callbackMu.Lock()
-	w.pointerCallback = fn
-	w.callbackMu.Unlock()
-}
-
-func (p *windowsPlatform) SetScrollCallback(fn func(gpucontext.ScrollEvent)) {
-	p.primary.setScrollCallback(fn)
-}
-
-func (w *win32Window) setScrollCallback(fn func(gpucontext.ScrollEvent)) {
-	w.callbackMu.Lock()
-	w.scrollCallback = fn
-	w.callbackMu.Unlock()
-}
-
-func (p *windowsPlatform) SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
-	p.primary.setKeyCallback(fn)
-}
-
-func (w *win32Window) setKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
-	w.callbackMu.Lock()
-	w.keyboardCallback = fn
-	w.callbackMu.Unlock()
-}
-
-func (p *windowsPlatform) SetCharCallback(fn func(rune)) {
-	p.primary.setCharCallback(fn)
-}
-
-func (w *win32Window) setCharCallback(fn func(rune)) {
-	w.callbackMu.Lock()
-	w.charCallback = fn
-	w.callbackMu.Unlock()
 }
 
 // SetModalFrameCallback registers a callback invoked via WM_TIMER during
@@ -1506,33 +1445,34 @@ func extractXButton(wParam uintptr) gpucontext.Button {
 }
 
 func (w *win32Window) dispatchPointerEvent(ev gpucontext.PointerEvent) {
-	w.callbackMu.RLock()
-	callback := w.pointerCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		callback(ev)
+	var evType EventType
+	switch ev.Type {
+	case gpucontext.PointerDown:
+		evType = EventPointerDown
+	case gpucontext.PointerUp:
+		evType = EventPointerUp
+	case gpucontext.PointerMove:
+		evType = EventPointerMove
+	case gpucontext.PointerEnter:
+		evType = EventPointerEnter
+	case gpucontext.PointerLeave:
+		evType = EventPointerLeave
+	default:
+		evType = EventPointerMove
 	}
+	w.platform.queueEvent(Event{WindowID: w.id, Type: evType, Pointer: ev})
 }
 
 func (w *win32Window) dispatchScrollEvent(ev gpucontext.ScrollEvent) {
-	w.callbackMu.RLock()
-	callback := w.scrollCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		callback(ev)
-	}
+	w.platform.queueEvent(Event{WindowID: w.id, Type: EventScroll, Scroll: ev})
 }
 
 func (w *win32Window) dispatchKeyEvent(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool) {
-	w.callbackMu.RLock()
-	callback := w.keyboardCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		callback(key, mods, pressed)
+	evType := EventKeyDown
+	if !pressed {
+		evType = EventKeyUp
 	}
+	w.platform.queueEvent(Event{WindowID: w.id, Type: evType, Key: key, Mods: mods})
 }
 
 // Virtual key code constants for keyboard handling.
@@ -2483,12 +2423,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		w.highSurrogate = 0
 		// Filter control characters (Ctrl+A..Z = 0x01..0x1A, DEL = 0x7F)
 		if char >= 32 && char != 127 {
-			w.callbackMu.RLock()
-			callback := w.charCallback
-			w.callbackMu.RUnlock()
-			if callback != nil {
-				callback(char)
-			}
+			p.queueEvent(Event{WindowID: w.id, Type: EventChar, Char: char})
 		}
 		return 0
 
@@ -2499,12 +2434,7 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		}
 		char := rune(wParam)
 		if char >= 32 && char != 127 {
-			w.callbackMu.RLock()
-			callback := w.charCallback
-			w.callbackMu.RUnlock()
-			if callback != nil {
-				callback(char)
-			}
+			p.queueEvent(Event{WindowID: w.id, Type: EventChar, Char: char})
 		}
 		return 0
 

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -36,6 +36,15 @@ const (
 	EventTypeClose
 	EventTypeResize
 	EventTypeFocus
+	EventTypeKeyDown
+	EventTypeKeyUp
+	EventTypeChar
+	EventTypePointerDown
+	EventTypePointerUp
+	EventTypePointerMove
+	EventTypePointerEnter
+	EventTypePointerLeave
+	EventTypeScroll
 )
 
 // PlatformEvent represents a platform event.
@@ -45,6 +54,19 @@ type PlatformEvent struct {
 	Width   int
 	Height  int
 	Focused bool // for focus events: true = gained, false = lost
+
+	// Keyboard (EventTypeKeyDown, EventTypeKeyUp)
+	Key  gpucontext.Key
+	Mods gpucontext.Modifiers
+
+	// Character input (EventTypeChar)
+	Char rune
+
+	// Pointer (EventTypePointer*)
+	Pointer gpucontext.PointerEvent
+
+	// Scroll (EventTypeScroll)
+	Scroll gpucontext.ScrollEvent
 }
 
 // xlibHandle holds the Xlib Display* pointer required for Vulkan surface creation.
@@ -93,12 +115,7 @@ type x11Window struct {
 	fullscreen      bool
 	hitTestCallback func(x, y float64) gpucontext.HitTestResult
 
-	// Callbacks for pointer, scroll, and keyboard events
-	pointerCallback  func(gpucontext.PointerEvent)
-	scrollCallback   func(gpucontext.ScrollEvent)
-	keyboardCallback func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)
-	charCallback     func(rune)
-	callbackMu       sync.RWMutex
+	callbackMu sync.RWMutex
 
 	// Graphics context for BlitPixels (software backend presentation).
 	// Lazily created on first BlitPixels call. Bound to this window's drawable.
@@ -1011,70 +1028,38 @@ func (p *Platform) Destroy() {
 	p.keymap = nil
 }
 
-// SetPointerCallback registers a callback for pointer events.
-func (p *Platform) SetPointerCallback(fn func(gpucontext.PointerEvent)) {
-	w := p.primary
-	w.callbackMu.Lock()
-	w.pointerCallback = fn
-	w.callbackMu.Unlock()
-}
-
-// SetScrollCallback registers a callback for scroll events.
-func (p *Platform) SetScrollCallback(fn func(gpucontext.ScrollEvent)) {
-	w := p.primary
-	w.callbackMu.Lock()
-	w.scrollCallback = fn
-	w.callbackMu.Unlock()
-}
-
-// SetKeyCallback registers a callback for keyboard events.
-func (p *Platform) SetKeyCallback(fn func(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool)) {
-	w := p.primary
-	w.callbackMu.Lock()
-	w.keyboardCallback = fn
-	w.callbackMu.Unlock()
-}
-
-// SetCharCallback registers a callback for Unicode character input.
-// TODO: Implement via libxkbcommon xkb_state_key_get_utf8 for full Unicode support.
-func (p *Platform) SetCharCallback(fn func(rune)) {
-	w := p.primary
-	w.callbackMu.Lock()
-	w.charCallback = fn
-	w.callbackMu.Unlock()
-}
-
-// dispatchPointerEvent dispatches a pointer event to the registered callback.
+// dispatchPointerEvent pushes a pointer event to the event queue.
 func (w *x11Window) dispatchPointerEvent(ev gpucontext.PointerEvent) {
-	w.callbackMu.RLock()
-	callback := w.pointerCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		callback(ev)
+	var evType EventType
+	switch ev.Type {
+	case gpucontext.PointerDown:
+		evType = EventTypePointerDown
+	case gpucontext.PointerUp:
+		evType = EventTypePointerUp
+	case gpucontext.PointerMove:
+		evType = EventTypePointerMove
+	case gpucontext.PointerEnter:
+		evType = EventTypePointerEnter
+	case gpucontext.PointerLeave:
+		evType = EventTypePointerLeave
+	default:
+		evType = EventTypePointerMove
 	}
+	w.queueEvent(PlatformEvent{Type: evType, Pointer: ev})
 }
 
-// dispatchScrollEvent dispatches a scroll event to the registered callback.
+// dispatchScrollEvent pushes a scroll event to the event queue.
 func (w *x11Window) dispatchScrollEvent(ev gpucontext.ScrollEvent) {
-	w.callbackMu.RLock()
-	callback := w.scrollCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		callback(ev)
-	}
+	w.queueEvent(PlatformEvent{Type: EventTypeScroll, Scroll: ev})
 }
 
-// dispatchKeyEvent dispatches a keyboard event to the registered callback.
+// dispatchKeyEvent pushes a keyboard event to the event queue.
 func (w *x11Window) dispatchKeyEvent(key gpucontext.Key, mods gpucontext.Modifiers, pressed bool) {
-	w.callbackMu.RLock()
-	callback := w.keyboardCallback
-	w.callbackMu.RUnlock()
-
-	if callback != nil {
-		callback(key, mods, pressed)
+	evType := EventTypeKeyDown
+	if !pressed {
+		evType = EventTypeKeyUp
 	}
+	w.queueEvent(PlatformEvent{Type: evType, Key: key, Mods: mods})
 }
 
 // handleKeyEvent processes a key press or release event.
@@ -1107,14 +1092,9 @@ func (p *Platform) handleKeyEvent(w *x11Window, keycode uint8, state uint16, pre
 		keysym := keymap.KeycodeToKeysym(keycode, shift, capsLock)
 		str := KeysymToString(keysym)
 		if str != "" {
-			w.callbackMu.RLock()
-			cb := w.charCallback
-			w.callbackMu.RUnlock()
-			if cb != nil {
-				for _, r := range str {
-					if r >= 32 && r != 127 {
-						cb(r)
-					}
+			for _, r := range str {
+				if r >= 32 && r != 127 {
+					w.queueEvent(PlatformEvent{Type: EventTypeChar, Char: r})
 				}
 			}
 		}

--- a/platform_provider_test.go
+++ b/platform_provider_test.go
@@ -36,16 +36,12 @@ func (m *mockWindow) PhysicalSize() (int, int) {
 	}
 	return int(float64(m.width) * s), int(float64(m.height) * s)
 }
-func (m *mockWindow) GetHandle() (uintptr, uintptr)                                   { return 0, 0 }
-func (m *mockWindow) InSizeMove() bool                                                { return false }
-func (m *mockWindow) SetTitle(_ string)                                               {}
-func (m *mockWindow) SetPointerCallback(func(gpucontext.PointerEvent))                {}
-func (m *mockWindow) SetScrollCallback(func(gpucontext.ScrollEvent))                  {}
-func (m *mockWindow) SetKeyCallback(func(gpucontext.Key, gpucontext.Modifiers, bool)) {}
-func (m *mockWindow) SetCharCallback(func(rune))                                      {}
-func (m *mockWindow) SetModalFrameCallback(func())                                    {}
-func (m *mockWindow) Destroy()                                                        {}
-func (m *mockWindow) ScaleFactor() float64                                            { return m.scaleFactor }
+func (m *mockWindow) GetHandle() (uintptr, uintptr) { return 0, 0 }
+func (m *mockWindow) InSizeMove() bool              { return false }
+func (m *mockWindow) SetTitle(_ string)             {}
+func (m *mockWindow) SetModalFrameCallback(func())  {}
+func (m *mockWindow) Destroy()                      {}
+func (m *mockWindow) ScaleFactor() float64          { return m.scaleFactor }
 func (m *mockWindow) PrepareFrame() platform.PrepareFrameResult {
 	w, h := m.PhysicalSize()
 	return platform.PrepareFrameResult{

--- a/window_manager.go
+++ b/window_manager.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/gogpu/gogpu/internal/platform"
+	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/wgpu"
 )
 
@@ -26,10 +27,15 @@ type Window struct {
 	platWindow platform.PlatformWindow // underlying platform window
 
 	// Per-window callbacks
-	onDraw   func(*Context)
-	onResize func(int, int)
-	onClose  func() bool // return false to reject close
-	visible  bool
+	onDraw       func(*Context)
+	onResize     func(int, int)
+	onClose      func() bool // return false to reject close
+	onKeyPress   func(gpucontext.Key, gpucontext.Modifiers)
+	onKeyRelease func(gpucontext.Key, gpucontext.Modifiers)
+	onTextInput  func(string)
+	onPointer    func(gpucontext.PointerEvent)
+	onScroll     func(gpucontext.ScrollEvent)
+	visible      bool
 }
 
 // ID returns the unique identifier for this window.
@@ -53,6 +59,31 @@ func (w *Window) SetOnResize(fn func(int, int)) {
 // Return false from the callback to reject the close request.
 func (w *Window) SetOnClose(fn func() bool) {
 	w.onClose = fn
+}
+
+// SetOnKeyPress sets the per-window key press callback.
+func (w *Window) SetOnKeyPress(fn func(gpucontext.Key, gpucontext.Modifiers)) {
+	w.onKeyPress = fn
+}
+
+// SetOnKeyRelease sets the per-window key release callback.
+func (w *Window) SetOnKeyRelease(fn func(gpucontext.Key, gpucontext.Modifiers)) {
+	w.onKeyRelease = fn
+}
+
+// SetOnTextInput sets the per-window text input callback.
+func (w *Window) SetOnTextInput(fn func(string)) {
+	w.onTextInput = fn
+}
+
+// SetOnPointer sets the per-window pointer event callback.
+func (w *Window) SetOnPointer(fn func(gpucontext.PointerEvent)) {
+	w.onPointer = fn
+}
+
+// SetOnScroll sets the per-window scroll event callback.
+func (w *Window) SetOnScroll(fn func(gpucontext.ScrollEvent)) {
+	w.onScroll = fn
 }
 
 // Close requests this window to close.

--- a/window_manager_test.go
+++ b/window_manager_test.go
@@ -1,0 +1,287 @@
+package gogpu
+
+import (
+	"testing"
+
+	"github.com/gogpu/gogpu/internal/platform"
+	"github.com/gogpu/gpucontext"
+)
+
+func TestWindowManager_AddGet(t *testing.T) {
+	wm := newWindowManager()
+
+	w := &Window{id: platform.NewWindowID()}
+	wm.add(w)
+
+	got := wm.get(w.id)
+	if got != w {
+		t.Error("get() should return the added window")
+	}
+}
+
+func TestWindowManager_GetUnknownID(t *testing.T) {
+	wm := newWindowManager()
+
+	got := wm.get(platform.NewWindowID())
+	if got != nil {
+		t.Error("get() should return nil for unknown ID")
+	}
+}
+
+func TestWindowManager_Remove(t *testing.T) {
+	wm := newWindowManager()
+
+	w := &Window{id: platform.NewWindowID()}
+	wm.add(w)
+	wm.remove(w.id)
+
+	if wm.get(w.id) != nil {
+		t.Error("get() should return nil after remove")
+	}
+	if wm.count() != 0 {
+		t.Errorf("count() = %d, want 0", wm.count())
+	}
+}
+
+func TestWindowManager_Count(t *testing.T) {
+	wm := newWindowManager()
+
+	if wm.count() != 0 {
+		t.Errorf("count() = %d, want 0 for empty manager", wm.count())
+	}
+
+	w1 := &Window{id: platform.NewWindowID()}
+	w2 := &Window{id: platform.NewWindowID()}
+	wm.add(w1)
+	wm.add(w2)
+
+	if wm.count() != 2 {
+		t.Errorf("count() = %d, want 2", wm.count())
+	}
+}
+
+func TestWindowManager_FocusAutoAssign(t *testing.T) {
+	wm := newWindowManager()
+
+	w1 := &Window{id: platform.NewWindowID()}
+	wm.add(w1)
+
+	if wm.focused != w1.id {
+		t.Error("first added window should receive focus automatically")
+	}
+}
+
+func TestWindowManager_FocusAfterRemove(t *testing.T) {
+	wm := newWindowManager()
+
+	w1 := &Window{id: platform.NewWindowID()}
+	w2 := &Window{id: platform.NewWindowID()}
+	wm.add(w1)
+	wm.add(w2)
+
+	wm.setFocus(w2.id)
+	wm.remove(w2.id)
+
+	if wm.focused != w1.id {
+		t.Errorf("focused = %d, want %d (first remaining window)", wm.focused, w1.id)
+	}
+}
+
+func TestWindowManager_SetFocusInvalidID(t *testing.T) {
+	wm := newWindowManager()
+
+	w := &Window{id: platform.NewWindowID()}
+	wm.add(w)
+
+	wm.setFocus(platform.NewWindowID())
+
+	if wm.focused != w.id {
+		t.Error("setFocus with unknown ID should not change focus")
+	}
+}
+
+func TestWindow_SetOnKeyPress(t *testing.T) {
+	t.Run("fires when set", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		var receivedKey gpucontext.Key
+		var receivedMods gpucontext.Modifiers
+		w.SetOnKeyPress(func(key gpucontext.Key, mods gpucontext.Modifiers) {
+			receivedKey = key
+			receivedMods = mods
+		})
+
+		w.onKeyPress(gpucontext.KeyA, gpucontext.ModShift)
+
+		if receivedKey != gpucontext.KeyA {
+			t.Errorf("key = %v, want KeyA", receivedKey)
+		}
+		if receivedMods != gpucontext.ModShift {
+			t.Errorf("mods = %v, want ModShift", receivedMods)
+		}
+	})
+
+	t.Run("nil callback safe", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		if w.onKeyPress != nil {
+			t.Error("onKeyPress should be nil by default")
+		}
+	})
+
+	t.Run("replacement", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		callCount := 0
+		w.SetOnKeyPress(func(gpucontext.Key, gpucontext.Modifiers) {
+			callCount = 1
+		})
+		w.SetOnKeyPress(func(gpucontext.Key, gpucontext.Modifiers) {
+			callCount = 2
+		})
+
+		w.onKeyPress(gpucontext.KeyB, 0)
+
+		if callCount != 2 {
+			t.Errorf("callCount = %d, want 2 (replaced callback should fire)", callCount)
+		}
+	})
+}
+
+func TestWindow_SetOnKeyRelease(t *testing.T) {
+	t.Run("fires when set", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		var receivedKey gpucontext.Key
+		w.SetOnKeyRelease(func(key gpucontext.Key, mods gpucontext.Modifiers) {
+			receivedKey = key
+		})
+
+		w.onKeyRelease(gpucontext.KeyEscape, 0)
+
+		if receivedKey != gpucontext.KeyEscape {
+			t.Errorf("key = %v, want KeyEscape", receivedKey)
+		}
+	})
+
+	t.Run("nil callback safe", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		if w.onKeyRelease != nil {
+			t.Error("onKeyRelease should be nil by default")
+		}
+	})
+}
+
+func TestWindow_SetOnTextInput(t *testing.T) {
+	t.Run("fires when set", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		var received string
+		w.SetOnTextInput(func(text string) {
+			received = text
+		})
+
+		w.onTextInput("hello")
+
+		if received != "hello" {
+			t.Errorf("text = %q, want %q", received, "hello")
+		}
+	})
+
+	t.Run("nil callback safe", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		if w.onTextInput != nil {
+			t.Error("onTextInput should be nil by default")
+		}
+	})
+}
+
+func TestWindow_SetOnPointer(t *testing.T) {
+	t.Run("fires when set", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		var received gpucontext.PointerEvent
+		w.SetOnPointer(func(ev gpucontext.PointerEvent) {
+			received = ev
+		})
+
+		ev := gpucontext.PointerEvent{
+			Type: gpucontext.PointerMove,
+			X:    42,
+			Y:    84,
+		}
+		w.onPointer(ev)
+
+		if received.X != 42 || received.Y != 84 {
+			t.Errorf("pointer = (%f, %f), want (42, 84)", received.X, received.Y)
+		}
+	})
+
+	t.Run("nil callback safe", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		if w.onPointer != nil {
+			t.Error("onPointer should be nil by default")
+		}
+	})
+}
+
+func TestWindow_SetOnScroll(t *testing.T) {
+	t.Run("fires when set", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		var received gpucontext.ScrollEvent
+		w.SetOnScroll(func(ev gpucontext.ScrollEvent) {
+			received = ev
+		})
+
+		ev := gpucontext.ScrollEvent{DeltaX: 5.5, DeltaY: -10.0}
+		w.onScroll(ev)
+
+		if received.DeltaX != 5.5 || received.DeltaY != -10.0 {
+			t.Errorf("scroll = (%f, %f), want (5.5, -10.0)", received.DeltaX, received.DeltaY)
+		}
+	})
+
+	t.Run("nil callback safe", func(t *testing.T) {
+		w := &Window{id: platform.NewWindowID()}
+		if w.onScroll != nil {
+			t.Error("onScroll should be nil by default")
+		}
+	})
+}
+
+func TestWindow_ID(t *testing.T) {
+	id := platform.NewWindowID()
+	w := &Window{id: id}
+
+	if w.ID() != id {
+		t.Errorf("ID() = %d, want %d", w.ID(), id)
+	}
+}
+
+func TestWindow_SizeNilPlatform(t *testing.T) {
+	w := &Window{
+		config: Config{Width: 640, Height: 480},
+	}
+
+	width, height := w.Size()
+	if width != 640 || height != 480 {
+		t.Errorf("Size() = (%d, %d), want (640, 480)", width, height)
+	}
+}
+
+func TestWindow_PhysicalSizeNilPlatform(t *testing.T) {
+	w := &Window{
+		config: Config{Width: 800, Height: 600},
+	}
+
+	width, height := w.PhysicalSize()
+	if width != 800 || height != 600 {
+		t.Errorf("PhysicalSize() = (%d, %d), want (800, 600)", width, height)
+	}
+}
+
+func TestWindow_Visible(t *testing.T) {
+	w := &Window{visible: true}
+	if !w.Visible() {
+		t.Error("Visible() should return true")
+	}
+
+	w.visible = false
+	if w.Visible() {
+		t.Error("Visible() should return false")
+	}
+}


### PR DESCRIPTION
## Summary

- Unify all platform input events through `PollEvents()` with `WindowID` tagging (winit/SDL3/Qt6 pattern)
- Secondary windows now receive keyboard, pointer, scroll, and char events
- Add per-window input callbacks: `SetOnKeyPress`, `SetOnKeyRelease`, `SetOnTextInput`, `SetOnPointer`, `SetOnScroll`
- Remove per-window callback registration from `PlatformWindow` interface
- 54 new tests (dispatch routing, multi-window isolation, callback setters)

Fixes #210

## Architecture (ADR-021)

All input events now flow through centralized `PollEvents()` — same path as close/resize/focus. Removes the dual dispatch path (centralized for lifecycle + per-window callbacks for input) that was the root cause of #210.

```
Platform (Win32/macOS/X11/Wayland)
    OS callbacks → Event{WindowID, Type, payload} → queue
    PollEvents() drains queue

App (app.go)
    classifyEvent() → dispatch by WindowID:
        per-window callback (if set)
        app-level EventSource (for UI frameworks)
        InputState (for Ebiten-style polling)
```

## Changed files (14)

| File | Change |
|------|--------|
| `internal/platform/platform.go` | +9 EventTypes, +5 Event payload fields, -4 callback methods from PlatformWindow |
| `internal/platform/platform_windows.go` | Push input to `queueEvent()` instead of callbacks |
| `internal/platform/platform_darwin.go` | Push input to `w.events` instead of callbacks |
| `internal/platform/platform_linux.go` | Push input to queue (X11 + Wayland) |
| `internal/platform/x11/platform.go` | Extend PlatformEvent with input types |
| `app.go` | Centralized dispatch, remove `setupInputEvents()` |
| `window_manager.go` | Per-window input callback fields + setters |
| `dispatch_test.go` | 29 dispatch tests |
| `window_manager_test.go` | 19 WindowManager + callback tests |
| `internal/platform/platform_test.go` | 4 EventType tests |
| `CHANGELOG.md` | v0.32.1 entry |
| `README.md` | Multi-Window Input section |
| `ROADMAP.md` | v0.32.1 entry + multi-window checklist |

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass (54 new tests)
- [x] `golangci-lint run` — 0 issues (Windows, Linux, macOS)
- [x] `go fmt ./...` — clean
- [ ] CI (all platforms)
- [ ] Backend smoke test (Vulkan, GLES, Software)
