### PR TITLE
fix: diagnostic logging for PresentTexture/drawTexturedQuad (#247, v0.37.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.2] - 2026-05-17
+
+### Added
+
+- **Diagnostic logging for presentation layer** (#247) -- `slog.Debug` in `PresentTexture` (texture+surface dims+scale), `drawTexturedQuad` (quad+texture dims, first 3 frames), and `resize` (old->new dimensions). For HiDPI remote debugging (gg#327).
+
 ## [0.37.1] - 2026-05-17
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.37.2** | 2026-05-17 | **Diagnostic logging** (#247) — slog.Debug in PresentTexture/drawTexturedQuad/resize for HiDPI debugging |
 | **v0.37.1** | 2026-05-17 | **X11 Russian keyboard fix** (#233) — `_XKB_RULES_NAMES` root window property for multi-layout keymap (pure Go, zero deps) |
 | **v0.37.0** | 2026-05-17 | **ScrollPhase/IsMomentum** (#239, ADR-032) + **Wayland key repeat** (#240, ADR-033) + **X11 detectable auto-repeat** — gpucontext v0.19.0 |
 | **v0.36.2** | 2026-05-16 | **HiDPI logical sizing** (#237, ADR-030) + **Ring buffer event queue** (#238, ADR-031) — WithSize=logical, EventQueue[T] all platforms |

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package gogpu
 import (
 	"fmt"
 	"image"
+	"log/slog"
 	"unsafe"
 
 	"github.com/gogpu/gogpu/gmath"
@@ -200,6 +201,11 @@ func (c *Context) PresentTexture(tex any) error {
 		return fmt.Errorf("gogpu: PresentTexture called with nil *Texture")
 	}
 	ws := c.activeSurface()
+	slog.Debug("gogpu: PresentTexture",
+		"texW", t.width, "texH", t.height,
+		"surfaceW", ws.width, "surfaceH", ws.height,
+		"scale", c.scaleFactor,
+	)
 	return c.renderer.drawTexturedQuad(t, DrawTextureOptions{
 		Width:  float32(ws.width),
 		Height: float32(ws.height),

--- a/renderer.go
+++ b/renderer.go
@@ -63,6 +63,10 @@ type windowSurface struct {
 	// (lazy acquire pattern). Reset at frame boundary.
 	hasGPUWork bool
 
+	// presentLogCount tracks how many times HiDPI diagnostic logs have been
+	// emitted for this surface. Limited to avoid log spam even at Debug level.
+	presentLogCount int
+
 	// frameStarted tracks whether beginFrame was called this frame cycle.
 	// With lazy acquire, beginFrame is deferred until the first draw call.
 	// If OnDraw produces no GPU work, beginFrame is never called → no
@@ -390,6 +394,11 @@ func (ws *windowSurface) resize(width, height int, device *wgpu.Device, adapter 
 	// Save old dimensions in case Configure fails -- we must keep
 	// width/height consistent with the actual swapchain size.
 	oldWidth, oldHeight := ws.width, ws.height
+
+	slog.Debug("gogpu: surface resize",
+		"oldWidth", oldWidth, "oldHeight", oldHeight,
+		"newWidth", width, "newHeight", height,
+	)
 
 	// Note: width/height validated positive above
 	ws.width = uint32(width)   //nolint:gosec // G115: validated positive above
@@ -946,6 +955,17 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 		return nil // No frame in progress
 	}
 	ws.hasGPUWork = true
+
+	// HiDPI diagnostic logging (first 3 frames per surface to avoid spam).
+	if ws.presentLogCount < 3 {
+		ws.presentLogCount++
+		slog.Debug("gogpu: drawTexturedQuad",
+			"quadW", opts.Width, "quadH", opts.Height,
+			"texW", tex.width, "texH", tex.height,
+			"surfaceW", ws.width, "surfaceH", ws.height,
+			"frame", ws.presentLogCount,
+		)
+	}
 
 	// Ensure pipeline is initialized (lazy init on first draw)
 	if !r.texQuadPipelineInited {


### PR DESCRIPTION
Debug-level slog logging in presentation layer for HiDPI debugging. PresentTexture logs texture+surface+scale, drawTexturedQuad logs quad+texture (first 3 frames), resize logs old->new. Closes #247.