### PR TITLE
feat: ScrollPhase/IsMomentum + Wayland key repeat + X11 detectable auto-repeat (#239, #240, v0.37.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.0] - 2026-05-17
+
+### Added
+
+- **ScrollPhase + IsMomentum on ScrollEvent** (#239, ADR-032) -- `ScrollPhase` enum (None/Began/Changed/Ended/Canceled) and `IsMomentum bool` on `gpucontext.ScrollEvent`. macOS: maps NSEvent.phase and NSEvent.momentumPhase via new ObjC selectors. Enables apps to distinguish active scroll from trackpad momentum. Zero-value backward compatible. Requires gpucontext v0.19.0.
+
+### Fixed
+
+- **Wayland key repeat** (#240, ADR-033, @celer) -- client-side key repeat timer using `time.AfterFunc` + `time.Ticker` (winit pattern). Compositors send rate/delay via `wl_keyboard.repeat_info`, client generates repeat events. `xkb_keymap_key_repeats` check prevents modifier keys from repeating.
+- **X11 spurious KeyRelease during auto-repeat** (ADR-033) -- `XkbSetDetectableAutoRepeat` called during init via Xlib FFI. Eliminates fake KeyRelease events before each repeat KeyPress (GLFW/winit pattern).
+
+### Changed
+
+- **deps:** gpucontext v0.18.0 -> v0.19.0 (ScrollPhase API)
+
 ## [0.36.2] - 2026-05-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@
 | **Graphics API** | Runtime selection: Vulkan, DX12, Metal, GLES, Software |
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal), Browser/WASM (WebGPU) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), zero-copy surface rendering, damage-aware presentation |
-| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference, native macOS window tabbing |
+| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference, native macOS window tabbing |
+| **Scroll** | ScrollPhase + IsMomentum for macOS trackpad momentum detection (ADR-032), pixel/line/page delta modes |
 | **Sound** | Platform system sounds for UI feedback (winmm, NSSound, canberra/PulseAudio) |
 | **Compute** | Full compute shader support |
 | **Window Chrome** | Frameless windows with custom title bars, DWM shadow, hit-test regions |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.37.0** | 2026-05-17 | **ScrollPhase/IsMomentum** (#239, ADR-032) + **Wayland key repeat** (#240, ADR-033) + **X11 detectable auto-repeat** — gpucontext v0.19.0 |
 | **v0.36.2** | 2026-05-16 | **HiDPI logical sizing** (#237, ADR-030) + **Ring buffer event queue** (#238, ADR-031) — WithSize=logical, EventQueue[T] all platforms |
 | **v0.36.1** | 2026-05-16 | **X11 keyboard regression fix** — XkbStateNotify 6-field sync (winit pattern), UpdateKey→UpdateMask, cascading fallback |
 | **v0.36.0** | 2026-05-16 | **Unified XKB text input** (#233, ADR-029, @unxed) — AltGr/Level3 on all layouts, shared xkbcommon for X11+Wayland, 15 FFI bindings, ModsIndices, KeyWithoutModifiers |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -534,12 +534,12 @@ Platform Layer          InputState               Game Loop
 
 ### Platform Implementation
 
-| Platform | Pointer Events | Keyboard | Text Input | Scroll |
-|----------|---------------|----------|------------|--------|
-| Windows  | WM_MOUSE*     | WM_KEYDOWN/UP | WM_CHAR/SYSCHAR/UNICHAR (UTF-16 surrogates, AltGr via isAltGrSequence) | WM_MOUSEWHEEL |
-| Linux (Wayland) | wl_pointer (libwayland goffi) | wl_keyboard (libwayland goffi) | xkbcommon `xkb_state_key_get_utf8` (AltGr/Level3, all layouts) | wl_pointer.axis |
-| Linux (X11) | MotionNotify, ButtonPress | KeyPress/Release | xkbcommon `xkb_state_key_get_utf8` (AltGr/Level3, all layouts), fallback: KeysymToRune | Button 4-7 |
-| macOS    | NSEvent mouse | NSEvent key | NSEvent characters (UTF-8) | NSEvent scroll |
+| Platform | Pointer Events | Keyboard | Text Input | Scroll | Key Repeat |
+|----------|---------------|----------|------------|--------|------------|
+| Windows  | WM_MOUSE*     | WM_KEYDOWN/UP | WM_CHAR/SYSCHAR/UNICHAR (UTF-16 surrogates, AltGr via isAltGrSequence) | WM_MOUSEWHEEL | OS native (WM_KEYDOWN repeat) |
+| Linux (Wayland) | wl_pointer (libwayland goffi) | wl_keyboard (libwayland goffi) | xkbcommon `xkb_state_key_get_utf8` (AltGr/Level3, all layouts) | wl_pointer.axis | Client-side timer (ADR-033, `xkb_keymap_key_repeats`) |
+| Linux (X11) | MotionNotify, ButtonPress | KeyPress/Release | xkbcommon `xkb_state_key_get_utf8` (AltGr/Level3, all layouts), fallback: KeysymToRune | Button 4-7 | X server auto-repeat + `XkbSetDetectableAutoRepeat` |
+| macOS    | NSEvent mouse | NSEvent key | NSEvent characters (UTF-8) | NSEvent scroll (ScrollPhase + IsMomentum, ADR-032) | OS native (isARepeat) |
 
 ## Renderer Pipeline
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.1
 	github.com/go-webgpu/webgpu v0.4.3
-	github.com/gogpu/gpucontext v0.18.0
+	github.com/gogpu/gpucontext v0.19.0
 	github.com/gogpu/gputypes v0.5.0
 	github.com/gogpu/wgpu v0.28.1
 	golang.org/x/sys v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.5.1 h1:RSPR+YKT0tmbp5Uon+xwhN1veC9cehmqMptMkQuopok
 github.com/go-webgpu/goffi v0.5.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
-github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
+github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
+github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.13 h1:VlponVgD1fEfNotx0874M4n7tnfum8YlMEB3pBdd2Ps=

--- a/internal/platform/darwin/events.go
+++ b/internal/platform/darwin/events.go
@@ -54,6 +54,21 @@ func (a *Application) PollEventsWithHandler(handler EventHandler) bool {
 	return processed
 }
 
+// NSEventPhase is a bitmask that describes the phase of a scroll gesture.
+// macOS uses power-of-two values (not sequential).
+type NSEventPhase uint64
+
+// NSEventPhase constants from AppKit/NSEvent.h.
+const (
+	NSEventPhaseNone       NSEventPhase = 0
+	NSEventPhaseBegan      NSEventPhase = 1 << 0 // 1
+	NSEventPhaseStationary NSEventPhase = 1 << 1 // 2
+	NSEventPhaseChanged    NSEventPhase = 1 << 2 // 4
+	NSEventPhaseEnded      NSEventPhase = 1 << 3 // 8
+	NSEventPhaseCancelled  NSEventPhase = 1 << 4 // 16
+	NSEventPhaseMayBegin   NSEventPhase = 1 << 5 // 32
+)
+
 // EventInfo contains extracted information from an NSEvent for pointer handling.
 type EventInfo struct {
 	Type          NSEventType
@@ -65,6 +80,9 @@ type EventInfo struct {
 	ScrollDeltaY  float64
 	IsPrecise     bool
 	KeyCode       uint16 // Virtual key code for keyboard events
+	// Scroll gesture phases (macOS trackpad)
+	Phase         NSEventPhase // Active gesture phase
+	MomentumPhase NSEventPhase // Momentum/inertia phase
 	// Tablet/pen properties
 	Subtype            NSUInteger
 	Pressure           float64 // 0.0-1.0 (pen pressure)
@@ -120,7 +138,7 @@ func GetEventInfo(event ID) EventInfo {
 		}
 	}
 
-	// Scroll deltas
+	// Scroll deltas and gesture phases
 	if info.Type == NSEventTypeScrollWheel {
 		info.IsPrecise = event.GetBool(selectors.hasPreciseScrollingDeltas)
 		if info.IsPrecise {
@@ -131,6 +149,10 @@ func GetEventInfo(event ID) EventInfo {
 			info.ScrollDeltaX = event.GetDouble(selectors.deltaX)
 			info.ScrollDeltaY = event.GetDouble(selectors.deltaY)
 		}
+		// Gesture phase tracking for trackpad scroll gestures.
+		// phase = active touch gesture, momentumPhase = inertial coast after lift.
+		info.Phase = NSEventPhase(event.GetUint64(selectors.phase))
+		info.MomentumPhase = NSEventPhase(event.GetUint64(selectors.momentumPhase))
 	}
 
 	// Key code for keyboard events

--- a/internal/platform/darwin/selectors.go
+++ b/internal/platform/darwin/selectors.go
@@ -122,6 +122,10 @@ var selectors struct {
 	deltaX                      SEL
 	deltaY                      SEL
 
+	// NSEvent - scroll gesture phases (macOS trackpad)
+	phase         SEL // NSEventPhase bitmask for active gesture
+	momentumPhase SEL // NSEventPhase bitmask for momentum/inertia
+
 	// NSEvent - tablet/pen properties
 	pressure           SEL
 	tilt               SEL // Returns NSPoint {x, y} each -1.0 to 1.0
@@ -314,6 +318,10 @@ func initSelectors() {
 		selectors.hasPreciseScrollingDeltas = RegisterSelector("hasPreciseScrollingDeltas")
 		selectors.deltaX = RegisterSelector("deltaX")
 		selectors.deltaY = RegisterSelector("deltaY")
+
+		// NSEvent - scroll gesture phases (macOS trackpad)
+		selectors.phase = RegisterSelector("phase")
+		selectors.momentumPhase = RegisterSelector("momentumPhase")
 
 		// NSEvent - tablet/pen properties
 		selectors.pressure = RegisterSelector("pressure")

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -594,14 +594,26 @@ func (w *darwinWindow) handleEvent(event darwin.ID, eventType darwin.NSEventType
 			// logical coordinate system. No scaling needed.
 		}
 
+		// Map macOS NSEventPhase to ScrollPhase.
+		// momentumPhase != None means this is an inertial scroll event.
+		isMomentum := info.MomentumPhase != darwin.NSEventPhaseNone
+		var phase gpucontext.ScrollPhase
+		if isMomentum {
+			phase = mapNSEventPhase(info.MomentumPhase)
+		} else {
+			phase = mapNSEventPhase(info.Phase)
+		}
+
 		ev := gpucontext.ScrollEvent{
-			X:         info.LocationX,
-			Y:         y,
-			DeltaX:    deltaX,
-			DeltaY:    deltaY,
-			DeltaMode: deltaMode,
-			Modifiers: w.modifiers,
-			Timestamp: w.eventTimestamp(),
+			X:          info.LocationX,
+			Y:          y,
+			DeltaX:     deltaX,
+			DeltaY:     deltaY,
+			DeltaMode:  deltaMode,
+			Modifiers:  w.modifiers,
+			Timestamp:  w.eventTimestamp(),
+			Phase:      phase,
+			IsMomentum: isMomentum,
 		}
 		w.dispatchScrollEvent(ev)
 
@@ -799,6 +811,23 @@ func (w *darwinWindow) checkResize() {
 // eventTimestamp returns the event timestamp as duration since start.
 func (w *darwinWindow) eventTimestamp() time.Duration {
 	return time.Since(w.startTime)
+}
+
+// mapNSEventPhase converts macOS NSEventPhase bitmask to gpucontext.ScrollPhase.
+// NSEventPhase uses power-of-two values; we collapse them to sequential enum.
+func mapNSEventPhase(phase darwin.NSEventPhase) gpucontext.ScrollPhase {
+	switch {
+	case phase&darwin.NSEventPhaseBegan != 0 || phase&darwin.NSEventPhaseMayBegin != 0:
+		return gpucontext.ScrollPhaseBegan
+	case phase&darwin.NSEventPhaseChanged != 0 || phase&darwin.NSEventPhaseStationary != 0:
+		return gpucontext.ScrollPhaseChanged
+	case phase&darwin.NSEventPhaseEnded != 0:
+		return gpucontext.ScrollPhaseEnded
+	case phase&darwin.NSEventPhaseCancelled != 0:
+		return gpucontext.ScrollPhaseCanceled
+	default:
+		return gpucontext.ScrollPhaseNone
+	}
 }
 
 // extractModifiers converts NSEventModifierFlags to gpucontext.Modifiers.

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -23,6 +23,7 @@ import (
 type xkbKeyHandler interface {
 	Ready() bool
 	KeyGetUtf8(keycode uint32) string
+	KeyRepeats(keycode uint32) bool
 	UpdateMask(modsDepressed, modsLatched, modsLocked, layoutDepressed, layoutLatched, layoutLocked uint32)
 	SetKeymapFromFD(fd int, size uint32) error
 	Close()
@@ -71,6 +72,16 @@ type waylandWindow struct {
 	// XKB keyboard layout support (libxkbcommon.so.0 via goffi).
 	// Non-nil when libxkbcommon is available; nil falls back to evdevKeycodeToRune.
 	xkb xkbKeyHandler
+
+	// Key repeat state (Wayland client-side timer, ADR-033).
+	// Wayland compositors send rate/delay via wl_keyboard.repeat_info
+	// but do NOT send synthetic key events. Client must implement timer.
+	repeatMu    sync.Mutex
+	repeatKey   uint32        // evdev keycode of currently repeating key (0 = none)
+	repeatRate  int32         // keys per second (from compositor)
+	repeatDelay int32         // milliseconds before first repeat (from compositor)
+	repeatTimer *time.Timer   // initial delay timer
+	repeatStop  chan struct{} // signal to stop repeat goroutine
 
 	callbackMu sync.RWMutex
 }
@@ -880,6 +891,8 @@ func (p *waylandPlatform) setupInputCallbacks() {
 			w.pointerMu.Lock()
 			w.keyboardFocused = false
 			w.pointerMu.Unlock()
+			// Cancel any active key repeat on focus lost (ADR-033)
+			w.cancelAllKeyRepeat()
 			w.queueEvent(Event{Type: EventFocus, Focused: false})
 		},
 		OnKeyboardKey: func(serial, timeMs, key, state uint32) {
@@ -905,6 +918,13 @@ func (p *waylandPlatform) setupInputCallbacks() {
 					w.queueEvent(Event{Type: EventChar, Char: r})
 				}
 			}
+
+			// Key repeat management (Wayland client-side, ADR-033)
+			if pressed {
+				w.startKeyRepeat(key, gpuKey, mods)
+			} else {
+				w.stopKeyRepeat(key)
+			}
 		},
 		OnKeyboardModifiers: func(serial, modsDepressed, modsLatched, modsLocked, group uint32) {
 			w.pointerMu.Lock()
@@ -918,7 +938,10 @@ func (p *waylandPlatform) setupInputCallbacks() {
 			}
 		},
 		OnKeyboardRepeat: func(rate, delay int32) {
-			// Stored for future key repeat implementation
+			w.repeatMu.Lock()
+			w.repeatRate = rate
+			w.repeatDelay = delay
+			w.repeatMu.Unlock()
 		},
 
 		// Touch events
@@ -1214,6 +1237,87 @@ func (w *waylandWindow) dispatchKeyEvent(key gpucontext.Key, mods gpucontext.Mod
 // queueEvent pushes a platform event to the window's ring buffer queue.
 func (w *waylandWindow) queueEvent(event Event) {
 	w.events.Push(event)
+}
+
+// startKeyRepeat begins client-side key repeat for the given key (ADR-033).
+// Wayland compositors send repeat_info (rate/delay) but do NOT generate
+// synthetic key events -- the client must implement its own timer.
+func (w *waylandWindow) startKeyRepeat(evdevKey uint32, gpuKey gpucontext.Key, mods gpucontext.Modifiers) {
+	w.repeatMu.Lock()
+	defer w.repeatMu.Unlock()
+
+	// Check if key should repeat (skip modifiers, function keys, etc.)
+	if w.xkb != nil && w.xkb.Ready() {
+		if !w.xkb.KeyRepeats(evdevKey) {
+			return
+		}
+	}
+
+	// Cancel any existing repeat
+	w.cancelRepeatLocked()
+
+	rate := w.repeatRate
+	delay := w.repeatDelay
+	if rate <= 0 || delay <= 0 {
+		return // Repeat disabled by compositor
+	}
+
+	w.repeatKey = evdevKey
+	w.repeatStop = make(chan struct{})
+	stop := w.repeatStop
+
+	interval := time.Second / time.Duration(rate)
+
+	// Start initial delay timer, then repeat at rate
+	w.repeatTimer = time.AfterFunc(time.Duration(delay)*time.Millisecond, func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				// Generate repeat key event
+				w.dispatchKeyEvent(gpuKey, mods, true)
+				// Generate repeat char event (printable keys only)
+				if r := w.keycodeToRune(evdevKey); r >= 32 {
+					w.queueEvent(Event{Type: EventChar, Char: r})
+				}
+			}
+		}
+	})
+}
+
+// stopKeyRepeat stops key repeat if the released key matches the repeating key.
+func (w *waylandWindow) stopKeyRepeat(evdevKey uint32) {
+	w.repeatMu.Lock()
+	defer w.repeatMu.Unlock()
+	if w.repeatKey == evdevKey {
+		w.cancelRepeatLocked()
+	}
+}
+
+// cancelAllKeyRepeat unconditionally cancels any active key repeat.
+// Used on focus lost and window destroy.
+func (w *waylandWindow) cancelAllKeyRepeat() {
+	w.repeatMu.Lock()
+	defer w.repeatMu.Unlock()
+	w.cancelRepeatLocked()
+}
+
+// cancelRepeatLocked stops the repeat timer and goroutine.
+// Caller must hold w.repeatMu.
+func (w *waylandWindow) cancelRepeatLocked() {
+	if w.repeatStop != nil {
+		close(w.repeatStop)
+		w.repeatStop = nil
+	}
+	if w.repeatTimer != nil {
+		w.repeatTimer.Stop()
+		w.repeatTimer = nil
+	}
+	w.repeatKey = 0
 }
 
 // evdevModsToModifiers converts evdev modifier bitmasks to gpucontext.Modifiers.

--- a/internal/platform/wayland_xkb_test.go
+++ b/internal/platform/wayland_xkb_test.go
@@ -303,6 +303,10 @@ func (m *mockXKBHandle) SetKeymapFromFD(fd int, size uint32) error {
 	return nil
 }
 
+func (m *mockXKBHandle) KeyRepeats(_ uint32) bool {
+	return true // All keys repeat in tests
+}
+
 func (m *mockXKBHandle) Close() {}
 
 // Verify mockXKBHandle satisfies xkbKeyHandler at compile time.

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -459,6 +459,14 @@ func (p *Platform) Init(config Config) error {
 		logger().Info("x11 DPI scale", "factor", p.scaleFactor)
 	}
 
+	// Enable detectable auto-repeat to suppress spurious KeyRelease events
+	// during key repeat. Without this, X11 sends KeyRelease+KeyPress pairs
+	// for each repeat, making it impossible to distinguish real release from repeat.
+	// ADR-033: Key Repeat.
+	if xlib != nil {
+		p.setDetectableAutoRepeat()
+	}
+
 	if xlib != nil {
 		logger().Info("x11 init complete", "window", fmt.Sprintf("%#x", w.window), "display", fmt.Sprintf("%#x", xlib.display))
 	} else {
@@ -1281,6 +1289,55 @@ func (p *Platform) Destroy() {
 	p.primary = nil
 	p.atoms = nil
 	p.keymap = nil
+}
+
+// setDetectableAutoRepeat calls XkbSetDetectableAutoRepeat to suppress
+// spurious KeyRelease events during key repeat (ADR-033).
+// Without this, X11 sends a KeyRelease immediately before each synthetic
+// KeyPress during repeat, making it impossible to distinguish a real
+// key release from a repeat-related one.
+func (p *Platform) setDetectableAutoRepeat() {
+	if p.xlib == nil || p.xlib.display == 0 {
+		return
+	}
+
+	// XkbSetDetectableAutoRepeat(Display*, Bool detectable, Bool* supported_rtrn) -> Bool
+	sym, err := ffi.GetSymbol(p.xlib.lib, "XkbSetDetectableAutoRepeat")
+	if err != nil || sym == nil {
+		logger().Debug("XkbSetDetectableAutoRepeat not available", "err", err)
+		return
+	}
+
+	// Prepare CIF: (Display*, Bool, Bool*) -> Bool
+	// In X11: Bool = int (4 bytes), Display* = ptr
+	var cif types.CallInterface
+	if err := ffi.PrepareCallInterface(&cif, types.DefaultCall,
+		types.SInt32TypeDescriptor, // return Bool
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // Display*
+			types.SInt32TypeDescriptor,  // Bool detectable
+			types.PointerTypeDescriptor, // Bool* supported_rtrn
+		}); err != nil {
+		logger().Debug("XkbSetDetectableAutoRepeat: failed to prepare CIF", "err", err)
+		return
+	}
+
+	detectable := int32(1) // True — enable detectable auto-repeat
+	var supported int32
+	var result int32
+	display := p.xlib.display
+	args := [3]unsafe.Pointer{
+		unsafe.Pointer(&display),
+		unsafe.Pointer(&detectable),
+		unsafe.Pointer(&supported),
+	}
+	_ = ffi.CallFunction(&cif, sym, unsafe.Pointer(&result), args[:])
+
+	if supported != 0 {
+		logger().Info("XkbSetDetectableAutoRepeat enabled")
+	} else {
+		logger().Debug("XkbSetDetectableAutoRepeat: server does not support detectable auto-repeat")
+	}
 }
 
 // dispatchPointerEvent pushes a pointer event to the event queue.

--- a/internal/platform/xkb/xkb.go
+++ b/internal/platform/xkb/xkb.go
@@ -70,6 +70,9 @@ type Handle struct {
 	fnStateModNameIsActive    unsafe.Pointer // xkb_state_mod_name_is_active(state, name, type) -> int
 	fnStateKeyGetLayout       unsafe.Pointer // xkb_state_key_get_layout(state, key) -> layout_index
 
+	// Function pointers -- ADR-033: key repeat
+	fnKeymapKeyRepeats unsafe.Pointer // xkb_keymap_key_repeats(keymap, key) -> int
+
 	// Call interfaces (prepared once) -- existing
 	cifContextNew          types.CallInterface
 	cifContextUnref        types.CallInterface
@@ -90,6 +93,9 @@ type Handle struct {
 	cifKeymapModGetIndex       types.CallInterface
 	cifStateModNameIsActive    types.CallInterface
 	cifStateKeyGetLayout       types.CallInterface
+
+	// Call interfaces -- ADR-033: key repeat
+	cifKeymapKeyRepeats types.CallInterface
 }
 
 // xkbcommon constants.
@@ -398,6 +404,26 @@ func (h *Handle) ModNameIsActive(name string) bool {
 	return h.stateModNameIsActive(name) == 1
 }
 
+// KeyRepeats returns true if the given key should generate repeat events.
+// Most printable and editing keys repeat; modifiers and function keys do not.
+// keycode is the evdev keycode (NOT offset -- offset is applied internally).
+// Returns false when no keymap is loaded or xkb_keymap_key_repeats is unavailable.
+func (h *Handle) KeyRepeats(keycode uint32) bool {
+	if h == nil || h.keymap == 0 || h.fnKeymapKeyRepeats == nil {
+		return false
+	}
+
+	xkbKey := keycode + XKBEvdevOffset
+
+	var result int32
+	args := [2]unsafe.Pointer{
+		unsafe.Pointer(&h.keymap),
+		unsafe.Pointer(&xkbKey),
+	}
+	_ = ffi.CallFunction(&h.cifKeymapKeyRepeats, h.fnKeymapKeyRepeats, unsafe.Pointer(&result), args[:])
+	return result == 1
+}
+
 // GetModsIndices returns the cached modifier indices resolved at keymap creation.
 func (h *Handle) GetModsIndices() ModsIndices {
 	if h == nil {
@@ -497,6 +523,7 @@ func (h *Handle) resolveSymbols() error {
 		{"xkb_keymap_mod_get_index", &h.fnKeymapModGetIndex},
 		{"xkb_state_mod_name_is_active", &h.fnStateModNameIsActive},
 		{"xkb_state_key_get_layout", &h.fnStateKeyGetLayout},
+		{"xkb_keymap_key_repeats", &h.fnKeymapKeyRepeats},
 	}
 
 	for _, s := range phase2 {
@@ -599,6 +626,14 @@ func (h *Handle) prepareCIFs() error {
 		// xkb_layout_index_t xkb_state_key_get_layout(state, key) -> uint32
 		if err := ffi.PrepareCallInterface(&h.cifStateKeyGetLayout, types.DefaultCall, u32, []*types.TypeDescriptor{ptr, u32}); err != nil {
 			return fmt.Errorf("xkbcommon: failed to prepare CIF state_key_get_layout: %w", err)
+		}
+	}
+
+	// ADR-033: key repeat
+	if h.fnKeymapKeyRepeats != nil {
+		// int xkb_keymap_key_repeats(keymap, key) -> int32
+		if err := ffi.PrepareCallInterface(&h.cifKeymapKeyRepeats, types.DefaultCall, i32, []*types.TypeDescriptor{ptr, u32}); err != nil {
+			return fmt.Errorf("xkbcommon: failed to prepare CIF keymap_key_repeats: %w", err)
 		}
 	}
 

--- a/internal/platform/xkb/xkb_test.go
+++ b/internal/platform/xkb/xkb_test.go
@@ -295,3 +295,30 @@ func TestResolveModsIndicesNoKeymap(t *testing.T) {
 		t.Errorf("resolveModsIndices (no keymap).Alt = %d, want %d", indices.Alt, xkbModInvalid)
 	}
 }
+
+// TestKeyRepeatsNilHandle verifies KeyRepeats returns false on nil handle.
+func TestKeyRepeatsNilHandle(t *testing.T) {
+	var h *Handle
+	if h.KeyRepeats(30) {
+		t.Error("nil Handle.KeyRepeats(30) = true, want false")
+	}
+}
+
+// TestKeyRepeatsNoKeymap verifies KeyRepeats returns false when no keymap is loaded.
+func TestKeyRepeatsNoKeymap(t *testing.T) {
+	h := &Handle{} // keymap is 0
+	if h.KeyRepeats(30) {
+		t.Error("empty Handle.KeyRepeats(30) = true, want false")
+	}
+}
+
+// TestKeyRepeatsNoSymbol verifies KeyRepeats returns false when symbol is not resolved.
+func TestKeyRepeatsNoSymbol(t *testing.T) {
+	h := &Handle{
+		keymap: 0x12345678, // Fake non-zero keymap
+		// fnKeymapKeyRepeats is nil (symbol not resolved)
+	}
+	if h.KeyRepeats(30) {
+		t.Error("Handle.KeyRepeats(30) with nil symbol = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary

- **ScrollPhase + IsMomentum** (#239, ADR-032) -- macOS trackpad momentum detection via NSEvent.phase/momentumPhase
- **Wayland key repeat** (#240, ADR-033, @celer) -- client-side timer fixes backspace/key hold
- **X11 detectable auto-repeat** (ADR-033) -- XkbSetDetectableAutoRepeat eliminates spurious KeyRelease

## ScrollPhase (macOS)

- `ScrollPhase` enum: None/Began/Changed/Ended/Canceled
- `IsMomentum bool` on ScrollEvent
- New ObjC selectors: phase, momentumPhase
- Zero-value backward compatible (all other platforms: None/false)
- Requires gpucontext v0.19.0

## Key Repeat (Wayland)

- Client-side timer: `time.AfterFunc(delay)` then `time.Ticker(1/rate)`
- `xkb_keymap_key_repeats` check (skip modifier keys)
- Cancel on key release / focus lost
- Generates KeyDown + EventChar on each tick

## X11 Auto-Repeat

- `XkbSetDetectableAutoRepeat(display, True)` via Xlib FFI
- Suppresses fake KeyRelease before each repeat KeyPress

## Test plan

- [ ] CI passes (Linux, Windows, macOS)
- [ ] @celer: Wayland -- hold backspace, chars deleted continuously
- [ ] @unxed: X11 -- no spurious KeyRelease during repeat
- [ ] macOS tester: trackpad scroll -- ScrollPhase values correct

Closes #239
Closes #240