### PR TITLE
fix: AltGr/Level3 on X11 — subscribe to modifier state changes (#233, v0.37.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.5] - 2026-05-17
+
+### Fixed
+
+- **AltGr / Level3 modifier on X11** (#233, @unxed) -- XkbSelectEvents subscribed to `XkbGroupStateMask` only (group changes). Modifier changes (AltGr press/release) were never delivered to xkbcommon. Added `XkbModifierStateMask` to subscription (SDL3/GTK4 pattern). Guillemets and all Level3 characters now work.
+
 ## [0.37.4] - 2026-05-17
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.37.5** | 2026-05-17 | **AltGr/Level3 fix** (#233) -- XkbModifierStateMask subscription, guillemets work |
 | **v0.37.4** | 2026-05-17 | **X11 layout switch fix** (#233) -- lockedGroup uint8 bug + Wayland pattern for effective group |
 | **v0.37.3** | 2026-05-17 | **X11 initial state sync + XWayland** (#233) -- xkbGetFullState + UpdateMask, XWayland detection, XkbNewKeyboardNotify |
 | **v0.37.2** | 2026-05-17 | **Diagnostic logging** (#247) — slog.Debug in PresentTexture/drawTexturedQuad/resize for HiDPI debugging |

--- a/internal/platform/x11/xkb.go
+++ b/internal/platform/x11/xkb.go
@@ -25,7 +25,8 @@ const (
 	XkbStateNotifyMask       = 0x0004 // bit 2: state changes (group, modifiers)
 
 	// XKB state detail masks for per-event details (affectState/stateDetails).
-	XkbGroupStateMask = 0x0010 // group changes specifically
+	XkbModifierStateMask = 0x0001 // modifier changes (AltGr, Shift, Ctrl, etc.)
+	XkbGroupStateMask    = 0x0010 // group changes (layout switching)
 
 	// XKB device spec: use the core keyboard.
 	XkbUseCoreKbd = 0x0100
@@ -241,9 +242,13 @@ func (c *Connection) xkbSelectEvents(majorOpcode uint8) error {
 	e.PutUint16(uint16(selectAll))   // selectAll: NewKeyboard + Map get all details
 	e.PutUint16(0)                   // affectMap
 	e.PutUint16(0)                   // map
-	// Per-event details for StateNotify (in affectWhich but NOT in selectAll):
-	e.PutUint16(XkbGroupStateMask) // affectState: we want group changes
-	e.PutUint16(XkbGroupStateMask) // stateDetails: group changes
+	// Per-event details for StateNotify: subscribe to BOTH modifier and group changes.
+	// Without XkbModifierStateMask, AltGr (Level3) press/release events are never delivered,
+	// so xkbcommon never learns about Level3 modifier → guillemets don't work.
+	// SDL3 and GTK4 use the same pattern: XkbGroupStateMask | XkbModifierStateMask.
+	stateDetails := uint16(XkbGroupStateMask | XkbModifierStateMask)
+	e.PutUint16(stateDetails) // affectState
+	e.PutUint16(stateDetails) // stateDetails
 
 	_, err := c.sendRequest(e.Bytes())
 	return err


### PR DESCRIPTION
XkbSelectEvents subscribed to XkbGroupStateMask only. Modifier changes never delivered. Added XkbModifierStateMask (SDL3/GTK4 pattern). Guillemets work.