### PR TITLE
fix: macOS PUA key filter, Linux EventClose WindowID, deps update (v0.34.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.4] - 2026-05-13
+
+### Added
+
+- **macOS window delegate** (#213, ADR-022 Phase 2, @lkmavi) — `GoGPUWindowDelegate` with `windowShouldClose:` for native close event detection. Per-window `darwinPlatformWindow` owns `*darwin.Window` directly. Multi-window `PollEvents` iterates all windows. `PlatformWindowCloser` optional interface (type assertion, no interface expansion). `safeOnClose` panic recovery. `setDelegate:nil` cleanup in `Destroy()`. 13 tests.
+
+### Fixed
+
+- **macOS TextField text corruption** (ui#101 Thread H, @AnyCPU) — `dispatchCharFromEvent` now stops at null terminator and filters macOS PUA function-key sentinels (U+F700-U+F8FF). Previously, arrow keys, F-keys, and Delete were passed as text characters. Same pattern as SDL/GLFW/winit.
+- **Linux EventClose missing WindowID** — X11 and Wayland `EventClose` events now include `WindowID`. Previously all close events had `WindowID=0`, which broke `windowCloseEvent` routing after PR #222 removed the zero-ID fallback. Pre-existing bug, now fixed on both X11 (1 location) and Wayland (4 locations).
+
+### Changed
+
+- **deps:** wgpu v0.27.3 → v0.27.4 (goffi v0.5.1 — struct ABI fix for macOS Intel, XMM return registers)
+
 ## [0.34.3] - 2026-05-11
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,15 +25,19 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.32.0
+## Current State: v0.34.3
 
 ✅ **Production-ready** with full feature set:
-- **Adapter-aware render mode** — `GOGPU_RENDER_MODE=auto|cpu|gpu` (ADR-020). CPU rasterizer on software adapter (60 FPS), GPU on real hardware
-- **macOS native window tabbing** — `Config.WithTabbingMode()` + `WithTabbingIdentifier()` (GLFW/SDL3/Qt6 pattern, @lkmavi)
-- **AdapterInfo** — `gpucontext.DeviceProvider.AdapterInfo()` exposes adapter type for render mode decisions
+- **Three-mode render loop** — IDLE/ANIMATING/CONTINUOUS modes with lazy swapchain acquire (ADR-023)
+- **SubpixelLayout detection** — LCD/ClearType auto-detect on all platforms (ADR-024)
+- **Platform system sounds** — `sound.Play(sound.Click)` on Windows/macOS/Linux, zero CGO (ADR-025)
+- **Window close lifecycle** — `SetOnClose(func() bool)` rejection, ID pool, `OnAnyWindowClosed` (ADR-022, @lkmavi)
+- **macOS window delegate** — `GoGPUWindowDelegate` with `windowShouldClose:`, per-window routing (ADR-022 Phase 2, @lkmavi)
+- **Centralized input dispatch** — all input events through `PollEvents()` with `WindowID` (ADR-021, @lkmavi)
+- **Adapter-aware render mode** — `GOGPU_RENDER_MODE=auto|cpu|gpu` (ADR-020)
+- **macOS native window tabbing** — `Config.WithTabbingMode()` + `WithTabbingIdentifier()` (@lkmavi)
 - **Runtime fullscreen** — `App.SetFullscreen(bool)`, `App.ToggleFullscreen()` on all platforms (ADR-018)
 - **Multi-window** — `App.NewWindow()` creates additional windows with shared GPU device (ADR-010)
-- **EventFocus** — window focus/blur events on all platforms for multi-window VSync routing
 - **Damage-aware presentation** — `Context.SetDamageRects()` passes dirty regions to compositor (ADR-013)
 - Dual backend (Rust/Pure Go) — cross-platform (Windows, macOS, Linux)
 - **PlatformManager / PlatformWindow** — clean process-level / per-window split (Qt6 pattern)
@@ -60,6 +64,9 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.34.3** | 2026-05-11 | deps: wgpu v0.27.3 |
+| **v0.34.2** | 2026-05-11 | **Window close lifecycle** (#213, ADR-022, @lkmavi) — close rejection, ID pool, OnAnyWindowClosed |
+| **v0.34.1** | 2026-05-10 | deps: wgpu v0.27.2 |
 | **v0.34.0** | 2026-05-09 | **System sounds** (ADR-025) — `sound/` subpackage, winmm/NSSound/canberra, zero CGO |
 | **v0.33.0** | 2026-05-09 | **SubpixelLayout detection** (ADR-024) — LCD/ClearType auto-detect, all platforms, gpucontext v0.18.0 |
 | **v0.32.3** | 2026-05-08 | **Three-mode render loop** (ADR-023) — IDLE/ANIMATING/CONTINUOUS, lazy acquire, 10%→<1% GPU for UI |
@@ -116,10 +123,19 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 - [x] WindowID on all events for multi-window routing (v0.28.1)
 - [x] Centralized input dispatch — all input through PollEvents() with WindowID (ADR-021, v0.32.1)
 - [x] Per-window input callbacks — SetOnKeyPress, SetOnPointer, SetOnScroll, etc. (v0.32.1)
+- [x] Close-as-request — `SetOnClose(func() bool)` rejection, ID pool, `OnAnyWindowClosed` (ADR-022, v0.34.2, @lkmavi)
+- [x] macOS window delegate — `GoGPUWindowDelegate` with `windowShouldClose:`, per-window event routing (ADR-022 Phase 2, @lkmavi)
 - [ ] VSync mode switching on focus change (surface reconfigure)
 - [ ] Window types: Normal, Dialog, Tool, Popup with parent-child
-- [ ] Close-as-request (OnClose returns bool to reject)
 - [ ] Unified platform package structure (REFACTOR-PLATFORM-001)
+
+### Universal App Lifecycle (ADR-026)
+
+Surface-based lifecycle for desktop + mobile + web + headless. Replaces "primary window" concept. GPU Device decoupled from any window. Research: 15 enterprise frameworks (Flutter, SDL3, Qt6, winit, Bevy).
+
+- [ ] **Phase 2** — Renderer decoupling: RenderTarget with nilable surface, Device/Queue independent (@kolkov)
+- [ ] **Phase 3** — Lifecycle API: `AppLifecycle` states, `QuitOnLastSurfaceClosed` (@kolkov)
+- [ ] **Phase 4** — Mobile platforms: Android ANativeWindow, iOS CAMetalLayer, Web canvas (community)
 
 ### v1.0.0 — Production Release
 
@@ -140,7 +156,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 | **Android** | Android platform support | Backlog (ANDROID-001) |
 | **iOS** | iOS platform support | Planned |
 | **Ecosystem Logging** | Unified slog-based logging across all repos | Backlog (TASK-LOG-001) |
-| **System Tray** | OS-level tray icon (Win32 Notification Area, macOS Menu Bar Extra, Linux AppIndicator/SNI) | Planned — [Research](docs/dev/research/UI_FRAMEWORK_CONCERNS.md), low retrofit cost |
+| **System Tray** | OS-level tray icon (Win32/macOS/Linux) | ✅ Shipped — [gogpu/systray](https://github.com/gogpu/systray) v0.1.0 |
 | **Native Dialogs** | File open/save, color picker, message box | Planned |
 | **Drag & Drop** | OS-level and inter-window drag and drop | Planned |
 | **Clipboard** | Rich clipboard (images, HTML, custom types) | Planned |

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/gogpu/gogpu
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.5.0
+	github.com/go-webgpu/goffi v0.5.1
 	github.com/go-webgpu/webgpu v0.4.3
 	github.com/gogpu/gpucontext v0.18.0
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/wgpu v0.27.3
+	github.com/gogpu/wgpu v0.27.4
 	golang.org/x/sys v0.44.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE=
-github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.5.1 h1:RSPR+YKT0tmbp5Uon+xwhN1veC9cehmqMptMkQuopok=
+github.com/go-webgpu/goffi v0.5.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
@@ -8,7 +8,7 @@ github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.13 h1:VlponVgD1fEfNotx0874M4n7tnfum8YlMEB3pBdd2Ps=
 github.com/gogpu/naga v0.17.13/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.27.3 h1:VRR17ManIotIYkAN/sKBX1cyGa/jw6utGMXhEckINt4=
-github.com/gogpu/wgpu v0.27.3/go.mod h1:LordcEpJM76P0Ispw3r+3F2fAhd8khbBL7PgUa2iW/A=
+github.com/gogpu/wgpu v0.27.4 h1:9dlucfHFFNStK6usR0UxmMO0vaAgQ17VWqdMCLNG0vc=
+github.com/gogpu/wgpu v0.27.4/go.mod h1:icn/JDIIYMxk68DpU7t1f9xV+seRyFI2j3YBMY6qSho=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -697,11 +697,21 @@ func (w *darwinWindow) dispatchCharFromEvent(event darwin.ID) {
 	// Convert to Go byte slice (safe: pointer valid within this autorelease pool scope)
 	data := unsafe.Slice((*byte)(unsafe.Pointer(utf8Ptr)), length*4) //nolint:govet // ObjC UTF8String pointer, bounded by NSString length
 
-	// Decode UTF-8 runes and push each non-control character to event queue
+	// Decode UTF-8 runes and push each non-control character to event queue.
+	// Stop at null terminator (UTF8String is a C string).
+	// Skip macOS Private Use Area function-key sentinels (U+F700-U+F8FF):
+	// arrows, F-keys, Delete, Home, End, etc. SDL/GLFW/winit all filter this range.
 	for i := 0; i < len(data); {
 		r, size := utf8.DecodeRune(data[i:])
 		if r == utf8.RuneError && size <= 1 {
-			break // end of valid UTF-8
+			break
+		}
+		if r == 0 {
+			break
+		}
+		if r >= 0xF700 && r <= 0xF8FF {
+			i += size
+			continue
 		}
 		if r >= 32 && r != 127 {
 			w.events = append(w.events, Event{Type: EventChar, Char: r})

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -80,7 +80,8 @@ type waylandPlatform struct {
 	envScaleFactor float64
 
 	// Primary window for backward-compatible single-window API.
-	primary *waylandWindow
+	primary         *waylandWindow
+	primaryWindowID WindowID
 }
 
 // x11Platform wraps x11.Platform to implement the Platform interface.
@@ -90,7 +91,8 @@ type x11Platform struct {
 	// Channel-based wakeup for cross-goroutine WakeUp → WaitEvents unblocking.
 	// Replaces the wakePipe+unix.Poll pattern to avoid dual-poller race with
 	// net.Conn (Go runtime netpoller vs kernel poll on dup'd fd).
-	wakeCh chan struct{}
+	wakeCh          chan struct{}
+	primaryWindowID WindowID
 }
 
 // newPlatformManager returns a PlatformManager for Linux.
@@ -138,7 +140,9 @@ func (p *x11Platform) CreateWindow(config Config) (PlatformWindow, error) {
 	if err := p.inner.Init(x11Config); err != nil {
 		return nil, err
 	}
-	return &x11PlatformWindow{platform: p, id: NewWindowID()}, nil
+	id := NewWindowID()
+	p.primaryWindowID = id
+	return &x11PlatformWindow{platform: p, id: id}, nil
 }
 
 // PollEvents processes pending X11 events.
@@ -146,7 +150,7 @@ func (p *x11Platform) PollEvents() Event {
 	event := p.inner.PollEvents()
 	switch event.Type {
 	case x11.EventTypeClose:
-		return Event{Type: EventClose}
+		return Event{Type: EventClose, WindowID: p.primaryWindowID}
 	case x11.EventTypeResize:
 		// X11: scale=1.0 baseline, logical == physical
 		return Event{
@@ -438,7 +442,9 @@ func (p *waylandPlatform) CreateWindow(config Config) (PlatformWindow, error) {
 	if err := p.initSingleConnection(config); err != nil {
 		return nil, err
 	}
-	return &waylandPlatformWindow{platform: p, id: NewWindowID()}, nil
+	id := NewWindowID()
+	p.primaryWindowID = id
+	return &waylandPlatformWindow{platform: p, id: id}, nil
 }
 
 // initSingleConnection initializes using a single C libwayland connection.
@@ -618,7 +624,7 @@ func (p *waylandPlatform) initCSD(config Config) error {
 			w.eventMu.Lock()
 			w.shouldClose = true
 			w.eventMu.Unlock()
-			w.queueEvent(Event{Type: EventClose})
+			w.queueEvent(Event{Type: EventClose, WindowID: p.primaryWindowID})
 			p.WakeUp() // unblock WaitEvents so main loop sees shouldClose
 		},
 	); err != nil {
@@ -953,7 +959,7 @@ func (p *waylandPlatform) setupInputCallbacks() {
 			w.eventMu.Lock()
 			w.shouldClose = true
 			w.eventMu.Unlock()
-			w.queueEvent(Event{Type: EventClose})
+			w.queueEvent(Event{Type: EventClose, WindowID: p.primaryWindowID})
 			p.WakeUp() // unblock WaitEvents so main loop sees shouldClose
 		},
 		OnConfigure: func(width, height int32) {
@@ -1802,7 +1808,7 @@ func (p *waylandPlatform) PollEvents() Event {
 			w.eventMu.Lock()
 			w.shouldClose = true
 			w.eventMu.Unlock()
-			w.queueEvent(Event{Type: EventClose})
+			w.queueEvent(Event{Type: EventClose, WindowID: p.primaryWindowID})
 		}
 
 		// Dispatch CSD events (separate queue, read by DispatchDefaultQueue above)
@@ -2165,5 +2171,5 @@ func (p *waylandPlatform) CloseWindow() {
 	w.eventMu.Lock()
 	w.shouldClose = true
 	w.eventMu.Unlock()
-	w.queueEvent(Event{Type: EventClose})
+	w.queueEvent(Event{Type: EventClose, WindowID: p.primaryWindowID})
 }


### PR DESCRIPTION
## Summary

- **macOS TextField fix** (ui#101 Thread H, @AnyCPU) — `dispatchCharFromEvent` now stops at null terminator and filters PUA function-key sentinels (U+F700-U+F8FF)
- **Linux EventClose WindowID** — X11 and Wayland close events now include proper `WindowID` (5 locations)
- **deps:** wgpu v0.27.3 → v0.27.4 (goffi v0.5.1 — struct ABI fix for macOS Intel)

## Test plan

- [x] `go build ./...` (Windows, Linux cross, macOS cross)
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues
- [ ] CI: Build × 3, Test × 3, Lint, Formatting
