### PR TITLE
fix: X11 multi-layout keymap via _XKB_RULES_NAMES (#233, v0.37.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.1] - 2026-05-17
+
+### Fixed
+
+- **X11 Russian keyboard input** (#233, @unxed) -- `xkb_keymap_new_from_names(NULL)` loaded only system default layout ("us"). Now reads `_XKB_RULES_NAMES` property from X11 root window for actual RMLVO configuration (e.g., "us,ru,ru"). Zero new dependencies -- uses existing pure Go X11 protocol. Graceful fallback to system defaults if property missing.
+
 ## [0.37.0] - 2026-05-17
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.37.1** | 2026-05-17 | **X11 Russian keyboard fix** (#233) — `_XKB_RULES_NAMES` root window property for multi-layout keymap (pure Go, zero deps) |
 | **v0.37.0** | 2026-05-17 | **ScrollPhase/IsMomentum** (#239, ADR-032) + **Wayland key repeat** (#240, ADR-033) + **X11 detectable auto-repeat** — gpucontext v0.19.0 |
 | **v0.36.2** | 2026-05-16 | **HiDPI logical sizing** (#237, ADR-030) + **Ring buffer event queue** (#238, ADR-031) — WithSize=logical, EventQueue[T] all platforms |
 | **v0.36.1** | 2026-05-16 | **X11 keyboard regression fix** — XkbStateNotify 6-field sync (winit pattern), UpdateKey→UpdateMask, cascading fallback |

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -389,20 +389,9 @@ func (p *Platform) Init(config Config) error {
 	}
 
 	// Load libxkbcommon for proper text input (AltGr, dead keys, multi-layout).
-	// Uses system default keymap via xkb_keymap_new_from_names(NULL).
+	// First try RMLVO from _XKB_RULES_NAMES, then system defaults.
 	// Non-fatal: falls back to manual KeycodeToKeysymGroup (no AltGr support).
-	xkbHandle, xkbcommonErr := xkbcommon.New()
-	if xkbcommonErr != nil {
-		logger().Info("xkbcommon not available for X11, AltGr may not work", "err", xkbcommonErr)
-	} else {
-		if namesErr := xkbHandle.SetKeymapFromNames(); namesErr != nil {
-			logger().Warn("xkbcommon: failed to load system keymap", "err", namesErr)
-			xkbHandle.Close()
-		} else {
-			p.xkbState = xkbHandle
-			logger().Info("xkbcommon enabled for X11 text input")
-		}
-	}
+	p.initXkbcommon()
 
 	// Initialize XInput2 for touch support (non-fatal)
 	xi, err := conn.InitXInput2()
@@ -644,6 +633,110 @@ func parseXftRGBA(resources string) gpucontext.SubpixelLayout {
 	}
 	// Xft.rgba not set — default to RGB (most common LCD layout).
 	return gpucontext.SubpixelRGB
+}
+
+// initXkbcommon loads libxkbcommon and creates a keymap.
+// First tries to read the X server's actual RMLVO configuration from
+// _XKB_RULES_NAMES root window property (BUG-INPUT-004: multi-layout support).
+// Falls back to xkb_keymap_new_from_names(NULL) which only loads "us".
+// Non-fatal: if xkbcommon is unavailable, keyboard falls back to manual keysym lookup.
+func (p *Platform) initXkbcommon() {
+	xkbHandle, xkbcommonErr := xkbcommon.New()
+	if xkbcommonErr != nil {
+		logger().Info("xkbcommon not available for X11, AltGr may not work", "err", xkbcommonErr)
+		return
+	}
+
+	// Try to load keymap from X server's actual configuration.
+	// Read _XKB_RULES_NAMES property from root window for RMLVO.
+	loaded := false
+	rules, model, layout, variant, options := p.readXKBRulesNames()
+	if layout != "" {
+		if err := xkbHandle.SetKeymapFromRMLVO(rules, model, layout, variant, options); err != nil {
+			logger().Warn("xkbcommon: RMLVO keymap failed, trying defaults", "err", err, "layout", layout)
+		} else {
+			loaded = true
+			logger().Info("xkbcommon: keymap loaded from _XKB_RULES_NAMES", "layout", layout)
+		}
+	}
+
+	// Fallback to system defaults if RMLVO not available
+	if !loaded {
+		if err := xkbHandle.SetKeymapFromNames(); err != nil {
+			logger().Warn("xkbcommon: failed to load system keymap", "err", err)
+			xkbHandle.Close()
+			return
+		}
+		logger().Info("xkbcommon: keymap loaded from system defaults")
+	}
+
+	p.xkbState = xkbHandle
+}
+
+// readXKBRulesNames reads the _XKB_RULES_NAMES property from the root window.
+// Returns RMLVO (rules, model, layout, variant, options).
+// The property contains 5 null-terminated strings concatenated:
+// "evdev\0pc105\0us,ru,ru\0,,phonetic\0grp:alt_shift_toggle\0"
+// If property is missing or empty, all returned strings are empty.
+func (p *Platform) readXKBRulesNames() (string, string, string, string, string) {
+	if p.conn == nil {
+		return "", "", "", "", ""
+	}
+
+	// Intern the _XKB_RULES_NAMES atom
+	atom, err := p.conn.InternAtom("_XKB_RULES_NAMES", true)
+	if err != nil || atom == AtomNone {
+		return "", "", "", "", ""
+	}
+
+	// Get root window
+	root := p.conn.RootWindow()
+	if root == 0 {
+		return "", "", "", "", ""
+	}
+
+	// Read property (type AnyPropertyType=0, up to 256 longs = 1024 bytes)
+	data, _, _, err := p.conn.GetProperty(root, atom, Atom(0), 0, 256, false)
+	if err != nil || len(data) == 0 {
+		return "", "", "", "", ""
+	}
+
+	// Parse 5 null-terminated strings
+	parts := splitNullTerminated(data, 5)
+	var rules, model, layout, variant, options string
+	if len(parts) >= 1 {
+		rules = parts[0]
+	}
+	if len(parts) >= 2 {
+		model = parts[1]
+	}
+	if len(parts) >= 3 {
+		layout = parts[2]
+	}
+	if len(parts) >= 4 {
+		variant = parts[3]
+	}
+	if len(parts) >= 5 {
+		options = parts[4]
+	}
+
+	return rules, model, layout, variant, options
+}
+
+// splitNullTerminated splits a byte slice by null bytes into up to maxParts strings.
+func splitNullTerminated(data []byte, maxParts int) []string {
+	var parts []string
+	start := 0
+	for i, b := range data {
+		if b == 0 {
+			parts = append(parts, string(data[start:i]))
+			start = i + 1
+			if len(parts) >= maxParts {
+				break
+			}
+		}
+	}
+	return parts
 }
 
 // PollEvents processes pending X11 events.

--- a/internal/platform/x11/xkb_test.go
+++ b/internal/platform/x11/xkb_test.go
@@ -994,3 +994,84 @@ func TestXkbConstantsNotConfused(t *testing.T) {
 		t.Fatalf("XkbMapNotifyMask = 0x%04X, want 0x0002", XkbMapNotifyMask)
 	}
 }
+
+// --- Section 8: BUG-INPUT-004 — splitNullTerminated Tests ---
+
+func TestSplitNullTerminated(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		maxParts int
+		want     []string
+	}{
+		{
+			name:     "empty data",
+			data:     nil,
+			maxParts: 5,
+			want:     nil,
+		},
+		{
+			name:     "empty byte slice",
+			data:     []byte{},
+			maxParts: 5,
+			want:     nil,
+		},
+		{
+			name:     "5 parts typical RMLVO",
+			data:     []byte("evdev\x00pc105\x00us,ru,ru\x00,,phonetic\x00grp:alt_shift_toggle\x00"),
+			maxParts: 5,
+			want:     []string{"evdev", "pc105", "us,ru,ru", ",,phonetic", "grp:alt_shift_toggle"},
+		},
+		{
+			name:     "5 parts simple",
+			data:     []byte("evdev\x00pc105\x00us\x00\x00\x00"),
+			maxParts: 5,
+			want:     []string{"evdev", "pc105", "us", "", ""},
+		},
+		{
+			name:     "fewer parts than max",
+			data:     []byte("evdev\x00pc105\x00"),
+			maxParts: 5,
+			want:     []string{"evdev", "pc105"},
+		},
+		{
+			name:     "maxParts limits extraction",
+			data:     []byte("a\x00b\x00c\x00d\x00e\x00f\x00"),
+			maxParts: 3,
+			want:     []string{"a", "b", "c"},
+		},
+		{
+			name:     "single null byte",
+			data:     []byte{0},
+			maxParts: 5,
+			want:     []string{""},
+		},
+		{
+			name:     "no null terminator in data",
+			data:     []byte("evdev"),
+			maxParts: 5,
+			want:     nil,
+		},
+		{
+			name:     "trailing data after null",
+			data:     []byte("evdev\x00trailing"),
+			maxParts: 5,
+			want:     []string{"evdev"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitNullTerminated(tt.data, tt.maxParts)
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitNullTerminated() returned %d parts, want %d\ngot:  %q\nwant: %q",
+					len(got), len(tt.want), got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("part[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/platform/xkb/xkb.go
+++ b/internal/platform/xkb/xkb.go
@@ -209,6 +209,89 @@ func (h *Handle) SetKeymapFromFD(fd int, size uint32) error {
 	return nil
 }
 
+// SetKeymapFromRMLVO creates a keymap from explicit RMLVO configuration.
+// This is used on X11 to load the server's actual keymap (read from _XKB_RULES_NAMES
+// root window property) instead of system defaults. This ensures multi-layout configs
+// (e.g., "us,ru,ru") are loaded with all groups, not just the first one.
+func (h *Handle) SetKeymapFromRMLVO(rules, model, layout, variant, options string) error {
+	if h == nil {
+		return fmt.Errorf("xkbcommon: handle is nil")
+	}
+	if h.fnKeymapNewFromNames == nil {
+		return fmt.Errorf("xkbcommon: xkb_keymap_new_from_names not available")
+	}
+
+	// Destroy old keymap/state
+	h.destroyState()
+	h.destroyKeymap()
+
+	// Build null-terminated C strings.
+	// These slices MUST stay alive until after the FFI call returns
+	// (Go GC could collect them if no references remain).
+	rulesC := append([]byte(rules), 0)
+	modelC := append([]byte(model), 0)
+	layoutC := append([]byte(layout), 0)
+	variantC := append([]byte(variant), 0)
+	optionsC := append([]byte(options), 0)
+
+	// Build xkb_rule_names struct: 5 consecutive pointer-sized fields.
+	// struct xkb_rule_names { const char *rules, *model, *layout, *variant, *options; }
+	var rulesPtr, modelPtr, layoutPtr, variantPtr, optionsPtr uintptr
+	if rules != "" {
+		rulesPtr = uintptr(unsafe.Pointer(&rulesC[0]))
+	}
+	if model != "" {
+		modelPtr = uintptr(unsafe.Pointer(&modelC[0]))
+	}
+	if layout != "" {
+		layoutPtr = uintptr(unsafe.Pointer(&layoutC[0]))
+	}
+	if variant != "" {
+		variantPtr = uintptr(unsafe.Pointer(&variantC[0]))
+	}
+	if options != "" {
+		optionsPtr = uintptr(unsafe.Pointer(&optionsC[0]))
+	}
+
+	// xkb_rule_names struct in memory: 5 pointers
+	names := [5]uintptr{rulesPtr, modelPtr, layoutPtr, variantPtr, optionsPtr}
+	namesPtr := uintptr(unsafe.Pointer(&names[0]))
+
+	flags := XKBKeymapCompileNoFlags
+	var result uintptr
+	args := [3]unsafe.Pointer{
+		unsafe.Pointer(&h.context),
+		unsafe.Pointer(&namesPtr),
+		unsafe.Pointer(&flags),
+	}
+	_ = ffi.CallFunction(&h.cifKeymapNewFromNames, h.fnKeymapNewFromNames, unsafe.Pointer(&result), args[:])
+	if result == 0 {
+		return fmt.Errorf("xkbcommon: xkb_keymap_new_from_names returned NULL for layout %q", layout)
+	}
+	h.keymap = result
+
+	// Create state
+	state, err := h.stateNew(result)
+	if err != nil {
+		h.destroyKeymap()
+		return err
+	}
+	h.state = state
+
+	// Resolve modifier indices for the new keymap
+	h.resolveModsIndices()
+
+	// Keep references alive past FFI call (prevent premature GC).
+	_ = rulesC
+	_ = modelC
+	_ = layoutC
+	_ = variantC
+	_ = optionsC
+
+	slog.Debug("xkbcommon: keymap loaded from RMLVO", "layout", layout, "model", model, "options", options)
+	return nil
+}
+
 // SetKeymapFromNames creates a keymap from system default XKB configuration.
 // Calls xkb_keymap_new_from_names(context, NULL, 0) which reads RMLVO from:
 // - XKB_DEFAULT_* environment variables

--- a/internal/platform/xkb/xkb_test.go
+++ b/internal/platform/xkb/xkb_test.go
@@ -322,3 +322,23 @@ func TestKeyRepeatsNoSymbol(t *testing.T) {
 		t.Error("Handle.KeyRepeats(30) with nil symbol = true, want false")
 	}
 }
+
+// --- BUG-INPUT-004: SetKeymapFromRMLVO tests ---
+
+// TestSetKeymapFromRMLVO_NilHandle verifies error on nil handle.
+func TestSetKeymapFromRMLVO_NilHandle(t *testing.T) {
+	var h *Handle
+	err := h.SetKeymapFromRMLVO("evdev", "pc105", "us,ru", ",", "")
+	if err == nil {
+		t.Error("nil Handle.SetKeymapFromRMLVO() = nil, want error")
+	}
+}
+
+// TestSetKeymapFromRMLVO_NoFunction verifies error when symbol is not resolved.
+func TestSetKeymapFromRMLVO_NoFunction(t *testing.T) {
+	h := &Handle{} // fnKeymapNewFromNames is nil
+	err := h.SetKeymapFromRMLVO("evdev", "pc105", "us,ru", ",", "")
+	if err == nil {
+		t.Error("Handle.SetKeymapFromRMLVO() with nil symbol = nil, want error")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes Russian keyboard input on X11 (#233, @unxed). Root cause: `xkb_keymap_new_from_names(NULL)` loaded only system default layout (\"us\"). User has `us,ru,ru` but xkbcommon keymap had only 1 group.

## Fix

Read `_XKB_RULES_NAMES` property from X11 root window (standard since X.Org 7.0, 2005). Parse RMLVO, pass to `xkb_keymap_new_from_names` with populated struct. Zero new dependencies -- pure Go X11 protocol.

## Why not XCB (winit/Qt6 approach)?

winit/Qt6 use `xkb_x11_keymap_new_from_device` via XCB. This requires 2 new .so libraries + 5 FFI bindings. We have pure Go X11 protocol -- XCB is unnecessary. `_XKB_RULES_NAMES` produces identical keymap.

## Changes

- `xkb.Handle.SetKeymapFromRMLVO()` -- builds `xkb_rule_names` struct, passes to `xkb_keymap_new_from_names`
- `x11.Platform.readXKBRulesNames()` -- reads root window property via existing InternAtom + GetProperty
- `x11.Platform.initXkbcommon()` -- RMLVO -> system defaults -> manual fallback chain
- 10 new tests (splitNullTerminated, nil safety)

## Test plan

- [ ] CI passes
- [ ] @unxed: X11, layout us,ru,ru -- Russian characters work
- [ ] Wayland -- no regression