### PR TITLE
fix: X11 initial XKB state sync + XWayland detection (#233, v0.37.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.3] - 2026-05-17
+
+### Fixed
+
+- **X11 initial XKB state sync** (#233, @unxed) -- `xkb_state_new` starts at group=0, but X server may be at group=1 (Russian). Now calls `xkbGetFullState` + `UpdateMask` immediately after state creation (winit FocusIn pattern). Also fixes `handleMappingNotify` to sync full state.
+- **XWayland keyboard support** (#233) -- `_XKB_RULES_NAMES` root window property unreliable under XWayland (freedesktop#612). Now detects XWayland via `QueryExtension("XWAYLAND")` (SDL3 pattern), skips RMLVO, uses system defaults. Subscribes to `XkbNewKeyboardNotify` + `XkbMapNotify` for keymap reload on layout changes.
+- **Platform detection** -- warns when Wayland session detected but `WAYLAND_DISPLAY` not set (XWayland fallback).
+
 ## [0.37.2] - 2026-05-17
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.37.3** | 2026-05-17 | **X11 initial state sync + XWayland** (#233) -- xkbGetFullState + UpdateMask, XWayland detection, XkbNewKeyboardNotify |
 | **v0.37.2** | 2026-05-17 | **Diagnostic logging** (#247) — slog.Debug in PresentTexture/drawTexturedQuad/resize for HiDPI debugging |
 | **v0.37.1** | 2026-05-17 | **X11 Russian keyboard fix** (#233) — `_XKB_RULES_NAMES` root window property for multi-layout keymap (pure Go, zero deps) |
 | **v0.37.0** | 2026-05-17 | **ScrollPhase/IsMomentum** (#239, ADR-032) + **Wayland key repeat** (#240, ADR-033) + **X11 detectable auto-repeat** — gpucontext v0.19.0 |

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -141,6 +141,10 @@ func newPlatformManager() PlatformManager {
 	}
 	// Fall back to X11 if DISPLAY is set
 	if os.Getenv("DISPLAY") != "" {
+		// BUG-INPUT-005: Warn when Wayland session uses X11 fallback (XWayland).
+		if os.Getenv("XDG_SESSION_TYPE") == "wayland" {
+			logger().Warn("Wayland session detected but WAYLAND_DISPLAY not set; using X11 (XWayland)")
+		}
 		logger().Info("platform selected", "type", "x11", "DISPLAY", os.Getenv("DISPLAY"))
 		x11.SetLogger(loggerPtr.Load().WithGroup("x11"))
 		return &x11Platform{}

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -168,6 +168,10 @@ type Platform struct {
 	// Nil if libxkbcommon is not available (falls back to manual KeycodeToKeysymGroup).
 	xkbState *xkbcommon.Handle
 
+	// XWayland detection: true when running under XWayland (Wayland compositor).
+	// _XKB_RULES_NAMES is unreliable under XWayland (freedesktop#612).
+	isXWayland bool
+
 	// DPI scale factor (from Xft.dpi or screen physical size) — process-level
 	scaleFactor float64
 
@@ -386,6 +390,13 @@ func (p *Platform) Init(config Config) error {
 		p.xkb = xkb
 		p.xkbGroup = xkb.Group
 		logger().Info("XKB enabled", "version", fmt.Sprintf("%d.%d", xkb.MajorVer, xkb.MinorVer), "group", xkb.Group)
+	}
+
+	// Detect XWayland before initXkbcommon — _XKB_RULES_NAMES is unreliable
+	// under XWayland (freedesktop#612). SDL3 uses QueryExtension("XWAYLAND").
+	p.isXWayland = p.detectXWayland()
+	if p.isXWayland {
+		logger().Info("XWayland detected — _XKB_RULES_NAMES may be unreliable")
 	}
 
 	// Load libxkbcommon for proper text input (AltGr, dead keys, multi-layout).
@@ -639,6 +650,7 @@ func parseXftRGBA(resources string) gpucontext.SubpixelLayout {
 // First tries to read the X server's actual RMLVO configuration from
 // _XKB_RULES_NAMES root window property (BUG-INPUT-004: multi-layout support).
 // Falls back to xkb_keymap_new_from_names(NULL) which only loads "us".
+// Under XWayland, skips _XKB_RULES_NAMES (unreliable per freedesktop#612).
 // Non-fatal: if xkbcommon is unavailable, keyboard falls back to manual keysym lookup.
 func (p *Platform) initXkbcommon() {
 	xkbHandle, xkbcommonErr := xkbcommon.New()
@@ -648,19 +660,24 @@ func (p *Platform) initXkbcommon() {
 	}
 
 	// Try to load keymap from X server's actual configuration.
-	// Read _XKB_RULES_NAMES property from root window for RMLVO.
+	// BUG-INPUT-005: Skip _XKB_RULES_NAMES under XWayland (unreliable per freedesktop#612).
 	loaded := false
-	rules, model, layout, variant, options := p.readXKBRulesNames()
-	if layout != "" {
-		if err := xkbHandle.SetKeymapFromRMLVO(rules, model, layout, variant, options); err != nil {
-			logger().Warn("xkbcommon: RMLVO keymap failed, trying defaults", "err", err, "layout", layout)
-		} else {
-			loaded = true
-			logger().Info("xkbcommon: keymap loaded from _XKB_RULES_NAMES", "layout", layout)
+	if !p.isXWayland {
+		// Native X11: read RMLVO from root window property.
+		rules, model, layout, variant, options := p.readXKBRulesNames()
+		if layout != "" {
+			if err := xkbHandle.SetKeymapFromRMLVO(rules, model, layout, variant, options); err != nil {
+				logger().Warn("xkbcommon: RMLVO keymap failed, trying defaults", "err", err, "layout", layout)
+			} else {
+				loaded = true
+				logger().Info("xkbcommon: keymap loaded from _XKB_RULES_NAMES", "layout", layout)
+			}
 		}
+	} else {
+		logger().Debug("xkbcommon: skipping _XKB_RULES_NAMES under XWayland (unreliable)")
 	}
 
-	// Fallback to system defaults if RMLVO not available
+	// Fallback to system defaults if RMLVO not available or under XWayland
 	if !loaded {
 		if err := xkbHandle.SetKeymapFromNames(); err != nil {
 			logger().Warn("xkbcommon: failed to load system keymap", "err", err)
@@ -671,6 +688,22 @@ func (p *Platform) initXkbcommon() {
 	}
 
 	p.xkbState = xkbHandle
+
+	// BUG-INPUT-005: Sync xkbcommon state with X server's current state (winit pattern).
+	// xkb_state_new starts at group=0 with zero modifiers. The X server may already
+	// be at a different group (e.g., Russian) or have modifiers like CapsLock active.
+	if p.xkb != nil && p.xkbState != nil && p.xkbState.Ready() {
+		if fullState, err := p.conn.xkbGetFullState(p.xkb.MajorOpcode); err == nil {
+			p.xkbState.UpdateMask(
+				fullState.BaseMods, fullState.LatchedMods, fullState.LockedMods,
+				fullState.BaseGroup, fullState.LatchedGroup, fullState.LockedGroup,
+			)
+			p.mu.Lock()
+			p.xkbGroup = fullState.Group
+			p.mu.Unlock()
+			logger().Debug("xkbcommon: initial state synced with X server", "group", fullState.Group)
+		}
+	}
 }
 
 // readXKBRulesNames reads the _XKB_RULES_NAMES property from the root window.
@@ -721,6 +754,20 @@ func (p *Platform) readXKBRulesNames() (string, string, string, string, string) 
 	}
 
 	return rules, model, layout, variant, options
+}
+
+// detectXWayland checks if we are running under XWayland by querying the
+// XWAYLAND X11 extension. SDL3 uses the same pattern.
+// Under XWayland, _XKB_RULES_NAMES is unreliable (freedesktop#612).
+func (p *Platform) detectXWayland() bool {
+	if p.conn == nil {
+		return false
+	}
+	ext, err := p.conn.QueryExtension("XWAYLAND")
+	if err != nil {
+		return false
+	}
+	return ext.Present
 }
 
 // splitNullTerminated splits a byte slice by null bytes into up to maxParts strings.
@@ -1142,7 +1189,19 @@ func (p *Platform) handleUnknownEvent(e *UnknownEvent) {
 	// XKB events share a single event type code (EventBase).
 	// The XKB sub-type is at byte 1 of the raw event (Data[0] in UnknownEvent).
 	xkbType := e.Data[0]
-	if xkbType != XkbStateNotify {
+
+	switch xkbType {
+	case 0, 1: // XkbNewKeyboardNotify (0) or XkbMapNotify (1)
+		// BUG-INPUT-005: Keymap changed (keyboard hot-plug or layout reconfiguration).
+		// Reload the keymap and re-sync state.
+		logger().Debug("XKB keymap changed, reloading", "type", xkbType)
+		p.reloadXkbKeymap()
+		return
+
+	case XkbStateNotify: // = 2
+		// Fall through to state handling below.
+
+	default:
 		return
 	}
 
@@ -1190,25 +1249,85 @@ func (p *Platform) handleUnknownEvent(e *UnknownEvent) {
 	}
 }
 
-// handleMappingNotify re-reads XKB state when keyboard mapping changes.
+// handleMappingNotify re-reads XKB full state when keyboard mapping changes.
 // Some X servers send MappingNotify instead of XkbStateNotify on layout switch.
 // SDL3 uses the same fallback pattern.
+// BUG-INPUT-005: Now uses full state sync (modifiers + group) instead of group-only.
 func (p *Platform) handleMappingNotify() {
 	if p.xkb == nil {
 		return
 	}
-	group, err := p.conn.xkbGetState(p.xkb.MajorOpcode)
+	fullState, err := p.conn.xkbGetFullState(p.xkb.MajorOpcode)
 	if err != nil {
 		return
 	}
+
 	p.mu.Lock()
-	if p.xkbGroup != group {
-		p.xkbGroup = group
-		p.mu.Unlock()
-		logger().Debug("XKB group changed via MappingNotify", "group", group)
+	changed := p.xkbGroup != fullState.Group
+	p.xkbGroup = fullState.Group
+	xkbState := p.xkbState
+	p.mu.Unlock()
+
+	// Sync xkbcommon state with full modifier + group info.
+	if xkbState != nil && xkbState.Ready() {
+		xkbState.UpdateMask(
+			fullState.BaseMods, fullState.LatchedMods, fullState.LockedMods,
+			fullState.BaseGroup, fullState.LatchedGroup, fullState.LockedGroup,
+		)
+	}
+
+	if changed {
+		logger().Debug("XKB group changed via MappingNotify", "group", fullState.Group)
+	}
+}
+
+// reloadXkbKeymap re-reads the keymap and re-syncs xkbcommon state.
+// Called on XkbNewKeyboardNotify (keyboard hot-plug) and XkbMapNotify (keymap changed).
+// BUG-INPUT-005: Handles layout reconfiguration without restart.
+func (p *Platform) reloadXkbKeymap() {
+	p.mu.Lock()
+	xkbState := p.xkbState
+	p.mu.Unlock()
+
+	if xkbState == nil {
 		return
 	}
-	p.mu.Unlock()
+
+	// Re-read keymap (RMLVO or system defaults).
+	// Under XWayland, _XKB_RULES_NAMES is unreliable — use system defaults.
+	if !p.isXWayland {
+		rules, model, layout, variant, options := p.readXKBRulesNames()
+		if layout != "" {
+			if err := xkbState.SetKeymapFromRMLVO(rules, model, layout, variant, options); err == nil {
+				logger().Info("xkbcommon: keymap reloaded from _XKB_RULES_NAMES", "layout", layout)
+			}
+		}
+	} else {
+		if err := xkbState.SetKeymapFromNames(); err == nil {
+			logger().Info("xkbcommon: keymap reloaded from system defaults (XWayland)")
+		}
+	}
+
+	// Sync state after keymap reload.
+	if p.xkb != nil && xkbState.Ready() {
+		if fullState, err := p.conn.xkbGetFullState(p.xkb.MajorOpcode); err == nil {
+			xkbState.UpdateMask(
+				fullState.BaseMods, fullState.LatchedMods, fullState.LockedMods,
+				fullState.BaseGroup, fullState.LatchedGroup, fullState.LockedGroup,
+			)
+			p.mu.Lock()
+			p.xkbGroup = fullState.Group
+			p.mu.Unlock()
+		}
+	}
+
+	// Also re-read keyboard mapping for the fallback path.
+	keymap, _ := p.conn.GetKeyboardMapping()
+	if keymap != nil {
+		p.mu.Lock()
+		p.keymap = keymap
+		p.mu.Unlock()
+	}
 }
 
 // handleXITouchEvent processes an XI2 touch event and dispatches it as a PointerEvent.

--- a/internal/platform/x11/xkb.go
+++ b/internal/platform/x11/xkb.go
@@ -154,21 +154,94 @@ func (c *Connection) xkbGetState(majorOpcode uint8) (int, error) {
 	return group, nil
 }
 
+// XkbFullState holds the complete keyboard state from an XKB GetState reply.
+// Used for initial state sync and MappingNotify handling.
+type XkbFullState struct {
+	BaseMods     uint32
+	LatchedMods  uint32
+	LockedMods   uint32
+	BaseGroup    uint32
+	LatchedGroup uint32
+	LockedGroup  uint32
+	Group        int // effective group (0-3)
+}
+
+// xkbGetFullState sends an XkbGetState request (minor opcode 4) and returns the
+// complete keyboard state including modifiers and group fields. This is needed
+// for initial xkbcommon state sync (BUG-INPUT-005: winit pattern) and for
+// MappingNotify handling where the simple group-only xkbGetState is insufficient.
+func (c *Connection) xkbGetFullState(majorOpcode uint8) (XkbFullState, error) {
+	e := NewEncoder(c.byteOrder)
+	e.PutUint8(majorOpcode)
+	e.PutUint8(XkbMinorOpcodeGetState)
+	e.PutUint16(2) // request length: 8 bytes / 4 = 2 units
+	e.PutUint16(XkbUseCoreKbd)
+	e.PutUint16(0) // pad
+
+	reply, err := c.sendRequestWithReply(e.Bytes())
+	if err != nil {
+		return XkbFullState{}, err
+	}
+
+	if len(reply) < 18 {
+		return XkbFullState{}, fmt.Errorf("xkb: GetState reply too short for full state (%d bytes)", len(reply))
+	}
+
+	// Reply layout (32 bytes):
+	//   byte 0:     response_type (1 = Reply)
+	//   byte 1:     device ID
+	//   bytes 2-3:  sequence
+	//   bytes 4-7:  length
+	//   byte 8:     mods (effective)
+	//   byte 9:     base mods
+	//   byte 10:    latched mods
+	//   byte 11:    locked mods
+	//   byte 12:    group (effective, uint8)
+	//   byte 13:    locked group (uint8)
+	//   bytes 14-15: base group (int16 LE)
+	//   bytes 16-17: latched group (int16 LE)
+	//
+	// NOTE: baseGroup/latchedGroup are int16 in XKB wire format, but
+	// xkb_state_update_mask takes uint32. We convert via uint16 to uint32
+	// (same pattern as handleUnknownEvent).
+	state := XkbFullState{
+		BaseMods:     uint32(reply[9]),
+		LatchedMods:  uint32(reply[10]),
+		LockedMods:   uint32(reply[11]),
+		Group:        int(reply[12]),
+		LockedGroup:  uint32(reply[13]),
+		BaseGroup:    uint32(uint16(reply[14]) | uint16(reply[15])<<8),
+		LatchedGroup: uint32(uint16(reply[16]) | uint16(reply[17])<<8),
+	}
+
+	return state, nil
+}
+
 // xkbSelectEvents sends an XkbSelectEvents request (minor opcode 1) to subscribe
-// to XkbStateNotify events with group change details.
+// to XkbStateNotify, XkbNewKeyboardNotify, and XkbMapNotify events.
+// BUG-INPUT-005: Subscribe to keymap change events for hot-plug and layout reload.
 func (c *Connection) xkbSelectEvents(majorOpcode uint8) error {
+	// Subscribe to three event types:
+	//   - XkbStateNotify (group/modifier changes) — needs per-event details
+	//   - XkbNewKeyboardNotify (keyboard hot-plug) — via selectAll (all details)
+	//   - XkbMapNotify (keymap changed) — via selectAll (all details)
+	//
+	// Events in selectAll get all details automatically (no detail pair needed).
+	// Events in affectWhich but NOT in selectAll require per-event detail pairs.
+	affectWhich := XkbNewKeyboardNotifyMask | XkbMapNotifyMask | XkbStateNotifyMask
+	selectAll := XkbNewKeyboardNotifyMask | XkbMapNotifyMask // auto-select all details
+
 	e := NewEncoder(c.byteOrder)
 	e.PutUint8(majorOpcode)
 	e.PutUint8(XkbMinorOpcodeSelectEvents)
-	e.PutUint16(5)                  // request length: 20 bytes / 4 = 5 units
-	e.PutUint16(XkbUseCoreKbd)      // device spec
-	e.PutUint16(XkbStateNotifyMask) // affectWhich: subscribe to state change events
-	e.PutUint16(0)                  // clear: don't clear any event types
-	e.PutUint16(0)                  // selectAll: 0 — use per-event details below (not auto-select all)
-	e.PutUint16(0)                  // affectMap
-	e.PutUint16(0)                  // map
-	// Per-event details for StateNotify (included because StateNotify is in
-	// affectWhich but NOT in selectAll — XKB wire protocol requires detail pair):
+	e.PutUint16(5)                   // request length: 20 bytes / 4 = 5 units
+	e.PutUint16(XkbUseCoreKbd)       // device spec
+	e.PutUint16(uint16(affectWhich)) // affectWhich: subscribe to these event types
+	e.PutUint16(0)                   // clear: don't clear any event types
+	e.PutUint16(uint16(selectAll))   // selectAll: NewKeyboard + Map get all details
+	e.PutUint16(0)                   // affectMap
+	e.PutUint16(0)                   // map
+	// Per-event details for StateNotify (in affectWhich but NOT in selectAll):
 	e.PutUint16(XkbGroupStateMask) // affectState: we want group changes
 	e.PutUint16(XkbGroupStateMask) // stateDetails: group changes
 

--- a/internal/platform/x11/xkb_test.go
+++ b/internal/platform/x11/xkb_test.go
@@ -1075,3 +1075,139 @@ func TestSplitNullTerminated(t *testing.T) {
 		})
 	}
 }
+
+// --- Section 9: BUG-INPUT-005 — XkbFullState Tests ---
+
+func TestXkbFullState_ZeroValue(t *testing.T) {
+	var state XkbFullState
+	if state.Group != 0 {
+		t.Errorf("zero-value Group = %d, want 0", state.Group)
+	}
+	if state.BaseMods != 0 {
+		t.Errorf("zero-value BaseMods = %d, want 0", state.BaseMods)
+	}
+	if state.LatchedMods != 0 {
+		t.Errorf("zero-value LatchedMods = %d, want 0", state.LatchedMods)
+	}
+	if state.LockedMods != 0 {
+		t.Errorf("zero-value LockedMods = %d, want 0", state.LockedMods)
+	}
+	if state.BaseGroup != 0 {
+		t.Errorf("zero-value BaseGroup = %d, want 0", state.BaseGroup)
+	}
+	if state.LatchedGroup != 0 {
+		t.Errorf("zero-value LatchedGroup = %d, want 0", state.LatchedGroup)
+	}
+	if state.LockedGroup != 0 {
+		t.Errorf("zero-value LockedGroup = %d, want 0", state.LockedGroup)
+	}
+}
+
+func TestXkbFullState_FieldValues(t *testing.T) {
+	state := XkbFullState{
+		BaseMods:     1,
+		LatchedMods:  2,
+		LockedMods:   4,
+		BaseGroup:    1,
+		LatchedGroup: 0,
+		LockedGroup:  1,
+		Group:        1,
+	}
+
+	if state.BaseMods != 1 {
+		t.Errorf("BaseMods = %d, want 1", state.BaseMods)
+	}
+	if state.LockedMods != 4 {
+		t.Errorf("LockedMods = %d, want 4", state.LockedMods)
+	}
+	if state.Group != 1 {
+		t.Errorf("Group = %d, want 1", state.Group)
+	}
+	if state.LockedGroup != 1 {
+		t.Errorf("LockedGroup = %d, want 1", state.LockedGroup)
+	}
+}
+
+// --- Section 10: BUG-INPUT-005 — XkbNewKeyboardNotify/MapNotify Routing ---
+
+func TestHandleUnknownEvent_NewKeyboardNotify(t *testing.T) {
+	// XkbNewKeyboardNotify (type=0) should be handled (not ignored).
+	// We cannot fully test reloadXkbKeymap without a real connection,
+	// but we verify it does not crash and does not update xkbGroup
+	// (reloadXkbKeymap with nil conn just returns).
+	p := &Platform{
+		xkb: &XkbExtension{
+			EventBase: 85,
+		},
+		xkbGroup: 0,
+	}
+
+	e := &UnknownEvent{Type: 85}
+	e.Data[0] = 0 // XkbNewKeyboardNotify
+	e.Data[12] = 1
+
+	// Must not panic. reloadXkbKeymap returns early (xkbState is nil).
+	p.handleUnknownEvent(e)
+}
+
+func TestHandleUnknownEvent_MapNotify(t *testing.T) {
+	// XkbMapNotify (type=1) should be handled similarly.
+	p := &Platform{
+		xkb: &XkbExtension{
+			EventBase: 85,
+		},
+		xkbGroup: 0,
+	}
+
+	e := &UnknownEvent{Type: 85}
+	e.Data[0] = 1 // XkbMapNotify
+	e.Data[12] = 1
+
+	// Must not panic.
+	p.handleUnknownEvent(e)
+}
+
+func TestHandleUnknownEvent_UnknownXkbSubType(t *testing.T) {
+	// Unknown XKB sub-types (> 2) should be ignored without crash.
+	p := &Platform{
+		xkb: &XkbExtension{
+			EventBase: 85,
+		},
+		xkbGroup: 0,
+	}
+
+	for _, subType := range []uint8{3, 4, 5, 10, 255} {
+		e := &UnknownEvent{Type: 85}
+		e.Data[0] = subType
+		e.Data[12] = 1
+
+		p.handleUnknownEvent(e)
+
+		p.mu.Lock()
+		g := p.xkbGroup
+		p.mu.Unlock()
+
+		if g != 0 {
+			t.Errorf("xkbGroup changed to %d on unknown sub-type %d, want 0", g, subType)
+		}
+	}
+}
+
+// --- Section 11: BUG-INPUT-005 — XWayland Detection ---
+
+func TestDetectXWayland_NilConn(t *testing.T) {
+	p := &Platform{conn: nil}
+	if p.detectXWayland() {
+		t.Error("detectXWayland returned true with nil conn, want false")
+	}
+}
+
+func TestReloadXkbKeymap_NilXkbState(t *testing.T) {
+	// reloadXkbKeymap with nil xkbState should return without crash.
+	p := &Platform{
+		xkb:      &XkbExtension{MajorOpcode: 135},
+		xkbState: nil,
+	}
+	// Must not panic.
+	p.reloadXkbKeymap()
+}


### PR DESCRIPTION
## Summary

- **Initial XKB state sync** -- xkbGetFullState + UpdateMask after state creation (winit pattern)
- **XWayland detection** -- QueryExtension(\"XWAYLAND\"), skip unreliable RMLVO (freedesktop#612)
- **XkbNewKeyboardNotify/MapNotify** -- keymap reload on layout changes
- **Platform hint** -- warn if Wayland session but WAYLAND_DISPLAY not set

## Root Cause

xkb_state_new starts at group=0, zero mods. X server may be at group=1 (Russian). No initial sync caused \"always Russian\" after v0.37.1 RMLVO fix.

## Test plan

- [ ] CI passes
- [ ] @unxed: X11 native -- Russian/English switching works
- [ ] @unxed: XWayland -- keyboard works
- [ ] Non-HiDPI -- no regression