### PR TITLE
fix: deferred SetHitTestCallback — callback preserved across Run() init (v0.34.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.34.5] - 2026-05-14
+## [0.34.6] - 2026-05-14
+
+### Fixed
+
+- **Frameless window hit test callback lost before Run()** — `SetHitTestCallback` registered before `Run()` was silently dropped because `platWindow` was nil. Callback now stored on `App` and applied when platform window is created. Same deferred pattern as `EventSource` (v0.32.2). Fixes drag/resize in frameless windows when callback is registered in UI framework init.
 
 ### Changed
 

--- a/app.go
+++ b/app.go
@@ -43,6 +43,7 @@ type App struct {
 	onResize          func(int, int)
 	onClose           func() // called before renderer destruction
 	onAnyWindowClosed func(WindowID)
+	hitTestCallback   gpucontext.HitTestCallback // deferred until platWindow exists
 
 	// State
 	running   bool
@@ -202,6 +203,10 @@ func (a *App) Run() error {
 	// Store the primary platform window for per-window operations.
 	a.platWindow = platWindow
 
+	if a.hitTestCallback != nil {
+		a.applyHitTestCallback()
+	}
+
 	// Ensure input subsystems exist. Both EventSource() and Input() use
 	// lazy init so callers can register callbacks before Run(). We must
 	// NOT overwrite instances that were already created — UI frameworks
@@ -261,27 +266,7 @@ func (a *App) Run() error {
 		})
 	}()
 
-	// Register the primary window in the WindowManager.
-	// This validates the multi-window architecture end-to-end with the
-	// existing single-window case. The frame loop still renders via
-	// a.renderer (proven path); WindowManager tracks the window for
-	// future multi-window iteration.
-	a.windowManager = newWindowManager()
-
-	// Allocate internal ID from pool
-	internalID := a.windowManager.allocate()
-	a.primaryWindow = &Window{
-		id:         internalID,
-		platformID: platWindow.ID(),
-		config:     a.config,
-		surface:    a.renderer.primary,
-		platWindow: a.platWindow,
-		onDraw:     a.onDraw,
-		onResize:   a.onResize,
-		visible:    true,
-	}
-	a.primaryPlatformID = platWindow.ID()
-	a.windowManager.add(a.primaryWindow)
+	a.registerPrimaryWindow(platWindow)
 
 	// Main loop with three rendering modes (ADR-023):
 	//   1. IDLE: No activity — block on OS events (0% CPU, <1ms response)
@@ -594,7 +579,24 @@ type windowFrame struct {
 
 // renderFrameMultiThread renders a frame using the render thread.
 // All GPU operations happen on the render thread to keep main thread responsive.
-//
+func (a *App) registerPrimaryWindow(platWindow platform.PlatformWindow) {
+	a.windowManager = newWindowManager()
+	internalID := a.windowManager.allocate()
+	a.primaryWindow = &Window{
+		id:         internalID,
+		platformID: platWindow.ID(),
+		config:     a.config,
+		surface:    a.renderer.primary,
+		platWindow: a.platWindow,
+		onDraw:     a.onDraw,
+		onResize:   a.onResize,
+		visible:    true,
+	}
+	a.primaryPlatformID = platWindow.ID()
+	a.windowManager.add(a.primaryWindow)
+}
+
+// renderFrameMultiThread renders a frame using the render thread.
 // When multiple windows are open, each window with an onDraw callback gets
 // its own beginFrame/draw/endFrame cycle. GPU submission polling happens once
 // after all windows are presented.
@@ -892,16 +894,22 @@ func (a *App) IsFrameless() bool {
 // SetHitTestCallback sets the callback for custom hit testing in frameless mode.
 // Implements gpucontext.WindowChrome.
 func (a *App) SetHitTestCallback(callback gpucontext.HitTestCallback) {
+	a.hitTestCallback = callback
 	if a.platWindow != nil {
-		a.platWindow.SetHitTestCallback(
-			func(x, y float64) gpucontext.HitTestResult {
-				if callback != nil {
-					return callback(x, y)
-				}
-				return gpucontext.HitTestClient
-			},
-		)
+		a.applyHitTestCallback()
 	}
+}
+
+func (a *App) applyHitTestCallback() {
+	cb := a.hitTestCallback
+	a.platWindow.SetHitTestCallback(
+		func(x, y float64) gpucontext.HitTestResult {
+			if cb != nil {
+				return cb(x, y)
+			}
+			return gpucontext.HitTestClient
+		},
+	)
 }
 
 // Minimize minimizes the window.

--- a/window_chrome_test.go
+++ b/window_chrome_test.go
@@ -199,6 +199,44 @@ func TestConfigWithFrameless(t *testing.T) {
 	})
 }
 
+// TestHitTestCallbackDeferredUntilRun verifies that SetHitTestCallback
+// works when called before platWindow exists (deferred application).
+func TestHitTestCallbackDeferredUntilRun(t *testing.T) {
+	app := NewApp(DefaultConfig().WithFrameless(true))
+	mock := &mockWindow{width: 800, height: 600, scaleFactor: 1.0}
+
+	called := false
+	app.SetHitTestCallback(func(x, y float64) gpucontext.HitTestResult {
+		called = true
+		if y < 40 {
+			return gpucontext.HitTestCaption
+		}
+		return gpucontext.HitTestClient
+	})
+
+	if app.hitTestCallback == nil {
+		t.Fatal("hitTestCallback should be stored on App even without platWindow")
+	}
+	if mock.hitTestCallback != nil {
+		t.Fatal("platform callback should not be set yet")
+	}
+
+	app.platWindow = mock
+	app.applyHitTestCallback()
+
+	if mock.hitTestCallback == nil {
+		t.Fatal("platform callback should be set after applyHitTestCallback")
+	}
+
+	result := mock.hitTestCallback(100, 10)
+	if !called {
+		t.Error("deferred callback should have been called")
+	}
+	if result != gpucontext.HitTestCaption {
+		t.Errorf("callback(100, 10) = %v, want Caption", result)
+	}
+}
+
 // TestHitTestResultMapping verifies all HitTestResult values have correct String().
 func TestHitTestResultMapping(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- `SetHitTestCallback` registered before `Run()` was silently dropped (`platWindow == nil`)
- Callback now stored on `App.hitTestCallback`, applied in `Run()` after platform window creation
- Same deferred pattern as EventSource (v0.32.2)
- Extracted `registerPrimaryWindow()` helper to stay within funlen limit
- 1 new test: `TestHitTestCallbackDeferredUntilRun`

## Test plan
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues
- [x] UI IDE example — frameless drag works (user confirmed)
- [ ] CI: Build × 3, Test × 3, Lint, Formatting