### PR TITLE
fix: X11 layout switching -- use effective group instead of decomposed (#233, v0.37.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.4] - 2026-05-17
+
+### Fixed
+
+- **X11 keyboard layout switching "sticks" on Russian** (#233, @unxed) -- two bugs in XkbStateNotify handling: (1) `lockedGroup` read as int16 but is uint8 in XCB wire format, picking up `compatState` byte as high byte; (2) decomposed baseGroup/latchedGroup/lockedGroup can produce different effective group in xkbcommon due to double-wrapping with different keymap rules. Fix: use Wayland pattern on X11 -- pass effective group (already computed by X server) as layoutLocked with zeros for base/latched. Confirmed by xkbcommon source analysis and 5 reference frameworks.
+
 ## [0.37.3] - 2026-05-17
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.37.4** | 2026-05-17 | **X11 layout switch fix** (#233) -- lockedGroup uint8 bug + Wayland pattern for effective group |
 | **v0.37.3** | 2026-05-17 | **X11 initial state sync + XWayland** (#233) -- xkbGetFullState + UpdateMask, XWayland detection, XkbNewKeyboardNotify |
 | **v0.37.2** | 2026-05-17 | **Diagnostic logging** (#247) — slog.Debug in PresentTexture/drawTexturedQuad/resize for HiDPI debugging |
 | **v0.37.1** | 2026-05-17 | **X11 Russian keyboard fix** (#233) — `_XKB_RULES_NAMES` root window property for multi-layout keymap (pure Go, zero deps) |

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -696,7 +696,7 @@ func (p *Platform) initXkbcommon() {
 		if fullState, err := p.conn.xkbGetFullState(p.xkb.MajorOpcode); err == nil {
 			p.xkbState.UpdateMask(
 				fullState.BaseMods, fullState.LatchedMods, fullState.LockedMods,
-				fullState.BaseGroup, fullState.LatchedGroup, fullState.LockedGroup,
+				0, 0, uint32(fullState.Group),
 			)
 			p.mu.Lock()
 			p.xkbGroup = fullState.Group
@@ -1228,21 +1228,22 @@ func (p *Platform) handleUnknownEvent(e *UnknownEvent) {
 		baseMods := uint32(e.Data[9])
 		latchedMods := uint32(e.Data[10])
 		lockedMods := uint32(e.Data[11])
-		baseGroup := uint32(uint16(e.Data[13]) | uint16(e.Data[14])<<8)
-		latchedGroup := uint32(uint16(e.Data[15]) | uint16(e.Data[16])<<8)
-		lockedGroup := uint32(uint16(e.Data[17]) | uint16(e.Data[18])<<8)
 
 		p.mu.Lock()
 		p.xkbGroup = newGroup
 		xkbState := p.xkbState
 		p.mu.Unlock()
 
-		// Sync xkbcommon state with X server state (winit/Qt6 pattern).
-		// This is the ONLY way to update group/modifiers in xkbcommon on X11.
-		// xkb_state_update_key does NOT handle group changes.
+		// Sync xkbcommon state with X server's effective group.
+		// Use Wayland pattern: pass effective group (Data[12]) as layoutLocked,
+		// zeros for baseGroup/latchedGroup. This avoids two bugs:
+		// 1. lockedGroup is uint8 in XCB wire but we were reading 2 bytes (compatState leak)
+		// 2. Decomposed groups can produce different effective group in xkbcommon
+		//    due to double-wrapping with potentially different keymap rules.
+		// The effective group is already computed by the X server — safe to pass directly.
 		if xkbState != nil && xkbState.Ready() {
 			xkbState.UpdateMask(baseMods, latchedMods, lockedMods,
-				baseGroup, latchedGroup, lockedGroup)
+				0, 0, uint32(newGroup))
 		}
 
 		logger().Debug("XKB state changed", "group", newGroup)
@@ -1268,11 +1269,11 @@ func (p *Platform) handleMappingNotify() {
 	xkbState := p.xkbState
 	p.mu.Unlock()
 
-	// Sync xkbcommon state with full modifier + group info.
+	// Sync xkbcommon state using effective group (Wayland pattern).
 	if xkbState != nil && xkbState.Ready() {
 		xkbState.UpdateMask(
 			fullState.BaseMods, fullState.LatchedMods, fullState.LockedMods,
-			fullState.BaseGroup, fullState.LatchedGroup, fullState.LockedGroup,
+			0, 0, uint32(fullState.Group),
 		)
 	}
 
@@ -1308,12 +1309,12 @@ func (p *Platform) reloadXkbKeymap() {
 		}
 	}
 
-	// Sync state after keymap reload.
+	// Sync state after keymap reload using effective group (Wayland pattern).
 	if p.xkb != nil && xkbState.Ready() {
 		if fullState, err := p.conn.xkbGetFullState(p.xkb.MajorOpcode); err == nil {
 			xkbState.UpdateMask(
 				fullState.BaseMods, fullState.LatchedMods, fullState.LockedMods,
-				fullState.BaseGroup, fullState.LatchedGroup, fullState.LockedGroup,
+				0, 0, uint32(fullState.Group),
 			)
 			p.mu.Lock()
 			p.xkbGroup = fullState.Group


### PR DESCRIPTION
## Summary

Fixes X11 keyboard layout switching \"sticking\" on Russian (#233, @unxed).

## Root Cause (two bugs)

1. **lockedGroup byte width**: XCB wire format has lockedGroup as uint8 (1 byte), but we read 2 bytes, picking up compatState in the high byte. With grp:lalt_lshift_toggle, compatState is non-zero during switching, corrupting lockedGroup.

2. **Double-wrapping**: Even with correct bytes, decomposed baseGroup/latchedGroup/lockedGroup can produce different effective group in xkbcommon vs X server due to different keymap wrapping rules (especially with misc:typo option).

## Fix

Use Wayland pattern on all 4 UpdateMask call sites: pass effective group (already computed by X server) as layoutLocked, zeros for base/latched:

```go
xkbState.UpdateMask(baseMods, latchedMods, lockedMods, 0, 0, uint32(effectiveGroup))
```

Same pattern as GLFW (Wayland) and winit (core events). Confirmed safe by xkbcommon source analysis.

## Test plan

- [ ] CI passes
- [ ] @unxed: layout switching en/ru works both directions