### PR TITLE
feat: SubpixelLayout detection on all platforms (ADR-024, v0.33.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] - 2026-05-09
+
+### Added
+
+- **SubpixelLayout detection** (ADR-024) — auto-detect display subpixel arrangement for LCD/ClearType font rendering. Windows: SystemParametersInfo + Avalon.Graphics registry (Qt6 pattern). macOS: SubpixelNone (dead since Mojave). Linux X11: Xft.rgba from X resources + HiDPI check. Linux Wayland: fontconfig XML + HiDPI env vars. 27+ tests across all platforms. Zero CGO.
+
+### Changed
+
+- **deps:** gpucontext v0.17.0 → v0.18.0 (SubpixelLayout on PlatformProvider)
+
 ## [0.32.3] - 2026-05-08
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,6 +60,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.33.0** | 2026-05-09 | **SubpixelLayout detection** (ADR-024) — LCD/ClearType auto-detect, all platforms, gpucontext v0.18.0 |
 | **v0.32.3** | 2026-05-08 | **Three-mode render loop** (ADR-023) — IDLE/ANIMATING/CONTINUOUS, lazy acquire, 10%→<1% GPU for UI |
 | **v0.32.2** | 2026-05-07 | Fix EventSource callback loss on Run() — lazy init for pre-Run() registrations |
 | **v0.32.1** | 2026-05-07 | **Centralized input dispatch** (ADR-021, #210, @lkmavi) — multi-window input fix, per-window callbacks, 54 tests |

--- a/app.go
+++ b/app.go
@@ -802,6 +802,16 @@ func (a *App) FontScale() float32 {
 	return 1.0
 }
 
+// SubpixelLayout returns the display's subpixel arrangement for LCD text rendering.
+// Returns SubpixelNone when the manager is not initialized or on HiDPI displays.
+// Implements gpucontext.PlatformProvider.
+func (a *App) SubpixelLayout() gpucontext.SubpixelLayout {
+	if a.manager != nil {
+		return a.manager.SubpixelLayout()
+	}
+	return gpucontext.SubpixelNone
+}
+
 // SetFrameless enables or disables frameless window mode.
 // Implements gpucontext.WindowChrome.
 func (a *App) SetFrameless(frameless bool) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,6 +251,16 @@ naga (shader)              wgpu              go-webgpu/webgpu
 - gg GPU accelerator uses `*wgpu.Device`/`*wgpu.Queue` for render pipeline dispatch
 - All projects use compatible `gputypes.TextureFormat` etc.
 
+**gpucontext interfaces:**
+
+| Interface | Purpose | Implementor |
+|-----------|---------|-------------|
+| `DeviceProvider` | GPU device/queue/format sharing | gogpu.App |
+| `PlatformProvider` | OS capabilities (DarkMode, FontScale, SubpixelLayout) | gogpu.App |
+| `EventSource` | Input events (keyboard, mouse, scroll, IME) | gogpu.App |
+| `WindowProvider` | Window size, scale factor | gogpu.App |
+| `WindowChrome` | Frameless windows, fullscreen | gogpu.App |
+
 ## Package Structure
 
 ### gogpu

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/go-webgpu/webgpu v0.4.3
-	github.com/gogpu/gpucontext v0.17.0
+	github.com/gogpu/gpucontext v0.18.0
 	github.com/gogpu/gputypes v0.5.0
 	github.com/gogpu/wgpu v0.27.1
 	golang.org/x/sys v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=
-github.com/gogpu/gpucontext v0.17.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
+github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
+github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.13 h1:VlponVgD1fEfNotx0874M4n7tnfum8YlMEB3pBdd2Ps=

--- a/internal/platform/desktop_linux.go
+++ b/internal/platform/desktop_linux.go
@@ -7,6 +7,14 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/gogpu/gpucontext"
+)
+
+// Linux desktop environment variable names used for display scale detection.
+const (
+	envGDKScale      = "GDK_SCALE"
+	envQTScaleFactor = "QT_SCALE_FACTOR"
 )
 
 // detectDarkMode checks environment variables and desktop settings to determine
@@ -77,6 +85,111 @@ func detectReduceMotion() bool {
 	// No reliable environment-only detection without D-Bus.
 	// D-Bus portal (org.freedesktop.portal.Settings) would be the proper solution.
 	return false
+}
+
+// detectSubpixelLayout determines the subpixel layout from environment
+// variables and fontconfig settings. Used as a fallback for Wayland
+// (which cannot read X resources) and when X11 RESOURCE_MANAGER is unavailable.
+//
+// Detection order:
+//  1. GDK_SCALE / QT_SCALE_FACTOR >= 2 → SubpixelNone (HiDPI, subpixels too small)
+//  2. Fontconfig config files (~/.config/fontconfig/fonts.conf or /etc/fonts/local.conf)
+//     <match><edit name="rgba"><const>rgb</const></edit></match>
+//  3. Default to SubpixelRGB (most common LCD arrangement)
+func detectSubpixelLayout() gpucontext.SubpixelLayout {
+	// HiDPI displays should use grayscale AA — subpixels are too small to matter.
+	if isHiDPI() {
+		return gpucontext.SubpixelNone
+	}
+
+	// Check fontconfig user config (~/.config/fontconfig/fonts.conf)
+	if layout, ok := parseFontconfigRGBA(userFontconfigPath()); ok {
+		return layout
+	}
+
+	// Check fontconfig system config
+	if layout, ok := parseFontconfigRGBA("/etc/fonts/local.conf"); ok {
+		return layout
+	}
+
+	// Default: RGB is the most common subpixel arrangement for LCDs.
+	return gpucontext.SubpixelRGB
+}
+
+// isHiDPI returns true if environment variables indicate HiDPI (scale >= 2.0).
+func isHiDPI() bool {
+	for _, envVar := range []string{envGDKScale, envQTScaleFactor} {
+		if s := os.Getenv(envVar); s != "" {
+			if v, err := strconv.ParseFloat(s, 64); err == nil && v >= 2.0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// userFontconfigPath returns the path to the user's fontconfig configuration file.
+func userFontconfigPath() string {
+	configDir := os.Getenv("XDG_CONFIG_HOME")
+	if configDir == "" {
+		home := os.Getenv("HOME")
+		if home == "" {
+			return ""
+		}
+		configDir = filepath.Join(home, ".config")
+	}
+	return filepath.Join(configDir, "fontconfig", "fonts.conf")
+}
+
+// parseFontconfigRGBA reads a fontconfig XML file and looks for an rgba setting.
+// Fontconfig uses XML like: <edit name="rgba"><const>rgb</const></edit>
+// Returns the layout and true if found, false otherwise.
+func parseFontconfigRGBA(path string) (gpucontext.SubpixelLayout, bool) {
+	if path == "" {
+		return gpucontext.SubpixelNone, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return gpucontext.SubpixelNone, false
+	}
+
+	content := string(data)
+
+	// Simple text search for the rgba const value in fontconfig XML.
+	// We look for patterns like: name="rgba"...<const>rgb</const>
+	// This avoids pulling in an XML parser for a single config value.
+	idx := strings.Index(content, `name="rgba"`)
+	if idx < 0 {
+		return gpucontext.SubpixelNone, false
+	}
+
+	// Find the <const> value after the rgba attribute.
+	rest := content[idx:]
+	constStart := strings.Index(rest, "<const>")
+	if constStart < 0 {
+		return gpucontext.SubpixelNone, false
+	}
+	rest = rest[constStart+len("<const>"):]
+	constEnd := strings.Index(rest, "</const>")
+	if constEnd < 0 {
+		return gpucontext.SubpixelNone, false
+	}
+
+	value := strings.TrimSpace(rest[:constEnd])
+	switch strings.ToLower(value) {
+	case "rgb":
+		return gpucontext.SubpixelRGB, true
+	case "bgr":
+		return gpucontext.SubpixelBGR, true
+	case "vrgb":
+		return gpucontext.SubpixelVRGB, true
+	case "vbgr":
+		return gpucontext.SubpixelVBGR, true
+	case "none":
+		return gpucontext.SubpixelNone, true
+	default:
+		return gpucontext.SubpixelNone, false
+	}
 }
 
 // isKDE returns true if the current desktop environment is KDE Plasma.

--- a/internal/platform/desktop_linux_test.go
+++ b/internal/platform/desktop_linux_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gogpu/gpucontext"
 )
 
 func TestDetectDarkMode(t *testing.T) {
@@ -241,5 +243,184 @@ func TestIsDarkKDEColorScheme(t *testing.T) {
 	os.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "nonexistent"))
 	if isDarkKDEColorScheme() {
 		t.Error("isDarkKDEColorScheme() = true with no config file")
+	}
+}
+
+func TestIsHiDPI(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		want    bool
+	}{
+		{"no env vars", map[string]string{}, false},
+		{"GDK_SCALE=1", map[string]string{"GDK_SCALE": "1"}, false},
+		{"GDK_SCALE=2", map[string]string{"GDK_SCALE": "2"}, true},
+		{"GDK_SCALE=3", map[string]string{"GDK_SCALE": "3"}, true},
+		{"QT_SCALE_FACTOR=1.5", map[string]string{"QT_SCALE_FACTOR": "1.5"}, false},
+		{"QT_SCALE_FACTOR=2", map[string]string{"QT_SCALE_FACTOR": "2"}, true},
+		{"invalid value", map[string]string{"GDK_SCALE": "abc"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			savedGDK := os.Getenv("GDK_SCALE")
+			savedQT := os.Getenv("QT_SCALE_FACTOR")
+			defer func() {
+				os.Setenv("GDK_SCALE", savedGDK)
+				os.Setenv("QT_SCALE_FACTOR", savedQT)
+			}()
+
+			os.Unsetenv("GDK_SCALE")
+			os.Unsetenv("QT_SCALE_FACTOR")
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+			}
+
+			got := isHiDPI()
+			if got != tt.want {
+				t.Errorf("isHiDPI() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFontconfigRGBA(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantOK     bool
+		wantLayout gpucontext.SubpixelLayout
+	}{
+		{
+			name:       "rgb",
+			content:    `<match><edit name="rgba" mode="assign"><const>rgb</const></edit></match>`,
+			wantOK:     true,
+			wantLayout: gpucontext.SubpixelRGB,
+		},
+		{
+			name:       "bgr",
+			content:    `<match><edit name="rgba" mode="assign"><const>bgr</const></edit></match>`,
+			wantOK:     true,
+			wantLayout: gpucontext.SubpixelBGR,
+		},
+		{
+			name:       "vrgb",
+			content:    `<match><edit name="rgba" mode="assign"><const>vrgb</const></edit></match>`,
+			wantOK:     true,
+			wantLayout: gpucontext.SubpixelVRGB,
+		},
+		{
+			name:       "vbgr",
+			content:    `<match><edit name="rgba" mode="assign"><const>vbgr</const></edit></match>`,
+			wantOK:     true,
+			wantLayout: gpucontext.SubpixelVBGR,
+		},
+		{
+			name:       "none",
+			content:    `<match><edit name="rgba" mode="assign"><const>none</const></edit></match>`,
+			wantOK:     true,
+			wantLayout: gpucontext.SubpixelNone,
+		},
+		{
+			name:       "no rgba setting",
+			content:    `<match><edit name="antialias"><bool>true</bool></edit></match>`,
+			wantOK:     false,
+			wantLayout: gpucontext.SubpixelNone,
+		},
+		{
+			name:       "empty file",
+			content:    "",
+			wantOK:     false,
+			wantLayout: gpucontext.SubpixelNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			path := filepath.Join(tmpDir, "fonts.conf")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			layout, ok := parseFontconfigRGBA(path)
+			if ok != tt.wantOK {
+				t.Errorf("parseFontconfigRGBA() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if layout != tt.wantLayout {
+				t.Errorf("parseFontconfigRGBA() layout = %v, want %v", layout, tt.wantLayout)
+			}
+		})
+	}
+}
+
+func TestParseFontconfigRGBA_NonexistentFile(t *testing.T) {
+	layout, ok := parseFontconfigRGBA("/nonexistent/path/fonts.conf")
+	if ok {
+		t.Error("parseFontconfigRGBA() ok = true for nonexistent file")
+	}
+	if layout != gpucontext.SubpixelNone {
+		t.Errorf("parseFontconfigRGBA() = %v, want SubpixelNone", layout)
+	}
+}
+
+func TestParseFontconfigRGBA_EmptyPath(t *testing.T) {
+	layout, ok := parseFontconfigRGBA("")
+	if ok {
+		t.Error("parseFontconfigRGBA() ok = true for empty path")
+	}
+	if layout != gpucontext.SubpixelNone {
+		t.Errorf("parseFontconfigRGBA() = %v, want SubpixelNone", layout)
+	}
+}
+
+func TestDetectSubpixelLayout(t *testing.T) {
+	// Save and restore env vars
+	savedGDK := os.Getenv("GDK_SCALE")
+	savedQT := os.Getenv("QT_SCALE_FACTOR")
+	savedConfig := os.Getenv("XDG_CONFIG_HOME")
+	savedHome := os.Getenv("HOME")
+	defer func() {
+		os.Setenv("GDK_SCALE", savedGDK)
+		os.Setenv("QT_SCALE_FACTOR", savedQT)
+		os.Setenv("XDG_CONFIG_HOME", savedConfig)
+		os.Setenv("HOME", savedHome)
+	}()
+
+	// Test 1: HiDPI returns SubpixelNone
+	os.Setenv("GDK_SCALE", "2")
+	os.Setenv("XDG_CONFIG_HOME", "/nonexistent")
+	os.Unsetenv("HOME")
+	got := detectSubpixelLayout()
+	if got != gpucontext.SubpixelNone {
+		t.Errorf("detectSubpixelLayout() with HiDPI = %v, want SubpixelNone", got)
+	}
+
+	// Test 2: Non-HiDPI with fontconfig
+	os.Unsetenv("GDK_SCALE")
+	os.Unsetenv("QT_SCALE_FACTOR")
+	tmpDir := t.TempDir()
+	fontconfigDir := filepath.Join(tmpDir, "fontconfig")
+	if err := os.MkdirAll(fontconfigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	fontconfigFile := filepath.Join(fontconfigDir, "fonts.conf")
+	if err := os.WriteFile(fontconfigFile, []byte(
+		`<match><edit name="rgba" mode="assign"><const>bgr</const></edit></match>`,
+	), 0644); err != nil {
+		t.Fatal(err)
+	}
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	got = detectSubpixelLayout()
+	if got != gpucontext.SubpixelBGR {
+		t.Errorf("detectSubpixelLayout() with fontconfig bgr = %v, want SubpixelBGR", got)
+	}
+
+	// Test 3: No fontconfig, no HiDPI → default RGB
+	os.Setenv("XDG_CONFIG_HOME", "/nonexistent")
+	os.Setenv("HOME", "/nonexistent")
+	got = detectSubpixelLayout()
+	if got != gpucontext.SubpixelRGB {
+		t.Errorf("detectSubpixelLayout() default = %v, want SubpixelRGB", got)
 	}
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -134,6 +134,9 @@ type PlatformManager interface {
 	// FontScale returns font size preference multiplier.
 	FontScale() float32
 
+	// SubpixelLayout returns the display's subpixel arrangement for LCD text.
+	SubpixelLayout() gpucontext.SubpixelLayout
+
 	// Destroy releases all platform resources.
 	Destroy()
 }

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -1240,6 +1240,13 @@ func (p *darwinPlatform) HighContrast() bool {
 // Individual apps control their own text sizing. Returns 1.0 (no scaling).
 func (p *darwinPlatform) FontScale() float32 { return 1.0 }
 
+// SubpixelLayout returns the display's subpixel arrangement for LCD text rendering.
+// macOS disabled subpixel antialiasing system-wide starting with Mojave (10.14, 2018).
+// All modern macOS versions use grayscale AA only.
+func (p *darwinPlatform) SubpixelLayout() gpucontext.SubpixelLayout {
+	return gpucontext.SubpixelNone
+}
+
 // detectModifierKeyChange detects which modifier key was pressed/released.
 // macOS sends NSEventTypeFlagsChanged for modifier keys instead of keyDown/keyUp.
 func detectModifierKeyChange(keyCode uint16, flags darwin.NSEventModifierFlags) (gpucontext.Key, bool) {

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -223,6 +223,15 @@ func (p *x11Platform) ClipboardRead() (string, error) { return "", nil }
 // TODO(PLAT-008): Implement using X11 selections (XA_CLIPBOARD).
 func (p *x11Platform) ClipboardWrite(string) error { return nil }
 
+// SubpixelLayout returns the display's subpixel arrangement for LCD text rendering.
+// Delegates to the X11 platform which reads Xft.rgba from RESOURCE_MANAGER.
+func (p *x11Platform) SubpixelLayout() gpucontext.SubpixelLayout {
+	if p.inner != nil {
+		return p.inner.SubpixelLayout()
+	}
+	return gpucontext.SubpixelRGB
+}
+
 // DarkMode returns true if the system dark mode is active.
 func (p *x11Platform) DarkMode() bool { return detectDarkMode() }
 
@@ -1822,6 +1831,12 @@ func (p *waylandPlatform) ClipboardRead() (string, error) { return "", nil }
 // ClipboardWrite writes text to the system clipboard.
 // TODO(PLAT-008): Implement using wl_data_device and wl_data_source.
 func (p *waylandPlatform) ClipboardWrite(string) error { return nil }
+
+// SubpixelLayout returns the display's subpixel arrangement for LCD text rendering.
+// Wayland does not expose X resources, so this falls back to fontconfig detection.
+func (p *waylandPlatform) SubpixelLayout() gpucontext.SubpixelLayout {
+	return detectSubpixelLayout()
+}
 
 // DarkMode returns true if the system dark mode is active.
 func (p *waylandPlatform) DarkMode() bool { return detectDarkMode() }

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -146,9 +146,15 @@ const (
 	gmemMoveable  = 0x0002
 
 	// SystemParametersInfo constants
-	spiGetClientAreaAnimation = 0x1042
-	spiGetHighContrast        = 0x0042
-	hcfHighContrastOn         = 0x00000001
+	spiGetClientAreaAnimation  = 0x1042
+	spiGetHighContrast         = 0x0042
+	spiGetFontSmoothing        = 0x004A
+	spiGetFontSmoothingType    = 0x200A
+	fontSmoothingTypeClearType = 2
+	hcfHighContrastOn          = 0x00000001
+
+	// Registry: HKEY_LOCAL_MACHINE for subpixel layout
+	hkeyLocalMachine uintptr = 0x80000002
 
 	// Frameless window constants
 	wsPopup            = 0x80000000 // WS_POPUP
@@ -1177,6 +1183,79 @@ func (p *windowsPlatform) HighContrast() bool {
 // On Windows, font scale is derived from the DPI scale factor.
 func (p *windowsPlatform) FontScale() float32 {
 	return float32(p.ScaleFactor())
+}
+
+// SubpixelLayout returns the display's subpixel arrangement for LCD text rendering.
+// Detection follows Qt6's pattern (qwindowsscreen.cpp):
+//  1. Check if font smoothing is enabled (SPI_GETFONTSMOOTHING)
+//  2. Check if ClearType is the smoothing type (SPI_GETFONTSMOOTHINGTYPE)
+//  3. Read PixelStructure from registry (Avalon.Graphics\DISPLAY1)
+//     0=flat/grayscale, 1=RGB, 2=BGR. Default RGB if ClearType is on.
+func (p *windowsPlatform) SubpixelLayout() gpucontext.SubpixelLayout {
+	// Step 1: Check if font smoothing is enabled at all.
+	var enabled uint32
+	ret, _, _ := procSystemParametersInfoW.Call(
+		spiGetFontSmoothing, 0,
+		uintptr(unsafe.Pointer(&enabled)), 0,
+	)
+	if ret == 0 || enabled == 0 {
+		return gpucontext.SubpixelNone
+	}
+
+	// Step 2: Check if ClearType (subpixel) smoothing is active, not Standard (grayscale).
+	var smoothingType uint32
+	ret, _, _ = procSystemParametersInfoW.Call(
+		spiGetFontSmoothingType, 0,
+		uintptr(unsafe.Pointer(&smoothingType)), 0,
+	)
+	if ret == 0 || smoothingType != fontSmoothingTypeClearType {
+		return gpucontext.SubpixelNone
+	}
+
+	// Step 3: Read pixel structure from registry.
+	// HKLM\SOFTWARE\Microsoft\Avalon.Graphics\DISPLAY1\PixelStructure
+	// Values: 0=flat(grayscale), 1=RGB, 2=BGR.
+	keyPath, _ := windows.UTF16PtrFromString(`SOFTWARE\Microsoft\Avalon.Graphics\DISPLAY1`)
+	valueName, _ := windows.UTF16PtrFromString("PixelStructure")
+
+	var key uintptr
+	ret, _, _ = procRegOpenKeyExW.Call(
+		hkeyLocalMachine,
+		uintptr(unsafe.Pointer(keyPath)),
+		0, keyRead,
+		uintptr(unsafe.Pointer(&key)),
+	)
+	if ret != 0 {
+		// Registry key not found — ClearType is on but no pixel structure set.
+		// Default to RGB (most common LCD arrangement).
+		return gpucontext.SubpixelRGB
+	}
+	defer procRegCloseKey.Call(key) // RegCloseKey error is non-actionable
+
+	var pixelStructure uint32
+	var valueSize uint32 = 4
+	var valueType uint32
+	ret, _, _ = procRegQueryValueExW.Call(
+		key,
+		uintptr(unsafe.Pointer(valueName)),
+		0,
+		uintptr(unsafe.Pointer(&valueType)),
+		uintptr(unsafe.Pointer(&pixelStructure)),
+		uintptr(unsafe.Pointer(&valueSize)),
+	)
+	if ret != 0 {
+		return gpucontext.SubpixelRGB // default when ClearType is on
+	}
+
+	switch pixelStructure {
+	case 1:
+		return gpucontext.SubpixelRGB
+	case 2:
+		return gpucontext.SubpixelBGR
+	default:
+		// 0 = flat/grayscale. Unusual with ClearType on, but respect it.
+		return gpucontext.SubpixelNone
+	}
 }
 
 func (p *windowsPlatform) SetCursorMode(mode int) {

--- a/internal/platform/x11/dpi_test.go
+++ b/internal/platform/x11/dpi_test.go
@@ -4,6 +4,8 @@ package x11
 
 import (
 	"testing"
+
+	"github.com/gogpu/gpucontext"
 )
 
 func TestParseXftDPI(t *testing.T) {
@@ -84,6 +86,94 @@ func TestParseXftDPI(t *testing.T) {
 			got := parseXftDPI(tt.resources)
 			if got != tt.want {
 				t.Errorf("parseXftDPI() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseXftRGBA(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources string
+		want      gpucontext.SubpixelLayout
+	}{
+		{
+			name:      "rgb layout",
+			resources: "Xft.rgba:\trgb\n",
+			want:      gpucontext.SubpixelRGB,
+		},
+		{
+			name:      "bgr layout",
+			resources: "Xft.rgba:\tbgr\n",
+			want:      gpucontext.SubpixelBGR,
+		},
+		{
+			name:      "vrgb layout",
+			resources: "Xft.rgba:\tvrgb\n",
+			want:      gpucontext.SubpixelVRGB,
+		},
+		{
+			name:      "vbgr layout",
+			resources: "Xft.rgba:\tvbgr\n",
+			want:      gpucontext.SubpixelVBGR,
+		},
+		{
+			name:      "none layout",
+			resources: "Xft.rgba:\tnone\n",
+			want:      gpucontext.SubpixelNone,
+		},
+		{
+			name:      "space separator",
+			resources: "Xft.rgba: rgb\n",
+			want:      gpucontext.SubpixelRGB,
+		},
+		{
+			name:      "among other resources",
+			resources: "Xft.antialias:\t1\nXft.hinting:\t1\nXft.dpi:\t168\nXft.rgba:\tbgr\n",
+			want:      gpucontext.SubpixelBGR,
+		},
+		{
+			name:      "no Xft.rgba present",
+			resources: "Xft.antialias:\t1\nXft.hinting:\t1\n",
+			want:      gpucontext.SubpixelRGB, // default
+		},
+		{
+			name:      "empty string",
+			resources: "",
+			want:      gpucontext.SubpixelRGB, // default
+		},
+		{
+			name:      "uppercase RGB",
+			resources: "Xft.rgba:\tRGB\n",
+			want:      gpucontext.SubpixelRGB,
+		},
+		{
+			name:      "mixed case",
+			resources: "Xft.rgba:\tBgr\n",
+			want:      gpucontext.SubpixelBGR,
+		},
+		{
+			name:      "unknown value defaults to RGB",
+			resources: "Xft.rgba:\tunknown\n",
+			want:      gpucontext.SubpixelRGB,
+		},
+		{
+			name:      "no trailing newline",
+			resources: "Xft.rgba:\trgb",
+			want:      gpucontext.SubpixelRGB,
+		},
+		{
+			name:      "whitespace around value",
+			resources: "Xft.rgba:  bgr  \n",
+			want:      gpucontext.SubpixelBGR,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseXftRGBA(tt.resources)
+			if got != tt.want {
+				t.Errorf("parseXftRGBA() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -477,6 +477,64 @@ func parseXftDPI(resources string) float64 {
 	return 0
 }
 
+// SubpixelLayout returns the display's subpixel arrangement by reading
+// Xft.rgba from the X RESOURCE_MANAGER property on the root window.
+// Returns SubpixelNone if the X connection is not available, Xft.rgba
+// is not set, or the scale factor indicates HiDPI (>= 2.0).
+func (p *Platform) SubpixelLayout() gpucontext.SubpixelLayout {
+	// HiDPI displays use grayscale AA (subpixels too small to matter).
+	if p.scaleFactor >= 2.0 {
+		return gpucontext.SubpixelNone
+	}
+
+	if p.conn == nil {
+		return gpucontext.SubpixelNone
+	}
+
+	rootWindow := p.conn.RootWindow()
+	if rootWindow == 0 {
+		return gpucontext.SubpixelRGB
+	}
+
+	data, _, _, err := p.conn.GetProperty(rootWindow, AtomResourceManager, Atom(0), 0, 8192, false)
+	if err != nil || len(data) == 0 {
+		return gpucontext.SubpixelRGB
+	}
+
+	return parseXftRGBA(string(data))
+}
+
+// parseXftRGBA parses the Xft.rgba value from an X RESOURCE_MANAGER string.
+// The string contains lines like "Xft.rgba:\trgb" or "Xft.rgba: bgr".
+// Valid values: "rgb", "bgr", "vrgb", "vbgr", "none".
+// Returns SubpixelRGB if Xft.rgba is not found (most common LCD default).
+func parseXftRGBA(resources string) gpucontext.SubpixelLayout {
+	for _, line := range strings.Split(resources, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Xft.rgba:") {
+			continue
+		}
+		value := strings.TrimSpace(line[len("Xft.rgba:"):])
+		value = strings.ToLower(value)
+		switch value {
+		case "rgb":
+			return gpucontext.SubpixelRGB
+		case "bgr":
+			return gpucontext.SubpixelBGR
+		case "vrgb":
+			return gpucontext.SubpixelVRGB
+		case "vbgr":
+			return gpucontext.SubpixelVBGR
+		case "none":
+			return gpucontext.SubpixelNone
+		default:
+			return gpucontext.SubpixelRGB
+		}
+	}
+	// Xft.rgba not set — default to RGB (most common LCD layout).
+	return gpucontext.SubpixelRGB
+}
+
 // PollEvents processes pending X11 events.
 func (p *Platform) PollEvents() PlatformEvent {
 	w := p.primary

--- a/platform_provider_test.go
+++ b/platform_provider_test.go
@@ -68,27 +68,29 @@ func (m *mockWindow) Close()               { m.closed = true }
 
 // mockManager implements platform.PlatformManager for testing.
 type mockManager struct {
-	clipboardText string
-	darkMode      bool
-	reduceMotion  bool
-	highContrast  bool
-	fontScale     float32
+	clipboardText  string
+	darkMode       bool
+	reduceMotion   bool
+	highContrast   bool
+	fontScale      float32
+	subpixelLayout gpucontext.SubpixelLayout
 }
 
 func (m *mockManager) Init() error { return nil }
 func (m *mockManager) CreateWindow(platform.Config) (platform.PlatformWindow, error) {
 	return &mockWindow{}, nil
 }
-func (m *mockManager) PollEvents() platform.Event       { return platform.Event{} }
-func (m *mockManager) WaitEvents()                      {}
-func (m *mockManager) WakeUp()                          {}
-func (m *mockManager) ClipboardRead() (string, error)   { return m.clipboardText, nil }
-func (m *mockManager) ClipboardWrite(text string) error { m.clipboardText = text; return nil }
-func (m *mockManager) DarkMode() bool                   { return m.darkMode }
-func (m *mockManager) ReduceMotion() bool               { return m.reduceMotion }
-func (m *mockManager) HighContrast() bool               { return m.highContrast }
-func (m *mockManager) FontScale() float32               { return m.fontScale }
-func (m *mockManager) Destroy()                         {}
+func (m *mockManager) PollEvents() platform.Event                { return platform.Event{} }
+func (m *mockManager) WaitEvents()                               {}
+func (m *mockManager) WakeUp()                                   {}
+func (m *mockManager) ClipboardRead() (string, error)            { return m.clipboardText, nil }
+func (m *mockManager) ClipboardWrite(text string) error          { m.clipboardText = text; return nil }
+func (m *mockManager) DarkMode() bool                            { return m.darkMode }
+func (m *mockManager) ReduceMotion() bool                        { return m.reduceMotion }
+func (m *mockManager) HighContrast() bool                        { return m.highContrast }
+func (m *mockManager) FontScale() float32                        { return m.fontScale }
+func (m *mockManager) SubpixelLayout() gpucontext.SubpixelLayout { return m.subpixelLayout }
+func (m *mockManager) Destroy()                                  {}
 
 // TestWindowProviderInterface verifies App implements gpucontext.WindowProvider.
 func TestWindowProviderInterface(t *testing.T) {
@@ -169,6 +171,13 @@ func TestPlatformProviderNilPlatform(t *testing.T) {
 			t.Errorf("FontScale() = %f, want 1.0", fs)
 		}
 	})
+
+	t.Run("SubpixelLayout", func(t *testing.T) {
+		sl := app.SubpixelLayout()
+		if sl != gpucontext.SubpixelNone {
+			t.Errorf("SubpixelLayout() = %v, want SubpixelNone", sl)
+		}
+	})
 }
 
 // TestWindowProviderDelegation verifies App delegates to platform correctly.
@@ -198,11 +207,12 @@ func TestWindowProviderDelegation(t *testing.T) {
 // TestPlatformProviderDelegation verifies App delegates PlatformProvider to platform.
 func TestPlatformProviderDelegation(t *testing.T) {
 	mockMgr := &mockManager{
-		clipboardText: "hello from clipboard",
-		darkMode:      true,
-		reduceMotion:  true,
-		highContrast:  true,
-		fontScale:     1.5,
+		clipboardText:  "hello from clipboard",
+		darkMode:       true,
+		reduceMotion:   true,
+		highContrast:   true,
+		fontScale:      1.5,
+		subpixelLayout: gpucontext.SubpixelBGR,
 	}
 	mockWin := &mockWindow{
 		width:       800,
@@ -295,6 +305,13 @@ func TestPlatformProviderDelegation(t *testing.T) {
 			t.Errorf("FontScale() = %f, want 1.5", fs)
 		}
 	})
+
+	t.Run("SubpixelLayout", func(t *testing.T) {
+		sl := app.SubpixelLayout()
+		if sl != gpucontext.SubpixelBGR {
+			t.Errorf("SubpixelLayout() = %v, want SubpixelBGR", sl)
+		}
+	})
 }
 
 // TestPlatformProviderFalseValues verifies delegation when platform returns false/default values.
@@ -315,5 +332,10 @@ func TestPlatformProviderFalseValues(t *testing.T) {
 	text, _ := app.ClipboardRead()
 	if text != "" {
 		t.Errorf("ClipboardRead() = %q, want empty", text)
+	}
+
+	sl := app.SubpixelLayout()
+	if sl != gpucontext.SubpixelNone {
+		t.Errorf("SubpixelLayout() = %v, want SubpixelNone (default)", sl)
 	}
 }


### PR DESCRIPTION
## Summary

- Auto-detect display subpixel arrangement for LCD/ClearType font rendering
- Windows: SystemParametersInfo + Avalon.Graphics registry (Qt6 pattern)
- macOS: SubpixelNone (dead since Mojave 10.14)
- Linux X11: Xft.rgba from X resources + HiDPI check
- Linux Wayland: fontconfig XML + HiDPI env vars
- 27+ tests across all platforms, zero CGO
- deps: gpucontext v0.17.0 → v0.18.0 (SubpixelLayout on PlatformProvider)

## Verified

- gg LCD ClearType text rendering: sharp text at 12-32px (screenshot confirmed)
- Lint 0 issues on Windows, Linux, macOS
- All tests pass

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues (3 platforms)
- [x] Visual: LCD ClearType text at multiple sizes
- [ ] CI