### PR TITLE
fix: Wayland keyboard layout + X11 runtime switch fix (#227, v0.34.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.8] - 2026-05-15
+
+### Added
+
+- **Wayland keyboard layout support** (#227, FEAT-INPUT-020 Phase 2) — `xkbcommon.so.0` loaded via goffi for keymap parsing and key-to-UTF8 conversion. `OnKeyboardKeymap` parses compositor keymap, `OnKeyboardModifiers` tracks layout group, `OnKeyboardKey` uses `xkb_state_key_get_utf8` for correct characters. Graceful fallback to English-only `evdevKeycodeToRune` if xkbcommon unavailable. 17 new tests.
+
+### Fixed
+
+- **X11 keyboard layout switching not detected at runtime** (#227, @paulie-g) — `XkbSelectEvents` wire format had `selectAll=XkbStateMask` which caused per-event detail pair to be misinterpreted by the server. Fix: `selectAll=0`, rely on explicit per-event details (GLFW/SDL3 pattern). Added `MappingNotify` → `XkbGetState` fallback for X servers that don't send `XkbStateNotify` on layout switch (SDL3 pattern).
+
 ## [0.34.7] - 2026-05-14
 
 ### Added
 
-- **Multi-keyboard layout support on X11** (#227, ADR-027, @unxed) — XKB extension protocol for keyboard group tracking. `KeycodeToKeysymGroup` with group-aware keysym lookup. `KeysymToRune` with full legacy Cyrillic keysym→Unicode table (70 entries: Russian, Ukrainian, Belarusian). `isLetter` extended for Cyrillic. Graceful fallback when XKB unavailable (group=0). 27 tests. Enables Russian, Ukrainian, and other non-Latin keyboard layouts on X11. Wayland support planned for Phase 2.
+- **Multi-keyboard layout support on X11** (#227, ADR-027, @unxed) — XKB extension protocol for keyboard group tracking. `KeycodeToKeysymGroup` with group-aware keysym lookup. `KeysymToRune` with full legacy Cyrillic keysym→Unicode table (70 entries: Russian, Ukrainian, Belarusian). `isLetter` extended for Cyrillic. Graceful fallback when XKB unavailable (group=0). 27 tests.
 
 ## [0.34.6] - 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 | **Graphics API** | Runtime selection: Vulkan, DX12, Metal, GLES, Software |
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), zero-copy surface rendering, damage-aware presentation |
-| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB), texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference, native macOS window tabbing |
+| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference, native macOS window tabbing |
 | **Sound** | Platform system sounds for UI feedback (winmm, NSSound, canberra/PulseAudio) |
 | **Compute** | Full compute shader support |
 | **Window Chrome** | Frameless windows with custom title bars, DWM shadow, hit-test regions |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.34.7
+## Current State: v0.34.8
 
 ✅ **Production-ready** with full feature set:
 - **Three-mode render loop** — IDLE/ANIMATING/CONTINUOUS modes with lazy swapchain acquire (ADR-023)
@@ -43,7 +43,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 - **PlatformManager / PlatformWindow** — clean process-level / per-window split (Qt6 pattern)
 - Multi-thread architecture (Ebiten/Gio pattern)
 - Event-driven rendering with three-state model (0% CPU when idle)
-- **Multi-keyboard layout (X11)** — XKB extension, group-aware keysym lookup, Cyrillic/Ukrainian/Belarusian support (ADR-027, @unxed)
+- **Multi-keyboard layout (X11 + Wayland)** — XKB extension + xkbcommon, group-aware keysym lookup, Cyrillic/Ukrainian/Belarusian (ADR-027, @unxed)
 - **Unicode text input** — SetCharCallback on all platforms (Win32/macOS/X11/Wayland)
 - **Automatic GPU resource lifecycle** — `TrackResource(io.Closer)` + LIFO shutdown
 - DeviceProvider/EventSource/WindowProvider/PlatformProvider for UI integration
@@ -65,6 +65,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.34.8** | 2026-05-15 | **Wayland keyboard layout** + X11 runtime switch fix (#227, @paulie-g) — xkbcommon, MappingNotify fallback, 44 tests |
 | **v0.34.7** | 2026-05-14 | **Multi-keyboard layout X11** (#227, ADR-027, @unxed) — XKB group tracking, Cyrillic keysyms, 27 tests |
 | **v0.34.6** | 2026-05-14 | Deferred SetHitTestCallback — frameless drag fix |
 | **v0.34.5** | 2026-05-14 | deps: wgpu v0.27.5 (NULL handle guards) |

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -16,6 +16,16 @@ import (
 	"github.com/gogpu/gpucontext"
 )
 
+// xkbKeyHandler abstracts the keyboard layout handling provided by libxkbcommon.
+// The production implementation is *wayland.XKBHandle; tests use a mock.
+type xkbKeyHandler interface {
+	Ready() bool
+	KeyGetUtf8(keycode uint32) string
+	UpdateMask(modsDepressed, modsLatched, modsLocked, group uint32)
+	SetKeymapFromFD(fd int, size uint32) error
+	Close()
+}
+
 // waylandWindow holds all per-window state for a Wayland surface.
 type waylandWindow struct {
 	// Frameless window state
@@ -51,6 +61,10 @@ type waylandWindow struct {
 
 	// Keyboard focus tracking
 	keyboardFocused bool
+
+	// XKB keyboard layout support (libxkbcommon.so.0 via goffi).
+	// Non-nil when libxkbcommon is available; nil falls back to evdevKeycodeToRune.
+	xkb xkbKeyHandler
 
 	callbackMu sync.RWMutex
 }
@@ -548,6 +562,15 @@ func (p *waylandPlatform) initSingleConnection(config Config) error {
 	// Detect env-based scale factor as fallback
 	p.envScaleFactor = detectEnvScaleFactor()
 
+	// Load libxkbcommon for proper keyboard layout support.
+	// Non-fatal: falls back to evdevKeycodeToRune (English-only) if unavailable.
+	xkbHandle, xkbErr := wayland.LoadXKBCommon()
+	if xkbErr != nil {
+		logger().Info("xkbcommon not available, keyboard limited to US QWERTY", "err", xkbErr)
+	} else {
+		p.primary.xkb = xkbHandle
+	}
+
 	// Set up input devices (pointer, keyboard, touch) on C display
 	seatGlobal := registry.GetGlobalByInterface(wayland.InterfaceWlSeat)
 	if seatGlobal != nil {
@@ -803,8 +826,14 @@ func (p *waylandPlatform) setupInputCallbacks() {
 
 		// Keyboard events
 		OnKeyboardKeymap: func(format uint32, fd int, size uint32) {
-			// For now, ignore keymap (basic evdev keycode mapping used).
-			// Full libxkbcommon integration is a future task.
+			if format != wayland.KeyboardKeymapFormatXKBV1 {
+				return
+			}
+			if w.xkb != nil {
+				if err := w.xkb.SetKeymapFromFD(fd, size); err != nil {
+					logger().Warn("xkbcommon: failed to load keymap from compositor", "err", err)
+				}
+			}
 		},
 		OnKeyboardEnter: func(serial uint32, keys []uint32) {
 			w.pointerMu.Lock()
@@ -832,11 +861,9 @@ func (p *waylandPlatform) setupInputCallbacks() {
 
 			w.dispatchKeyEvent(gpuKey, mods, pressed)
 
-			// Dispatch character input on key press only.
+			// Dispatch character input on key press only (no char for shortcuts).
 			if pressed && mods&(gpucontext.ModControl|gpucontext.ModAlt|gpucontext.ModSuper) == 0 {
-				shift := mods&gpucontext.ModShift != 0
-				capsLock := mods&gpucontext.ModCapsLock != 0
-				if r := evdevKeycodeToRune(key, shift, capsLock); r != 0 {
+				if r := w.keycodeToRune(key); r != 0 {
 					w.queueEvent(Event{Type: EventChar, Char: r})
 				}
 			}
@@ -845,6 +872,12 @@ func (p *waylandPlatform) setupInputCallbacks() {
 			w.pointerMu.Lock()
 			w.modifiers = evdevModsToModifiers(modsDepressed, modsLocked)
 			w.pointerMu.Unlock()
+
+			// Update xkbcommon state (modifier + layout group tracking).
+			// This enables proper multi-layout keyboard support.
+			if w.xkb != nil {
+				w.xkb.UpdateMask(modsDepressed, modsLatched, modsLocked, group)
+			}
 		},
 		OnKeyboardRepeat: func(rate, delay int32) {
 			// Stored for future key repeat implementation
@@ -1076,6 +1109,29 @@ func (w *waylandWindow) getModifiers() gpucontext.Modifiers {
 	w.pointerMu.RLock()
 	defer w.pointerMu.RUnlock()
 	return w.modifiers
+}
+
+// keycodeToRune converts an evdev keycode to a printable rune.
+// Uses xkbcommon (multi-layout aware) when available, falls back to evdevKeycodeToRune (US QWERTY).
+func (w *waylandWindow) keycodeToRune(keycode uint32) rune {
+	if w.xkb != nil && w.xkb.Ready() {
+		s := w.xkb.KeyGetUtf8(keycode)
+		if s != "" {
+			runes := []rune(s)
+			if len(runes) > 0 {
+				return runes[0]
+			}
+		}
+		return 0
+	}
+
+	// Fallback: hardcoded US QWERTY mapping
+	w.pointerMu.RLock()
+	mods := w.modifiers
+	w.pointerMu.RUnlock()
+	shift := mods&gpucontext.ModShift != 0
+	capsLock := mods&gpucontext.ModCapsLock != 0
+	return evdevKeycodeToRune(keycode, shift, capsLock)
 }
 
 // eventTimestamp returns the event timestamp as duration since start.
@@ -1860,6 +1916,12 @@ func (p *waylandPlatform) FontScale() float32 { return detectFontScale() }
 func (p *waylandPlatform) Destroy() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	// Close xkbcommon state (libxkbcommon objects)
+	if p.primary != nil && p.primary.xkb != nil {
+		p.primary.xkb.Close()
+		p.primary.xkb = nil
+	}
 
 	// Close wakeup pipe (process-level)
 	if p.wakePipe[0] != 0 {

--- a/internal/platform/wayland/xkbcommon.go
+++ b/internal/platform/wayland/xkbcommon.go
@@ -1,0 +1,365 @@
+//go:build linux
+
+package wayland
+
+import (
+	"fmt"
+	"log/slog"
+	"unsafe"
+
+	"github.com/go-webgpu/goffi/ffi"
+	"github.com/go-webgpu/goffi/types"
+	"golang.org/x/sys/unix"
+)
+
+// XKBHandle holds libxkbcommon state for keyboard layout handling.
+// Loaded via dlopen from libxkbcommon.so.0 — available on every Wayland desktop.
+// Non-fatal: if loading fails, the platform falls back to evdevKeycodeToRune (English only).
+type XKBHandle struct {
+	lib unsafe.Pointer // dlopen("libxkbcommon.so.0")
+
+	// xkb objects (opaque pointers)
+	context uintptr // xkb_context*
+	keymap  uintptr // xkb_keymap*
+	state   uintptr // xkb_state*
+
+	// Function pointers
+	fnContextNew          unsafe.Pointer
+	fnContextUnref        unsafe.Pointer
+	fnKeymapNewFromString unsafe.Pointer
+	fnKeymapUnref         unsafe.Pointer
+	fnStateNew            unsafe.Pointer
+	fnStateUnref          unsafe.Pointer
+	fnStateKeyGetUtf8     unsafe.Pointer
+	fnStateUpdateMask     unsafe.Pointer
+
+	// Call interfaces (prepared once)
+	cifContextNew          types.CallInterface
+	cifContextUnref        types.CallInterface
+	cifKeymapNewFromString types.CallInterface
+	cifKeymapUnref         types.CallInterface
+	cifStateNew            types.CallInterface
+	cifStateUnref          types.CallInterface
+	cifStateKeyGetUtf8     types.CallInterface
+	cifStateUpdateMask     types.CallInterface
+}
+
+// xkbcommon constants.
+const (
+	// XKB_CONTEXT_NO_FLAGS = 0
+	xkbContextNoFlags uint32 = 0
+
+	// XKB_KEYMAP_FORMAT_TEXT_V1 = 1
+	xkbKeymapFormatTextV1 uint32 = 1
+
+	// XKB_KEYMAP_COMPILE_NO_FLAGS = 0
+	xkbKeymapCompileNoFlags uint32 = 0
+
+	// Evdev keycode offset: Wayland sends evdev keycodes, xkbcommon expects evdev+8.
+	xkbEvdevOffset uint32 = 8
+)
+
+// LoadXKBCommon loads libxkbcommon.so.0 and creates an xkb_context.
+// Returns (nil, error) if the library is not available — caller should fall back gracefully.
+func LoadXKBCommon() (*XKBHandle, error) {
+	h := &XKBHandle{}
+
+	lib, err := ffi.LoadLibrary("libxkbcommon.so.0")
+	if err != nil {
+		return nil, fmt.Errorf("xkbcommon: failed to load libxkbcommon.so.0: %w", err)
+	}
+	h.lib = lib
+
+	if err := h.resolveSymbols(); err != nil {
+		return nil, err
+	}
+
+	if err := h.prepareCIFs(); err != nil {
+		return nil, err
+	}
+
+	// Create xkb_context
+	ctx, err := h.contextNew()
+	if err != nil {
+		return nil, err
+	}
+	h.context = ctx
+
+	slog.Debug("xkbcommon loaded successfully")
+	return h, nil
+}
+
+// SetKeymapFromFD reads a keymap from a file descriptor (sent by compositor via wl_keyboard.keymap).
+// The fd contains XKB keymap text (format XKB_KEYMAP_FORMAT_TEXT_V1).
+// After this call, KeyGetUtf8 and UpdateMask are ready to use.
+func (h *XKBHandle) SetKeymapFromFD(fd int, size uint32) error {
+	if h == nil {
+		return fmt.Errorf("xkbcommon: handle is nil")
+	}
+
+	// mmap the fd to read the keymap text
+	data, err := unix.Mmap(fd, 0, int(size), unix.PROT_READ, unix.MAP_PRIVATE)
+	if err != nil {
+		return fmt.Errorf("xkbcommon: mmap keymap fd: %w", err)
+	}
+	defer func() {
+		_ = unix.Munmap(data)
+	}()
+
+	// Find null terminator (xkb_keymap_new_from_string expects C string)
+	keymapStr := data
+	for i, b := range keymapStr {
+		if b == 0 {
+			keymapStr = keymapStr[:i]
+			break
+		}
+	}
+
+	// Destroy old keymap/state if present
+	h.destroyState()
+	h.destroyKeymap()
+
+	// xkb_keymap_new_from_string(context, string, format, flags)
+	keymap, err := h.keymapNewFromString(keymapStr)
+	if err != nil {
+		return err
+	}
+	h.keymap = keymap
+
+	// xkb_state_new(keymap)
+	state, err := h.stateNew(keymap)
+	if err != nil {
+		h.destroyKeymap()
+		return err
+	}
+	h.state = state
+
+	slog.Debug("xkbcommon: keymap loaded from compositor fd", "size", size)
+	return nil
+}
+
+// KeyGetUtf8 converts a key press to UTF-8 text using the current xkb state.
+// keycode is the evdev keycode (NOT offset — offset is applied internally).
+// Returns empty string for non-printable keys.
+func (h *XKBHandle) KeyGetUtf8(keycode uint32) string {
+	if h == nil || h.state == 0 {
+		return ""
+	}
+
+	// xkbcommon expects evdev keycode + 8
+	xkbKey := keycode + xkbEvdevOffset
+
+	// First call with NULL buffer to get required size
+	size := h.stateKeyGetUtf8(xkbKey, nil, 0)
+	if size <= 0 {
+		return ""
+	}
+
+	// Allocate buffer (size includes null terminator space needed)
+	buf := make([]byte, size+1)
+	written := h.stateKeyGetUtf8(xkbKey, buf, uint32(len(buf)))
+	if written <= 0 {
+		return ""
+	}
+
+	return string(buf[:written])
+}
+
+// UpdateMask updates the xkb state with modifier/group changes from the compositor.
+// Called from wl_keyboard.modifiers callback.
+func (h *XKBHandle) UpdateMask(modsDepressed, modsLatched, modsLocked, group uint32) {
+	if h == nil || h.state == 0 {
+		return
+	}
+	h.stateUpdateMask(modsDepressed, modsLatched, modsLocked, 0, 0, group)
+}
+
+// Ready returns true if xkbcommon is loaded and a keymap is active.
+func (h *XKBHandle) Ready() bool {
+	return h != nil && h.state != 0
+}
+
+// Close destroys all xkb objects and unloads the library.
+func (h *XKBHandle) Close() {
+	if h == nil {
+		return
+	}
+	h.destroyState()
+	h.destroyKeymap()
+	h.destroyContext()
+	// Note: we don't unload the library (ffi doesn't expose dlclose),
+	// it stays loaded for the process lifetime.
+}
+
+// --- Internal methods ---
+
+func (h *XKBHandle) resolveSymbols() error {
+	syms := []struct {
+		name string
+		dst  *unsafe.Pointer
+	}{
+		{"xkb_context_new", &h.fnContextNew},
+		{"xkb_context_unref", &h.fnContextUnref},
+		{"xkb_keymap_new_from_string", &h.fnKeymapNewFromString},
+		{"xkb_keymap_unref", &h.fnKeymapUnref},
+		{"xkb_state_new", &h.fnStateNew},
+		{"xkb_state_unref", &h.fnStateUnref},
+		{"xkb_state_key_get_utf8", &h.fnStateKeyGetUtf8},
+		{"xkb_state_update_mask", &h.fnStateUpdateMask},
+	}
+
+	for _, s := range syms {
+		sym, err := ffi.GetSymbol(h.lib, s.name)
+		if err != nil {
+			return fmt.Errorf("xkbcommon: symbol %s not found: %w", s.name, err)
+		}
+		if sym == nil {
+			return fmt.Errorf("xkbcommon: symbol %s is nil", s.name)
+		}
+		*s.dst = sym
+	}
+
+	return nil
+}
+
+func (h *XKBHandle) prepareCIFs() error {
+	ptr := types.PointerTypeDescriptor
+	u32 := types.UInt32TypeDescriptor
+	i32 := types.SInt32TypeDescriptor
+	void := types.VoidTypeDescriptor
+
+	cifDefs := []struct {
+		name string
+		cif  *types.CallInterface
+		ret  *types.TypeDescriptor
+		args []*types.TypeDescriptor
+	}{
+		// struct xkb_context* xkb_context_new(enum xkb_context_flags flags)
+		{"context_new", &h.cifContextNew, ptr, []*types.TypeDescriptor{u32}},
+		// void xkb_context_unref(struct xkb_context *context)
+		{"context_unref", &h.cifContextUnref, void, []*types.TypeDescriptor{ptr}},
+		// struct xkb_keymap* xkb_keymap_new_from_string(context, string, format, flags)
+		{"keymap_new_from_string", &h.cifKeymapNewFromString, ptr, []*types.TypeDescriptor{ptr, ptr, u32, u32}},
+		// void xkb_keymap_unref(struct xkb_keymap *keymap)
+		{"keymap_unref", &h.cifKeymapUnref, void, []*types.TypeDescriptor{ptr}},
+		// struct xkb_state* xkb_state_new(struct xkb_keymap *keymap)
+		{"state_new", &h.cifStateNew, ptr, []*types.TypeDescriptor{ptr}},
+		// void xkb_state_unref(struct xkb_state *state)
+		{"state_unref", &h.cifStateUnref, void, []*types.TypeDescriptor{ptr}},
+		// int xkb_state_key_get_utf8(state, key, buffer, size)
+		{"state_key_get_utf8", &h.cifStateKeyGetUtf8, i32, []*types.TypeDescriptor{ptr, u32, ptr, u32}},
+		// enum xkb_state_component xkb_state_update_mask(state, mods_depressed, mods_latched, mods_locked, layout_depressed, layout_latched, layout_locked)
+		{"state_update_mask", &h.cifStateUpdateMask, u32, []*types.TypeDescriptor{ptr, u32, u32, u32, u32, u32, u32}},
+	}
+
+	for _, d := range cifDefs {
+		if err := ffi.PrepareCallInterface(d.cif, types.DefaultCall, d.ret, d.args); err != nil {
+			return fmt.Errorf("xkbcommon: failed to prepare CIF %s: %w", d.name, err)
+		}
+	}
+
+	return nil
+}
+
+// contextNew calls xkb_context_new(XKB_CONTEXT_NO_FLAGS).
+func (h *XKBHandle) contextNew() (uintptr, error) {
+	flags := xkbContextNoFlags
+	var result uintptr
+	args := [1]unsafe.Pointer{unsafe.Pointer(&flags)}
+	_ = ffi.CallFunction(&h.cifContextNew, h.fnContextNew, unsafe.Pointer(&result), args[:])
+	if result == 0 {
+		return 0, fmt.Errorf("xkbcommon: xkb_context_new returned NULL")
+	}
+	return result, nil
+}
+
+// keymapNewFromString calls xkb_keymap_new_from_string.
+func (h *XKBHandle) keymapNewFromString(keymapStr []byte) (uintptr, error) {
+	// Ensure null terminator (allocate new slice to avoid mutating input)
+	cstr := make([]byte, len(keymapStr)+1)
+	copy(cstr, keymapStr)
+	strPtr := uintptr(unsafe.Pointer(&cstr[0]))
+	format := xkbKeymapFormatTextV1
+	flags := xkbKeymapCompileNoFlags
+
+	var result uintptr
+	args := [4]unsafe.Pointer{
+		unsafe.Pointer(&h.context),
+		unsafe.Pointer(&strPtr),
+		unsafe.Pointer(&format),
+		unsafe.Pointer(&flags),
+	}
+	_ = ffi.CallFunction(&h.cifKeymapNewFromString, h.fnKeymapNewFromString, unsafe.Pointer(&result), args[:])
+	if result == 0 {
+		return 0, fmt.Errorf("xkbcommon: xkb_keymap_new_from_string returned NULL (invalid keymap?)")
+	}
+	return result, nil
+}
+
+// stateNew calls xkb_state_new(keymap).
+func (h *XKBHandle) stateNew(keymap uintptr) (uintptr, error) {
+	var result uintptr
+	args := [1]unsafe.Pointer{unsafe.Pointer(&keymap)}
+	_ = ffi.CallFunction(&h.cifStateNew, h.fnStateNew, unsafe.Pointer(&result), args[:])
+	if result == 0 {
+		return 0, fmt.Errorf("xkbcommon: xkb_state_new returned NULL")
+	}
+	return result, nil
+}
+
+// stateKeyGetUtf8 calls xkb_state_key_get_utf8(state, key, buffer, size) -> int.
+func (h *XKBHandle) stateKeyGetUtf8(key uint32, buf []byte, bufSize uint32) int32 {
+	var bufPtr uintptr
+	if len(buf) > 0 {
+		bufPtr = uintptr(unsafe.Pointer(&buf[0]))
+	}
+
+	var result int32
+	args := [4]unsafe.Pointer{
+		unsafe.Pointer(&h.state),
+		unsafe.Pointer(&key),
+		unsafe.Pointer(&bufPtr),
+		unsafe.Pointer(&bufSize),
+	}
+	_ = ffi.CallFunction(&h.cifStateKeyGetUtf8, h.fnStateKeyGetUtf8, unsafe.Pointer(&result), args[:])
+	return result
+}
+
+// stateUpdateMask calls xkb_state_update_mask.
+func (h *XKBHandle) stateUpdateMask(modsDepressed, modsLatched, modsLocked, layoutDepressed, layoutLatched, layoutLocked uint32) {
+	var result uint32
+	args := [7]unsafe.Pointer{
+		unsafe.Pointer(&h.state),
+		unsafe.Pointer(&modsDepressed),
+		unsafe.Pointer(&modsLatched),
+		unsafe.Pointer(&modsLocked),
+		unsafe.Pointer(&layoutDepressed),
+		unsafe.Pointer(&layoutLatched),
+		unsafe.Pointer(&layoutLocked),
+	}
+	_ = ffi.CallFunction(&h.cifStateUpdateMask, h.fnStateUpdateMask, unsafe.Pointer(&result), args[:])
+}
+
+func (h *XKBHandle) destroyState() {
+	if h.state != 0 {
+		args := [1]unsafe.Pointer{unsafe.Pointer(&h.state)}
+		ffi.CallFunction(&h.cifStateUnref, h.fnStateUnref, nil, args[:])
+		h.state = 0
+	}
+}
+
+func (h *XKBHandle) destroyKeymap() {
+	if h.keymap != 0 {
+		args := [1]unsafe.Pointer{unsafe.Pointer(&h.keymap)}
+		ffi.CallFunction(&h.cifKeymapUnref, h.fnKeymapUnref, nil, args[:])
+		h.keymap = 0
+	}
+}
+
+func (h *XKBHandle) destroyContext() {
+	if h.context != 0 {
+		args := [1]unsafe.Pointer{unsafe.Pointer(&h.context)}
+		ffi.CallFunction(&h.cifContextUnref, h.fnContextUnref, nil, args[:])
+		h.context = 0
+	}
+}

--- a/internal/platform/wayland/xkbcommon_test.go
+++ b/internal/platform/wayland/xkbcommon_test.go
@@ -1,0 +1,106 @@
+//go:build linux
+
+package wayland
+
+import (
+	"testing"
+)
+
+// TestXKBConstants verifies xkbcommon constant values match the C header.
+func TestXKBConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		got  uint32
+		want uint32
+	}{
+		{"XKB_CONTEXT_NO_FLAGS", xkbContextNoFlags, 0},
+		{"XKB_KEYMAP_FORMAT_TEXT_V1", xkbKeymapFormatTextV1, 1},
+		{"XKB_KEYMAP_COMPILE_NO_FLAGS", xkbKeymapCompileNoFlags, 0},
+		{"evdev offset", xkbEvdevOffset, 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s = %d, want %d", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+// TestXKBHandleNilSafety verifies nil handle methods do not panic.
+func TestXKBHandleNilSafety(t *testing.T) {
+	var h *XKBHandle
+
+	// Ready should return false for nil handle
+	if h.Ready() {
+		t.Error("nil XKBHandle.Ready() = true, want false")
+	}
+
+	// KeyGetUtf8 should return empty string for nil handle
+	if got := h.KeyGetUtf8(30); got != "" {
+		t.Errorf("nil XKBHandle.KeyGetUtf8(30) = %q, want empty", got)
+	}
+
+	// UpdateMask should not panic on nil handle
+	h.UpdateMask(0, 0, 0, 0)
+
+	// Close should not panic on nil handle
+	h.Close()
+}
+
+// TestXKBHandleNoKeymap verifies methods work when no keymap is loaded.
+func TestXKBHandleNoKeymap(t *testing.T) {
+	h := &XKBHandle{} // No library loaded, no context
+
+	// Ready should return false (state is 0)
+	if h.Ready() {
+		t.Error("empty XKBHandle.Ready() = true, want false")
+	}
+
+	// KeyGetUtf8 should return empty string (state is 0)
+	if got := h.KeyGetUtf8(30); got != "" {
+		t.Errorf("empty XKBHandle.KeyGetUtf8(30) = %q, want empty", got)
+	}
+
+	// UpdateMask should not panic (state is 0)
+	h.UpdateMask(1, 0, 0, 1)
+
+	// Close should not panic (nothing to destroy)
+	h.Close()
+}
+
+// TestXKBHandleSetKeymapFromFD_NilHandle verifies error on nil handle.
+func TestXKBHandleSetKeymapFromFD_NilHandle(t *testing.T) {
+	var h *XKBHandle
+	err := h.SetKeymapFromFD(3, 100)
+	if err == nil {
+		t.Error("nil XKBHandle.SetKeymapFromFD() = nil, want error")
+	}
+}
+
+// TestXKBEvdevOffset verifies the evdev-to-xkb keycode offset.
+// XKB keycodes = evdev keycodes + 8 (historical X11 heritage).
+// Evdev key 'a' = 30, XKB key 'a' = 38.
+func TestXKBEvdevOffset(t *testing.T) {
+	tests := []struct {
+		name    string
+		evdev   uint32
+		wantXKB uint32
+	}{
+		{"key A (evdev 30)", 30, 38},
+		{"key Q (evdev 16)", 16, 24},
+		{"key 1 (evdev 2)", 2, 10},
+		{"key Space (evdev 57)", 57, 65},
+		{"key Escape (evdev 1)", 1, 9},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.evdev + xkbEvdevOffset
+			if got != tt.wantXKB {
+				t.Errorf("evdev %d + offset = %d, want %d", tt.evdev, got, tt.wantXKB)
+			}
+		})
+	}
+}

--- a/internal/platform/wayland_xkb_test.go
+++ b/internal/platform/wayland_xkb_test.go
@@ -1,0 +1,357 @@
+//go:build linux
+
+package platform
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gogpu/gogpu/internal/platform/wayland"
+	"github.com/gogpu/gpucontext"
+)
+
+// TestWaylandXKBKeyDispatch verifies that when xkbcommon is available (Ready),
+// KeyGetUtf8 is used for character dispatch instead of evdevKeycodeToRune.
+func TestWaylandXKBKeyDispatch(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{
+		ready:  true,
+		result: "a",
+	}
+	w.xkb = xkb
+
+	// Simulate key press on key 30 (KEY_A) — should use xkb
+	w.keyboardFocused = true
+	events := dispatchKeyWithXKB(w, 30, 0, true)
+
+	// Expect EventKeyDown + EventChar('a')
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events, got %d", len(events))
+	}
+
+	if events[0].Type != EventKeyDown {
+		t.Errorf("events[0].Type = %v, want EventKeyDown", events[0].Type)
+	}
+	if events[1].Type != EventChar {
+		t.Errorf("events[1].Type = %v, want EventChar", events[1].Type)
+	}
+	if events[1].Char != 'a' {
+		t.Errorf("events[1].Char = %q, want 'a'", events[1].Char)
+	}
+}
+
+// TestWaylandXKBMultiRuneDispatch verifies multi-byte UTF-8 characters.
+func TestWaylandXKBMultiRuneDispatch(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{
+		ready:  true,
+		result: "\u0439", // Cyrillic "й" (U+0439)
+	}
+	w.xkb = xkb
+	w.keyboardFocused = true
+
+	events := dispatchKeyWithXKB(w, 16, 0, true) // key Q → Cyrillic "й" in Russian layout
+
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events, got %d", len(events))
+	}
+	if events[1].Type != EventChar {
+		t.Errorf("events[1].Type = %v, want EventChar", events[1].Type)
+	}
+	if events[1].Char != '\u0439' {
+		t.Errorf("events[1].Char = %U, want U+0439", events[1].Char)
+	}
+}
+
+// TestWaylandXKBFallbackToEvdev verifies fallback to evdevKeycodeToRune when xkb is not ready.
+func TestWaylandXKBFallbackToEvdev(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	// xkb not available (nil)
+	w.xkb = nil
+	w.keyboardFocused = true
+
+	events := dispatchKeyWithXKB(w, 30, 0, true) // KEY_A
+
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events, got %d", len(events))
+	}
+	if events[1].Type != EventChar {
+		t.Errorf("events[1].Type = %v, want EventChar", events[1].Type)
+	}
+	if events[1].Char != 'a' {
+		t.Errorf("events[1].Char = %q, want 'a' (evdev fallback)", events[1].Char)
+	}
+}
+
+// TestWaylandXKBFallbackWhenNotReady verifies fallback when XKBHandle exists but state is 0.
+func TestWaylandXKBFallbackWhenNotReady(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{
+		ready:  false, // no keymap loaded yet
+		result: "",
+	}
+	w.xkb = xkb
+	w.keyboardFocused = true
+
+	events := dispatchKeyWithXKB(w, 30, 0, true) // KEY_A
+
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events, got %d", len(events))
+	}
+	if events[1].Char != 'a' {
+		t.Errorf("events[1].Char = %q, want 'a' (evdev fallback)", events[1].Char)
+	}
+}
+
+// TestWaylandXKBNoCharOnRelease verifies no char event on key release.
+func TestWaylandXKBNoCharOnRelease(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{
+		ready:  true,
+		result: "a",
+	}
+	w.xkb = xkb
+	w.keyboardFocused = true
+
+	events := dispatchKeyWithXKB(w, 30, 0, false) // release
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event (KeyUp only), got %d", len(events))
+	}
+	if events[0].Type != EventKeyUp {
+		t.Errorf("events[0].Type = %v, want EventKeyUp", events[0].Type)
+	}
+}
+
+// TestWaylandXKBNoCharWithCtrl verifies no char event when Ctrl is held.
+func TestWaylandXKBNoCharWithCtrl(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{
+		ready:  true,
+		result: "a",
+	}
+	w.xkb = xkb
+	w.keyboardFocused = true
+	w.modifiers = gpucontext.ModControl
+
+	events := dispatchKeyWithXKB(w, 30, gpucontext.ModControl, true)
+
+	// Only EventKeyDown, no EventChar (Ctrl+A is a shortcut, not text)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event (KeyDown only), got %d", len(events))
+	}
+	if events[0].Type != EventKeyDown {
+		t.Errorf("events[0].Type = %v, want EventKeyDown", events[0].Type)
+	}
+}
+
+// TestWaylandXKBNoCharOnNonPrintable verifies no char event for non-printable keys.
+func TestWaylandXKBNoCharOnNonPrintable(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{
+		ready:  true,
+		result: "", // Escape produces nothing
+	}
+	w.xkb = xkb
+	w.keyboardFocused = true
+
+	events := dispatchKeyWithXKB(w, 1, 0, true) // KEY_ESC
+
+	// Only EventKeyDown, no EventChar
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event (KeyDown only), got %d", len(events))
+	}
+}
+
+// TestWaylandXKBGroupSwitch verifies that UpdateMask is called with the group parameter.
+func TestWaylandXKBGroupSwitch(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{ready: true}
+	w.xkb = xkb
+
+	// Simulate wl_keyboard.modifiers with group=1 (second layout)
+	waylandModifiersCallback(w, 0, 0, 0, 1)
+
+	if xkb.lastGroup != 1 {
+		t.Errorf("xkb.lastGroup = %d, want 1", xkb.lastGroup)
+	}
+	if xkb.updateMaskCalled != 1 {
+		t.Errorf("xkb.updateMaskCalled = %d, want 1", xkb.updateMaskCalled)
+	}
+}
+
+// TestWaylandXKBGroupSwitchAffectsKeyOutput verifies that switching group changes character output.
+func TestWaylandXKBGroupSwitchAffectsKeyOutput(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{ready: true}
+	w.xkb = xkb
+	w.keyboardFocused = true
+
+	// Group 0 → English 'q'
+	xkb.result = "q"
+	events := dispatchKeyWithXKB(w, 16, 0, true)
+	if len(events) < 2 || events[1].Char != 'q' {
+		t.Errorf("group 0: expected 'q', got events: %+v", events)
+	}
+
+	// Switch to group 1 (Russian layout)
+	waylandModifiersCallback(w, 0, 0, 0, 1)
+	xkb.result = "\u0439" // Cyrillic й
+
+	events = dispatchKeyWithXKB(w, 16, 0, true)
+	if len(events) < 2 || events[1].Char != '\u0439' {
+		t.Errorf("group 1: expected U+0439, got events: %+v", events)
+	}
+}
+
+// TestWaylandXKBKeymapCallback verifies that OnKeyboardKeymap triggers SetKeymapFromFD.
+func TestWaylandXKBKeymapCallback(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{ready: false}
+	w.xkb = xkb
+
+	// Simulate keymap callback with XKB_KEYMAP_FORMAT_TEXT_V1 = 1
+	waylandKeymapCallback(w, 1, 42, 4096)
+
+	if xkb.setKeymapFD != 42 {
+		t.Errorf("xkb.setKeymapFD = %d, want 42", xkb.setKeymapFD)
+	}
+	if xkb.setKeymapSize != 4096 {
+		t.Errorf("xkb.setKeymapSize = %d, want 4096", xkb.setKeymapSize)
+	}
+}
+
+// TestWaylandXKBKeymapCallbackIgnoresNonXKB verifies non-XKB format is ignored.
+func TestWaylandXKBKeymapCallbackIgnoresNonXKB(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{ready: false}
+	w.xkb = xkb
+
+	// Format 0 = XKB_KEYMAP_FORMAT_NO_KEYMAP → should be ignored
+	waylandKeymapCallback(w, 0, 42, 4096)
+
+	if xkb.setKeymapFD != 0 {
+		t.Errorf("xkb.setKeymapFD = %d, want 0 (not called)", xkb.setKeymapFD)
+	}
+}
+
+// TestWaylandXKBThreadSafety verifies concurrent access to xkb handle is safe.
+func TestWaylandXKBThreadSafety(t *testing.T) {
+	w := &waylandWindow{startTime: time.Now()}
+	xkb := &mockXKBHandle{ready: true, result: "x"}
+	w.xkb = xkb
+	w.keyboardFocused = true
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(2)
+		go func(group uint32) {
+			defer wg.Done()
+			waylandModifiersCallback(w, 0, 0, 0, group)
+		}(uint32(i % 4))
+		go func() {
+			defer wg.Done()
+			dispatchKeyWithXKB(w, 30, 0, true)
+		}()
+	}
+	wg.Wait()
+	// No race conditions should occur — verified by -race flag
+}
+
+// --- Mock XKBHandle for testing ---
+
+// mockXKBHandle implements xkbKeyHandler for testing.
+type mockXKBHandle struct {
+	mu               sync.Mutex
+	ready            bool
+	result           string
+	lastGroup        uint32
+	updateMaskCalled int
+	setKeymapFD      int
+	setKeymapSize    uint32
+}
+
+func (m *mockXKBHandle) Ready() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ready
+}
+
+func (m *mockXKBHandle) KeyGetUtf8(keycode uint32) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.result
+}
+
+func (m *mockXKBHandle) UpdateMask(modsDepressed, modsLatched, modsLocked, group uint32) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastGroup = group
+	m.updateMaskCalled++
+}
+
+func (m *mockXKBHandle) SetKeymapFromFD(fd int, size uint32) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setKeymapFD = fd
+	m.setKeymapSize = size
+	return nil
+}
+
+func (m *mockXKBHandle) Close() {}
+
+// Verify mockXKBHandle satisfies xkbKeyHandler at compile time.
+var _ xkbKeyHandler = (*mockXKBHandle)(nil)
+
+// Verify *wayland.XKBHandle satisfies xkbKeyHandler at compile time.
+var _ xkbKeyHandler = (*wayland.XKBHandle)(nil)
+
+// --- Helper functions that exercise production code paths ---
+
+// dispatchKeyWithXKB simulates the OnKeyboardKey callback logic for testing.
+// Uses the production keycodeToRune method to verify the real code path.
+func dispatchKeyWithXKB(w *waylandWindow, keycode uint32, mods gpucontext.Modifiers, pressed bool) []Event {
+	w.eventMu.Lock()
+	w.events = nil // Clear queue
+	w.eventMu.Unlock()
+
+	gpuKey := evdevToKey(keycode)
+	w.dispatchKeyEvent(gpuKey, mods, pressed)
+
+	// Character dispatch on press only, no modifier keys — same logic as production callback
+	if pressed && mods&(gpucontext.ModControl|gpucontext.ModAlt|gpucontext.ModSuper) == 0 {
+		if r := w.keycodeToRune(keycode); r != 0 {
+			w.queueEvent(Event{Type: EventChar, Char: r})
+		}
+	}
+
+	w.eventMu.Lock()
+	result := make([]Event, len(w.events))
+	copy(result, w.events)
+	w.eventMu.Unlock()
+	return result
+}
+
+// waylandModifiersCallback simulates the OnKeyboardModifiers callback.
+// Mirrors the production callback: updates modifiers + xkb state.
+func waylandModifiersCallback(w *waylandWindow, modsDepressed, modsLatched, modsLocked, group uint32) {
+	w.pointerMu.Lock()
+	w.modifiers = evdevModsToModifiers(modsDepressed, modsLocked)
+	w.pointerMu.Unlock()
+
+	if w.xkb != nil {
+		w.xkb.UpdateMask(modsDepressed, modsLatched, modsLocked, group)
+	}
+}
+
+// waylandKeymapCallback simulates the OnKeyboardKeymap callback.
+// Mirrors the production callback: loads keymap from fd when format is XKB_V1.
+func waylandKeymapCallback(w *waylandWindow, format uint32, fd int, size uint32) {
+	if format != 1 { // XKB_KEYMAP_FORMAT_TEXT_V1
+		return
+	}
+	if w.xkb != nil {
+		_ = w.xkb.SetKeymapFromFD(fd, size)
+	}
+}

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -720,6 +720,9 @@ func (p *Platform) handleEvent(event Event) PlatformEvent {
 
 	case *UnknownEvent:
 		p.handleUnknownEvent(e)
+
+	case *MappingNotifyEvent:
+		p.handleMappingNotify()
 	}
 
 	return PlatformEvent{Type: EventTypeNone}
@@ -988,6 +991,27 @@ func (p *Platform) handleUnknownEvent(e *UnknownEvent) {
 		p.mu.Unlock()
 		logger().Debug("XKB group changed", "group", newGroup)
 	}
+}
+
+// handleMappingNotify re-reads XKB state when keyboard mapping changes.
+// Some X servers send MappingNotify instead of XkbStateNotify on layout switch.
+// SDL3 uses the same fallback pattern.
+func (p *Platform) handleMappingNotify() {
+	if p.xkb == nil {
+		return
+	}
+	group, err := p.conn.xkbGetState(p.xkb.MajorOpcode)
+	if err != nil {
+		return
+	}
+	p.mu.Lock()
+	if p.xkbGroup != group {
+		p.xkbGroup = group
+		p.mu.Unlock()
+		logger().Debug("XKB group changed via MappingNotify", "group", group)
+		return
+	}
+	p.mu.Unlock()
 }
 
 // handleXITouchEvent processes an XI2 touch event and dispatches it as a PointerEvent.

--- a/internal/platform/x11/xkb.go
+++ b/internal/platform/x11/xkb.go
@@ -158,12 +158,13 @@ func (c *Connection) xkbSelectEvents(majorOpcode uint8) error {
 	e.PutUint8(XkbMinorOpcodeSelectEvents)
 	e.PutUint16(5)             // request length: 20 bytes / 4 = 5 units
 	e.PutUint16(XkbUseCoreKbd) // device spec
-	e.PutUint16(XkbStateMask)  // affectWhich: subscribe to state events
-	e.PutUint16(0)             // clear: don't clear any event types
-	e.PutUint16(XkbStateMask)  // selectAll: enable state notifications
-	e.PutUint16(0)             // affectMap
-	e.PutUint16(0)             // map
-	// Per-event details for StateNotify:
+	e.PutUint16(XkbStateMask) // affectWhich: subscribe to state events
+	e.PutUint16(0)            // clear: don't clear any event types
+	e.PutUint16(0)            // selectAll: 0 — use per-event details below (not auto-select all)
+	e.PutUint16(0)            // affectMap
+	e.PutUint16(0)            // map
+	// Per-event details for StateNotify (included because StateNotify is in
+	// affectWhich but NOT in selectAll — XKB wire protocol requires detail pair):
 	e.PutUint16(XkbGroupStateMask) // affectState: we want group changes
 	e.PutUint16(XkbGroupStateMask) // stateDetails: group changes
 

--- a/internal/platform/x11/xkb.go
+++ b/internal/platform/x11/xkb.go
@@ -158,11 +158,11 @@ func (c *Connection) xkbSelectEvents(majorOpcode uint8) error {
 	e.PutUint8(XkbMinorOpcodeSelectEvents)
 	e.PutUint16(5)             // request length: 20 bytes / 4 = 5 units
 	e.PutUint16(XkbUseCoreKbd) // device spec
-	e.PutUint16(XkbStateMask) // affectWhich: subscribe to state events
-	e.PutUint16(0)            // clear: don't clear any event types
-	e.PutUint16(0)            // selectAll: 0 — use per-event details below (not auto-select all)
-	e.PutUint16(0)            // affectMap
-	e.PutUint16(0)            // map
+	e.PutUint16(XkbStateMask)  // affectWhich: subscribe to state events
+	e.PutUint16(0)             // clear: don't clear any event types
+	e.PutUint16(0)             // selectAll: 0 — use per-event details below (not auto-select all)
+	e.PutUint16(0)             // affectMap
+	e.PutUint16(0)             // map
 	// Per-event details for StateNotify (included because StateNotify is in
 	// affectWhich but NOT in selectAll — XKB wire protocol requires detail pair):
 	e.PutUint16(XkbGroupStateMask) // affectState: we want group changes


### PR DESCRIPTION
## Summary

Wayland keyboard layout support + X11 runtime layout switching fix. Completes FEAT-INPUT-020. Fixes #227.

### Wayland: xkbcommon integration
- `wayland/xkbcommon.go` — `XKBHandle` loads `libxkbcommon.so.0` via goffi
- `OnKeyboardKeymap` → `xkb_keymap_new_from_string` parses compositor keymap
- `OnKeyboardModifiers` → `xkb_state_update_mask` tracks layout group
- `OnKeyboardKey` → `xkb_state_key_get_utf8` for correct characters
- Graceful fallback to `evdevKeycodeToRune` if xkbcommon unavailable
- 17 new tests (12 integration + 5 xkbcommon unit)

### X11: runtime layout switching fix (@paulie-g)
- `XkbSelectEvents` wire format: `selectAll=XkbStateMask` caused per-event detail pair to be misinterpreted → events not delivered. Fix: `selectAll=0`
- Added `MappingNotify` → `XkbGetState` fallback (SDL3 pattern) for X servers that don't send `XkbStateNotify`

## Test plan

- [x] `go build ./...` — Windows ✅
- [x] `GOOS=linux go build ./...` — cross-compile ✅
- [x] `go test ./...` — all pass ✅
- [x] `golangci-lint run` — 0 issues (Windows, Linux, macOS) ✅
- [x] `go vet` — clean on Linux ✅
- [ ] CI: Build × 3, Test × 3, Lint, Formatting
- [ ] @paulie-g validation — X11 runtime layout switch
- [ ] @unxed validation — Wayland en+ru
