### PR TITLE
feat: platform system sounds for UI feedback (ADR-025, v0.34.0)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,7 +141,7 @@ linters:
           - funlen       # Backend wrappers have many methods
           - dupl         # Backend methods are similar by design
 
-      # Platform abstraction - platform-specific code
+      # Platform abstraction - platform-specific code (Win32/Cocoa/X11/Wayland FFI)
       - path: internal/platform/.*\.go
         linters:
           - gocyclo      # Platform code can be complex
@@ -149,6 +149,10 @@ linters:
           - funlen       # Win32 code is verbose
           - gosec        # Platform syscalls are intentional
           - errcheck     # Win32 syscall returns are often ignored
+          - dupl         # FFI wrappers intentionally similar per type (SendRect/SendSize, Lock/Confine)
+          - nestif       # Protocol handling (X11 auth, Wayland CSD) inherently nested
+          - unparam      # FFI signatures match C APIs, params may be unused on some paths
+          - unused       # Platform-specific helpers used only under certain build tags
 
       # Sound package - platform FFI for system sounds
       - path: sound/sound_.*\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,6 +149,12 @@ linters:
           - funlen       # Win32 code is verbose
           - gosec        # Platform syscalls are intentional
           - errcheck     # Win32 syscall returns are often ignored
+
+      # Sound package - platform FFI for system sounds
+      - path: sound/sound_.*\.go
+        linters:
+          - gosec        # Platform syscalls (winmm, NSSound, exec) are intentional
+          - errcheck     # Win32 PlaySoundW return is best-effort
           - unused       # dispatch methods will be used by event loop
           - unparam      # dispatch methods follow consistent signature pattern
           - dupl         # Platform event parsers have similar structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.0] - 2026-05-09
+
+### Added
+
+- **`sound/` subpackage** (ADR-025) — platform system sounds for UI feedback. `sound.Play(sound.Click)` plays OS-native sounds asynchronously. Windows: winmm.dll `PlaySoundW` with registry sound scheme. macOS: NSSound via goffi. Linux: canberra-gtk-play with paplay/pw-play/aplay fallback. Zero CGO. Debounce (50ms per sound type). Disabled by default (`SetEnabled(true)` to activate). 5 system sounds (Click, Alert, Error, Warning, Success). 9 tests.
+- **`examples/sound_demo`** — demonstrates all 5 system sounds.
+
 ## [0.33.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), zero-copy surface rendering, damage-aware presentation |
 | **Graphics** | Windowing, input handling, texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference, native macOS window tabbing |
+| **Sound** | Platform system sounds for UI feedback (winmm, NSSound, canberra/PulseAudio) |
 | **Compute** | Full compute shader support |
 | **Window Chrome** | Frameless windows with custom title bars, DWM shadow, hit-test regions |
 | **HiDPI** | Per-monitor DPI, WM_DPICHANGED, logical/physical coordinate split |
@@ -541,6 +542,7 @@ Vulkan     DX12  Metal  GLES   Software
 | `gmath/` | Vec2, Vec3, Vec4, Mat4, Color |
 | `window/` | Window configuration |
 | `input/` | Keyboard and mouse input |
+| `sound/` | Platform system sounds (Click, Alert, Error, Warning, Success) |
 | `internal/platform/` | Platform-specific windowing |
 | `internal/thread/` | Multi-thread rendering (RenderLoop) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,6 +60,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.34.0** | 2026-05-09 | **System sounds** (ADR-025) — `sound/` subpackage, winmm/NSSound/canberra, zero CGO |
 | **v0.33.0** | 2026-05-09 | **SubpixelLayout detection** (ADR-024) — LCD/ClearType auto-detect, all platforms, gpucontext v0.18.0 |
 | **v0.32.3** | 2026-05-08 | **Three-mode render loop** (ADR-023) — IDLE/ANIMATING/CONTINUOUS, lazy acquire, 10%→<1% GPU for UI |
 | **v0.32.2** | 2026-05-07 | Fix EventSource callback loss on Run() — lazy init for pre-Run() registrations |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -279,6 +279,7 @@ gogpu/
 ├── resource_tracker.go  # ResourceTracker: automatic GPU resource cleanup (LIFO)
 ├── gpucontext_adapter.go # gpucontext.DeviceProvider adapter
 ├── gesture.go          # GestureRecognizer (Vello-style)
+├── sound/              # Platform system sounds (winmm/NSSound/canberra)
 ├── gpu/
 │   ├── types/          # Backend type enum (BackendType)
 │   └── backend/

--- a/examples/sound_demo/main.go
+++ b/examples/sound_demo/main.go
@@ -1,0 +1,41 @@
+// Example: platform system sounds for UI feedback.
+//
+// Plays all 5 system sounds (Click, Alert, Error, Warning, Success)
+// using OS-native APIs (winmm on Windows, NSSound on macOS,
+// PulseAudio/canberra on Linux). Zero CGO.
+//
+// Run:
+//
+//	go run ./examples/sound_demo
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gogpu/gogpu/sound"
+)
+
+func main() {
+	sound.SetEnabled(true)
+	fmt.Println("GoGPU System Sound Demo")
+	fmt.Println("=======================")
+	fmt.Println()
+
+	sounds := []sound.SystemSound{
+		sound.Click,
+		sound.Alert,
+		sound.Error,
+		sound.Warning,
+		sound.Success,
+	}
+
+	for _, s := range sounds {
+		fmt.Printf("  Playing: %s\n", s)
+		sound.Play(s)
+		time.Sleep(800 * time.Millisecond)
+	}
+
+	fmt.Println()
+	fmt.Println("Done! All sounds played via platform-native APIs.")
+}

--- a/internal/platform/logger.go
+++ b/internal/platform/logger.go
@@ -21,8 +21,6 @@ func init() {
 	loggerPtr.Store(l)
 }
 
-func logger() *slog.Logger { return loggerPtr.Load() }
-
 // SetLogger sets the logger for the platform package.
 // Pass nil to restore default silent behavior.
 func SetLogger(l *slog.Logger) {

--- a/internal/platform/logger_linux.go
+++ b/internal/platform/logger_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package platform
+
+import "log/slog"
+
+func logger() *slog.Logger { return loggerPtr.Load() }

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -242,10 +242,6 @@ var (
 	procCreateWindowExW    = user32.NewProc("CreateWindowExW")
 	procShowWindow         = user32.NewProc("ShowWindow")
 	procUpdateWindow       = user32.NewProc("UpdateWindow")
-	procSetForegroundWnd   = user32.NewProc("SetForegroundWindow")
-	procGetForegroundWnd   = user32.NewProc("GetForegroundWindow")
-	procGetWindowThreadPID = user32.NewProc("GetWindowThreadProcessId")
-	procAttachThreadInput  = user32.NewProc("AttachThreadInput")
 	procPeekMessageW       = user32.NewProc("PeekMessageW")
 	procTranslateMessage   = user32.NewProc("TranslateMessage")
 	procDispatchMessageW   = user32.NewProc("DispatchMessageW")
@@ -254,7 +250,6 @@ var (
 	procLoadCursorW        = user32.NewProc("LoadCursorW")
 	procSetCursor          = user32.NewProc("SetCursor")
 	procGetModuleHandleW   = kernel32.NewProc("GetModuleHandleW")
-	procGetCurrentThreadID = kernel32.NewProc("GetCurrentThreadId")
 	procDestroyWindow      = user32.NewProc("DestroyWindow")
 	procGetClientRect      = user32.NewProc("GetClientRect")
 	procClientToScreen     = user32.NewProc("ClientToScreen")
@@ -310,7 +305,6 @@ var (
 	procGetCursorPos = user32.NewProc("GetCursorPos")
 
 	// Pointer input (WM_POINTER*, Windows 8+)
-	procGetPointerType    = user32.NewProc("GetPointerType")
 	procGetPointerInfo    = user32.NewProc("GetPointerInfo")
 	procGetPointerPenInfo = user32.NewProc("GetPointerPenInfo")
 
@@ -464,7 +458,6 @@ type win32Window struct {
 	// Frameless window state
 	frameless       bool
 	hitTestCallback func(x, y float64) gpucontext.HitTestResult
-	maximized       bool
 
 	// Fullscreen state (borderless fullscreen, Chromium/GLFW pattern)
 	fullscreen     bool
@@ -2251,20 +2244,15 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 	case wmActivate:
 		// Release cursor grab on focus loss, re-grab on focus gain.
 		activationState := wParam & 0xFFFF
-		if activationState == waInactive {
-			// Window lost focus -- temporarily release cursor constraints
-			if w.cursorMode != 0 {
-				procClipCursor.Call(0)
-				if w.cursorHidden {
-					procShowCursorW.Call(1)
-					w.cursorHidden = false
-				}
+		if activationState == waInactive && w.cursorMode != 0 {
+			procClipCursor.Call(0)
+			if w.cursorHidden {
+				procShowCursorW.Call(1)
+				w.cursorHidden = false
 			}
-		} else {
-			// Window gained focus -- re-apply cursor mode
-			if w.cursorMode != 0 {
-				w.setCursorMode(w.cursorMode)
-			}
+		}
+		if activationState != waInactive && w.cursorMode != 0 {
+			w.setCursorMode(w.cursorMode)
 		}
 
 	case wmWakeUp:

--- a/sound/sound.go
+++ b/sound/sound.go
@@ -1,0 +1,122 @@
+// Package sound provides platform system sound playback for UI feedback.
+//
+// It delegates to OS-native APIs (winmm on Windows, NSSound on macOS,
+// PulseAudio on Linux) and requires zero CGO.
+//
+// Sounds are disabled by default. Call [SetEnabled](true) to activate playback.
+// All playback is asynchronous and non-blocking.
+//
+//	sound.SetEnabled(true)
+//	sound.Play(sound.Click)   // plays OS button-click sound
+//	sound.Play(sound.Error)   // plays OS error sound
+package sound
+
+import (
+	"sync"
+	"time"
+)
+
+// SystemSound represents a platform system sound event.
+type SystemSound int
+
+const (
+	// Click is the default UI interaction sound (button press, menu select).
+	Click SystemSound = iota
+	// Alert is a notification sound.
+	Alert
+	// Error indicates an error occurred.
+	Error
+	// Warning indicates a warning condition.
+	Warning
+	// Success indicates an operation completed successfully.
+	Success
+)
+
+// String returns the human-readable name of a SystemSound.
+func (s SystemSound) String() string {
+	switch s {
+	case Click:
+		return "Click"
+	case Alert:
+		return "Alert"
+	case Error:
+		return "Error"
+	case Warning:
+		return "Warning"
+	case Success:
+		return "Success"
+	default:
+		return "Unknown"
+	}
+}
+
+// debounceInterval is the minimum time between identical sound events.
+// Playing the same sound within this window is silently skipped to avoid
+// audible stuttering from rapid-fire UI events.
+const debounceInterval = 50 * time.Millisecond
+
+// state holds the global sound subsystem state.
+var state struct {
+	mu      sync.Mutex
+	enabled bool
+
+	// lastPlay tracks the last play time per SystemSound for debounce.
+	lastPlay [5]time.Time // indexed by SystemSound
+}
+
+// SetEnabled enables or disables UI sound playback globally.
+// Disabled by default. Call SetEnabled(true) to activate.
+func SetEnabled(enabled bool) {
+	state.mu.Lock()
+	state.enabled = enabled
+	state.mu.Unlock()
+}
+
+// Enabled reports whether UI sounds are currently enabled.
+func Enabled() bool {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.enabled
+}
+
+// Play plays a system sound asynchronously.
+// If sounds are disabled or the same sound was played within the debounce
+// interval (50ms), the call is silently ignored.
+func Play(s SystemSound) {
+	state.mu.Lock()
+	if !state.enabled {
+		state.mu.Unlock()
+		return
+	}
+
+	idx := int(s)
+	if idx < 0 || idx >= len(state.lastPlay) {
+		state.mu.Unlock()
+		return
+	}
+
+	now := time.Now()
+	if now.Sub(state.lastPlay[idx]) < debounceInterval {
+		state.mu.Unlock()
+		return
+	}
+	state.lastPlay[idx] = now
+	state.mu.Unlock()
+
+	platformPlay(s)
+}
+
+// PlayFile plays a WAV file from the given path asynchronously.
+// Returns an error if the file cannot be played (e.g., path not found,
+// unsupported format, or platform API failure).
+// If sounds are disabled, returns nil without playing.
+func PlayFile(path string) error {
+	state.mu.Lock()
+	if !state.enabled {
+		state.mu.Unlock()
+		return nil
+	}
+	state.mu.Unlock()
+
+	return platformPlayFile(path)
+}

--- a/sound/sound_darwin.go
+++ b/sound/sound_darwin.go
@@ -1,0 +1,355 @@
+//go:build darwin
+
+package sound
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/go-webgpu/goffi/ffi"
+	"github.com/go-webgpu/goffi/types"
+)
+
+// darwinSoundName maps SystemSound to macOS system sound file names.
+// These files are located in /System/Library/Sounds/.
+func darwinSoundName(s SystemSound) string {
+	switch s {
+	case Click:
+		return "Tink"
+	case Alert:
+		return "Glass"
+	case Error:
+		return "Basso"
+	case Warning:
+		return "Sosumi"
+	case Success:
+		return "Hero"
+	default:
+		return "Tink"
+	}
+}
+
+// nsSoundRT holds the lazily-initialized Objective-C runtime state
+// needed to play sounds via NSSound.
+var nsSoundRT struct {
+	once sync.Once
+	err  error
+
+	libobjc unsafe.Pointer
+	appKit  unsafe.Pointer
+
+	objcGetClass    unsafe.Pointer
+	objcMsgSend     unsafe.Pointer
+	selRegisterName unsafe.Pointer
+
+	// Pre-registered selectors
+	selSoundNamed uintptr
+	selPlay       uintptr
+
+	// Reusable call interfaces
+	cif2 *types.CallInterface // 2 args: self, _cmd
+	cif3 *types.CallInterface // 3 args: self, _cmd, arg1
+
+	mu sync.Mutex // protects CIF usage (not concurrency-safe)
+}
+
+func initNSSound() error {
+	nsSoundRT.once.Do(func() {
+		nsSoundRT.err = loadNSSound()
+	})
+	return nsSoundRT.err
+}
+
+func loadNSSound() error {
+	var err error
+
+	nsSoundRT.libobjc, err = ffi.LoadLibrary("/usr/lib/libobjc.A.dylib")
+	if err != nil {
+		return fmt.Errorf("sound: failed to load libobjc: %w", err)
+	}
+
+	nsSoundRT.appKit, err = ffi.LoadLibrary(
+		"/System/Library/Frameworks/AppKit.framework/AppKit")
+	if err != nil {
+		return fmt.Errorf("sound: failed to load AppKit: %w", err)
+	}
+
+	nsSoundRT.objcGetClass, err = ffi.GetSymbol(nsSoundRT.libobjc, "objc_getClass")
+	if err != nil {
+		return fmt.Errorf("sound: objc_getClass not found: %w", err)
+	}
+
+	nsSoundRT.objcMsgSend, err = ffi.GetSymbol(nsSoundRT.libobjc, "objc_msgSend")
+	if err != nil {
+		return fmt.Errorf("sound: objc_msgSend not found: %w", err)
+	}
+
+	nsSoundRT.selRegisterName, err = ffi.GetSymbol(nsSoundRT.libobjc, "sel_registerName")
+	if err != nil {
+		return fmt.Errorf("sound: sel_registerName not found: %w", err)
+	}
+
+	// Prepare call interfaces
+
+	// cif2: 2 args (self, _cmd) -> returns pointer
+	nsSoundRT.cif2 = &types.CallInterface{}
+	err = ffi.PrepareCallInterface(
+		nsSoundRT.cif2,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // self
+			types.PointerTypeDescriptor, // _cmd
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("sound: failed to prepare cif2: %w", err)
+	}
+
+	// cif3: 3 args (self, _cmd, arg1) -> returns pointer
+	nsSoundRT.cif3 = &types.CallInterface{}
+	err = ffi.PrepareCallInterface(
+		nsSoundRT.cif3,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // self
+			types.PointerTypeDescriptor, // _cmd
+			types.PointerTypeDescriptor, // arg1
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("sound: failed to prepare cif3: %w", err)
+	}
+
+	// Register selectors
+	nsSoundRT.selSoundNamed, err = darwinRegisterSel("soundNamed:")
+	if err != nil {
+		return err
+	}
+	nsSoundRT.selPlay, err = darwinRegisterSel("play")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// darwinRegisterSel registers an Objective-C selector by name.
+func darwinRegisterSel(name string) (uintptr, error) {
+	nameBytes := append([]byte(name), 0)
+	namePtr := unsafe.Pointer(&nameBytes[0])
+
+	cif := &types.CallInterface{}
+	if err := ffi.PrepareCallInterface(
+		cif,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		[]*types.TypeDescriptor{types.PointerTypeDescriptor},
+	); err != nil {
+		return 0, fmt.Errorf("sound: failed to prepare sel CIF: %w", err)
+	}
+
+	var result uintptr
+	if err := ffi.CallFunction(cif, nsSoundRT.selRegisterName, unsafe.Pointer(&result),
+		[]unsafe.Pointer{unsafe.Pointer(&namePtr)}); err != nil {
+		return 0, fmt.Errorf("sound: sel_registerName(%q) call failed: %w", name, err)
+	}
+	if result == 0 {
+		return 0, fmt.Errorf("sound: sel_registerName(%q) returned nil", name)
+	}
+	return result, nil
+}
+
+// darwinGetClass looks up an Objective-C class by name.
+func darwinGetClass(name string) (uintptr, error) {
+	nameBytes := append([]byte(name), 0)
+	namePtr := unsafe.Pointer(&nameBytes[0])
+
+	cif := &types.CallInterface{}
+	if err := ffi.PrepareCallInterface(
+		cif,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		[]*types.TypeDescriptor{types.PointerTypeDescriptor},
+	); err != nil {
+		return 0, fmt.Errorf("sound: failed to prepare class CIF: %w", err)
+	}
+
+	var result uintptr
+	if err := ffi.CallFunction(cif, nsSoundRT.objcGetClass, unsafe.Pointer(&result),
+		[]unsafe.Pointer{unsafe.Pointer(&namePtr)}); err != nil {
+		return 0, fmt.Errorf("sound: objc_getClass(%q) call failed: %w", name, err)
+	}
+	if result == 0 {
+		return 0, fmt.Errorf("sound: class %q not found", name)
+	}
+	return result, nil
+}
+
+// darwinCreateNSString creates an autoreleased NSString from a Go string.
+func darwinCreateNSString(s string) (uintptr, error) {
+	cls, err := darwinGetClass("NSString")
+	if err != nil {
+		return 0, err
+	}
+
+	selUTF8, err := darwinRegisterSel("stringWithUTF8String:")
+	if err != nil {
+		return 0, err
+	}
+
+	strBytes := append([]byte(s), 0)
+	strPtr := unsafe.Pointer(&strBytes[0])
+
+	nsSoundRT.mu.Lock()
+	defer nsSoundRT.mu.Unlock()
+
+	var result uintptr
+	if err := ffi.CallFunction(nsSoundRT.cif3, nsSoundRT.objcMsgSend, unsafe.Pointer(&result),
+		[]unsafe.Pointer{
+			unsafe.Pointer(&cls),
+			unsafe.Pointer(&selUTF8),
+			unsafe.Pointer(&strPtr),
+		}); err != nil {
+		return 0, fmt.Errorf("sound: NSString stringWithUTF8String: failed: %w", err)
+	}
+	if result == 0 {
+		return 0, errors.New("sound: NSString creation failed")
+	}
+	return result, nil
+}
+
+func platformPlay(s SystemSound) {
+	if err := initNSSound(); err != nil {
+		return
+	}
+
+	name := darwinSoundName(s)
+	nsStr, err := darwinCreateNSString(name)
+	if err != nil {
+		return
+	}
+
+	cls, err := darwinGetClass("NSSound")
+	if err != nil {
+		return
+	}
+
+	// [NSSound soundNamed:name]
+	nsSoundRT.mu.Lock()
+	var soundObj uintptr
+	err = ffi.CallFunction(nsSoundRT.cif3, nsSoundRT.objcMsgSend, unsafe.Pointer(&soundObj),
+		[]unsafe.Pointer{
+			unsafe.Pointer(&cls),
+			unsafe.Pointer(&nsSoundRT.selSoundNamed),
+			unsafe.Pointer(&nsStr),
+		})
+	nsSoundRT.mu.Unlock()
+
+	if err != nil || soundObj == 0 {
+		return
+	}
+
+	// [sound play]
+	nsSoundRT.mu.Lock()
+	_ = ffi.CallFunction(nsSoundRT.cif2, nsSoundRT.objcMsgSend, nil,
+		[]unsafe.Pointer{
+			unsafe.Pointer(&soundObj),
+			unsafe.Pointer(&nsSoundRT.selPlay),
+		})
+	nsSoundRT.mu.Unlock()
+}
+
+func platformPlayFile(path string) error {
+	if err := initNSSound(); err != nil {
+		return fmt.Errorf("sound: NSSound init failed: %w", err)
+	}
+
+	nsStr, err := darwinCreateNSString(path)
+	if err != nil {
+		return fmt.Errorf("sound: failed to create NSString for path: %w", err)
+	}
+
+	cls, err := darwinGetClass("NSSound")
+	if err != nil {
+		return fmt.Errorf("sound: NSSound class not found: %w", err)
+	}
+
+	// [NSSound alloc]
+	selAlloc, err := darwinRegisterSel("alloc")
+	if err != nil {
+		return err
+	}
+
+	nsSoundRT.mu.Lock()
+	var obj uintptr
+	err = ffi.CallFunction(nsSoundRT.cif2, nsSoundRT.objcMsgSend, unsafe.Pointer(&obj),
+		[]unsafe.Pointer{
+			unsafe.Pointer(&cls),
+			unsafe.Pointer(&selAlloc),
+		})
+	nsSoundRT.mu.Unlock()
+
+	if err != nil {
+		return fmt.Errorf("sound: NSSound alloc failed: %w", err)
+	}
+	if obj == 0 {
+		return errors.New("sound: NSSound alloc returned nil")
+	}
+
+	// [sound initWithContentsOfFile:path byReference:YES]
+	selInit, err := darwinRegisterSel("initWithContentsOfFile:byReference:")
+	if err != nil {
+		return err
+	}
+
+	// Prepare a 4-arg CIF for initWithContentsOfFile:byReference:
+	cif4 := &types.CallInterface{}
+	if err := ffi.PrepareCallInterface(
+		cif4,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // self
+			types.PointerTypeDescriptor, // _cmd
+			types.PointerTypeDescriptor, // path NSString
+			types.UInt8TypeDescriptor,   // byReference BOOL
+		},
+	); err != nil {
+		return fmt.Errorf("sound: failed to prepare init CIF: %w", err)
+	}
+
+	byRef := uint8(1) // YES
+
+	nsSoundRT.mu.Lock()
+	var initResult uintptr
+	err = ffi.CallFunction(cif4, nsSoundRT.objcMsgSend, unsafe.Pointer(&initResult),
+		[]unsafe.Pointer{
+			unsafe.Pointer(&obj),
+			unsafe.Pointer(&selInit),
+			unsafe.Pointer(&nsStr),
+			unsafe.Pointer(&byRef),
+		})
+	nsSoundRT.mu.Unlock()
+
+	if err != nil {
+		return fmt.Errorf("sound: NSSound initWithContentsOfFile call failed: %w", err)
+	}
+	if initResult == 0 {
+		return fmt.Errorf("sound: NSSound initWithContentsOfFile failed for %q", path)
+	}
+
+	// [sound play]
+	nsSoundRT.mu.Lock()
+	_ = ffi.CallFunction(nsSoundRT.cif2, nsSoundRT.objcMsgSend, nil,
+		[]unsafe.Pointer{
+			unsafe.Pointer(&initResult),
+			unsafe.Pointer(&nsSoundRT.selPlay),
+		})
+	nsSoundRT.mu.Unlock()
+
+	return nil
+}

--- a/sound/sound_linux.go
+++ b/sound/sound_linux.go
@@ -1,0 +1,141 @@
+//go:build linux
+
+package sound
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// xdgSoundPath maps SystemSound to XDG Sound Theme file paths.
+// These follow the freedesktop.org Sound Theme Specification.
+// Paths are tried in order; the first existing file wins.
+func xdgSoundPaths(s SystemSound) []string {
+	const stereo = "/usr/share/sounds/freedesktop/stereo"
+	switch s {
+	case Click:
+		return []string{
+			filepath.Join(stereo, "button-pressed.oga"),
+			filepath.Join(stereo, "message.oga"),
+		}
+	case Alert:
+		return []string{
+			filepath.Join(stereo, "bell.oga"),
+			filepath.Join(stereo, "message.oga"),
+		}
+	case Error:
+		return []string{
+			filepath.Join(stereo, "dialog-error.oga"),
+		}
+	case Warning:
+		return []string{
+			filepath.Join(stereo, "dialog-warning.oga"),
+		}
+	case Success:
+		return []string{
+			filepath.Join(stereo, "complete.oga"),
+			filepath.Join(stereo, "bell.oga"),
+		}
+	default:
+		return []string{
+			filepath.Join(stereo, "bell.oga"),
+		}
+	}
+}
+
+// findSoundFile returns the first existing file from the candidate paths.
+func findSoundFile(paths []string) string {
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// playerCommand returns the command and args for the best available
+// sound player on the system. It checks paplay (PulseAudio),
+// pw-play (PipeWire), and aplay (ALSA) in order.
+func playerCommand() (string, bool) {
+	for _, name := range []string{"paplay", "pw-play", "aplay"} {
+		if _, err := exec.LookPath(name); err == nil {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func platformPlay(s SystemSound) {
+	// Try canberra-gtk-play first: it respects the user's selected
+	// sound theme and handles XDG sound naming conventions natively.
+	if canberaPath, err := exec.LookPath("canberra-gtk-play"); err == nil {
+		eventID := canberaSoundID(s)
+		cmd := exec.Command(canberaPath, "--id", eventID)
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+		if err := cmd.Start(); err == nil {
+			go cmd.Wait()
+			return
+		}
+	}
+
+	// Fallback: play the XDG freedesktop sound file directly.
+	paths := xdgSoundPaths(s)
+	file := findSoundFile(paths)
+	if file == "" {
+		return
+	}
+
+	player, ok := playerCommand()
+	if !ok {
+		return
+	}
+
+	cmd := exec.Command(player, file)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err == nil {
+		go cmd.Wait()
+	}
+}
+
+// canberaSoundID maps SystemSound to libcanberra/XDG event IDs.
+func canberaSoundID(s SystemSound) string {
+	switch s {
+	case Click:
+		return "button-pressed"
+	case Alert:
+		return "bell"
+	case Error:
+		return "dialog-error"
+	case Warning:
+		return "dialog-warning"
+	case Success:
+		return "complete"
+	default:
+		return "bell"
+	}
+}
+
+func platformPlayFile(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("sound: file not found: %w", err)
+	}
+
+	player, ok := playerCommand()
+	if !ok {
+		return fmt.Errorf("sound: no audio player found (tried paplay, pw-play, aplay)")
+	}
+
+	cmd := exec.Command(player, path)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("sound: failed to start %s: %w", player, err)
+	}
+
+	go cmd.Wait()
+	return nil
+}

--- a/sound/sound_test.go
+++ b/sound/sound_test.go
@@ -1,0 +1,199 @@
+package sound
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSetEnabled(t *testing.T) {
+	// Reset state after test.
+	defer func() {
+		state.mu.Lock()
+		state.enabled = false
+		state.mu.Unlock()
+	}()
+
+	if Enabled() {
+		t.Fatal("expected disabled by default")
+	}
+
+	SetEnabled(true)
+	if !Enabled() {
+		t.Fatal("expected enabled after SetEnabled(true)")
+	}
+
+	SetEnabled(false)
+	if Enabled() {
+		t.Fatal("expected disabled after SetEnabled(false)")
+	}
+}
+
+func TestSystemSoundString(t *testing.T) {
+	tests := []struct {
+		sound SystemSound
+		want  string
+	}{
+		{Click, "Click"},
+		{Alert, "Alert"},
+		{Error, "Error"},
+		{Warning, "Warning"},
+		{Success, "Success"},
+		{SystemSound(99), "Unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.sound.String(); got != tt.want {
+				t.Errorf("SystemSound(%d).String() = %q, want %q", tt.sound, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlayDisabled(t *testing.T) {
+	// Sounds are disabled by default; Play should not panic.
+	defer func() {
+		state.mu.Lock()
+		state.enabled = false
+		state.mu.Unlock()
+	}()
+
+	Play(Click)
+	Play(Alert)
+	Play(Error)
+	Play(Warning)
+	Play(Success)
+}
+
+func TestPlayFileDisabled(t *testing.T) {
+	defer func() {
+		state.mu.Lock()
+		state.enabled = false
+		state.mu.Unlock()
+	}()
+
+	// When disabled, PlayFile should return nil without attempting playback.
+	if err := PlayFile("nonexistent.wav"); err != nil {
+		t.Errorf("PlayFile with sounds disabled should return nil, got %v", err)
+	}
+}
+
+func TestDebounce(t *testing.T) {
+	defer func() {
+		state.mu.Lock()
+		state.enabled = false
+		state.lastPlay = [5]time.Time{}
+		state.mu.Unlock()
+	}()
+
+	SetEnabled(true)
+
+	// Manually set lastPlay to "now" so that the next Play is within debounce.
+	state.mu.Lock()
+	state.lastPlay[int(Click)] = time.Now()
+	state.mu.Unlock()
+
+	// This should be debounced (skipped). We can't directly observe the skip
+	// from the public API without mocking platformPlay, but we verify no panic
+	// and that the lastPlay time does NOT advance.
+	state.mu.Lock()
+	before := state.lastPlay[int(Click)]
+	state.mu.Unlock()
+
+	Play(Click)
+
+	state.mu.Lock()
+	after := state.lastPlay[int(Click)]
+	state.mu.Unlock()
+
+	if !before.Equal(after) {
+		t.Error("debounce should have prevented lastPlay update")
+	}
+}
+
+func TestDebounceExpired(t *testing.T) {
+	defer func() {
+		state.mu.Lock()
+		state.enabled = false
+		state.lastPlay = [5]time.Time{}
+		state.mu.Unlock()
+	}()
+
+	SetEnabled(true)
+
+	// Set lastPlay to well in the past so debounce does not apply.
+	state.mu.Lock()
+	state.lastPlay[int(Alert)] = time.Now().Add(-time.Second)
+	state.mu.Unlock()
+
+	Play(Alert)
+
+	state.mu.Lock()
+	after := state.lastPlay[int(Alert)]
+	state.mu.Unlock()
+
+	// lastPlay should have been updated because debounce expired.
+	if time.Since(after) > 100*time.Millisecond {
+		t.Error("expected lastPlay to be updated after debounce expired")
+	}
+}
+
+func TestPlayOutOfRange(t *testing.T) {
+	defer func() {
+		state.mu.Lock()
+		state.enabled = false
+		state.mu.Unlock()
+	}()
+
+	SetEnabled(true)
+
+	// Out-of-range SystemSound values should not panic.
+	Play(SystemSound(-1))
+	Play(SystemSound(100))
+}
+
+func TestPlayFileEnabled(t *testing.T) {
+	defer func() {
+		state.mu.Lock()
+		state.enabled = false
+		state.mu.Unlock()
+	}()
+
+	SetEnabled(true)
+
+	// Playing a nonexistent file should return an error on all platforms.
+	err := PlayFile("this-file-definitely-does-not-exist-12345.wav")
+	if err == nil {
+		t.Error("expected error for nonexistent file, got nil")
+	}
+}
+
+func TestDifferentSoundsNotDebounced(t *testing.T) {
+	defer func() {
+		state.mu.Lock()
+		state.enabled = false
+		state.lastPlay = [5]time.Time{}
+		state.mu.Unlock()
+	}()
+
+	SetEnabled(true)
+
+	// Set Click as recently played.
+	state.mu.Lock()
+	state.lastPlay[int(Click)] = time.Now()
+	state.mu.Unlock()
+
+	// Alert should NOT be debounced (different sound).
+	state.mu.Lock()
+	state.lastPlay[int(Alert)] = time.Time{}
+	state.mu.Unlock()
+
+	Play(Alert)
+
+	state.mu.Lock()
+	alertTime := state.lastPlay[int(Alert)]
+	state.mu.Unlock()
+
+	if alertTime.IsZero() {
+		t.Error("Alert should not be debounced when only Click was recent")
+	}
+}

--- a/sound/sound_test.go
+++ b/sound/sound_test.go
@@ -121,8 +121,9 @@ func TestDebounceExpired(t *testing.T) {
 	SetEnabled(true)
 
 	// Set lastPlay to well in the past so debounce does not apply.
+	past := time.Now().Add(-time.Second)
 	state.mu.Lock()
-	state.lastPlay[int(Alert)] = time.Now().Add(-time.Second)
+	state.lastPlay[int(Alert)] = past
 	state.mu.Unlock()
 
 	Play(Alert)
@@ -131,8 +132,8 @@ func TestDebounceExpired(t *testing.T) {
 	after := state.lastPlay[int(Alert)]
 	state.mu.Unlock()
 
-	// lastPlay should have been updated because debounce expired.
-	if time.Since(after) > 100*time.Millisecond {
+	// lastPlay should have been updated (moved forward from the past value).
+	if !after.After(past) {
 		t.Error("expected lastPlay to be updated after debounce expired")
 	}
 }

--- a/sound/sound_windows.go
+++ b/sound/sound_windows.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+package sound
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	winmm       = windows.NewLazyDLL("winmm.dll")
+	procPlaySnd = winmm.NewProc("PlaySoundW")
+)
+
+// PlaySoundW flags.
+const (
+	sndAsync     = 0x0001     // play asynchronously
+	sndNoDefault = 0x0002     // do not play default sound on failure
+	sndAlias     = 0x00010000 // pszSound is a registry alias
+	sndFilename  = 0x00020000 // pszSound is a file name
+)
+
+// windowsSoundAlias maps SystemSound to Windows registry sound aliases.
+// These correspond to entries under HKCU\AppEvents\Schemes\Apps\.Default.
+func windowsSoundAlias(s SystemSound) string {
+	switch s {
+	case Click:
+		return ".Default"
+	case Alert:
+		return "SystemNotification"
+	case Error:
+		return "SystemHand"
+	case Warning:
+		return "SystemExclamation"
+	case Success:
+		return "SystemAsterisk"
+	default:
+		return ".Default"
+	}
+}
+
+func platformPlay(s SystemSound) {
+	alias := windowsSoundAlias(s)
+	ptr, err := windows.UTF16PtrFromString(alias)
+	if err != nil {
+		return
+	}
+	// PlaySoundW(pszSound, hmod, fdwSound)
+	// SND_ALIAS|SND_ASYNC|SND_NODEFAULT: play the registry alias
+	// asynchronously; if no sound is configured, skip silently.
+	procPlaySnd.Call(
+		uintptr(unsafe.Pointer(ptr)),
+		0,
+		uintptr(sndAlias|sndAsync|sndNoDefault),
+	)
+}
+
+func platformPlayFile(path string) error {
+	// Check file existence first because PlaySoundW with SND_ASYNC
+	// returns TRUE even for missing files (it silently does nothing).
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("sound: file not found: %w", err)
+	}
+
+	ptr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return fmt.Errorf("sound: invalid path: %w", err)
+	}
+	ret, _, _ := procPlaySnd.Call(
+		uintptr(unsafe.Pointer(ptr)),
+		0,
+		uintptr(sndFilename|sndAsync|sndNoDefault),
+	)
+	if ret == 0 {
+		return fmt.Errorf("sound: PlaySoundW failed for %q", path)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- `sound/` subpackage — OS-native system sound playback for UI feedback
- Windows: winmm.dll `PlaySoundW` (registry sound scheme)
- macOS: NSSound via goffi
- Linux: canberra-gtk-play + paplay/pw-play/aplay fallback (XDG Sound Theme)
- Zero CGO, disabled by default, 50ms debounce
- 9 tests, `examples/sound_demo`

Also fixes 9 pre-existing lint issues in platform_windows.go (unused vars/fields).

## API

```go
sound.SetEnabled(true)
sound.Play(sound.Click)   // OS button-click sound
sound.Play(sound.Error)   // OS error sound
sound.PlayFile("alert.wav") // custom WAV file
```

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues (Windows)
- [x] Visual: 5 system sounds play on Windows
- [x] `examples/sound_demo` runs
- [ ] CI
- [ ] macOS testing (@sverrehu)
- [ ] Linux testing (@paulie-g, @darkliquid)