### PR TITLE
fix: Windows ESC no longer force-closes window (#254, v0.37.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.7] - 2026-05-17
+
+### Fixed
+
+- **Windows: ESC no longer force-closes window** (#254, @unxed) -- removed hardcoded `ESC = close` from platform layer. Applications receive `KeyEscape` as a normal key event and decide what to do. Matches winit/GLFW/SDL3 behavior.
+
 ## [0.37.6] - 2026-05-17
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.37.7** | 2026-05-17 | **Windows ESC fix** (#254) -- removed hardcoded ESC=close, app decides |
 | **v0.37.6** | 2026-05-17 | **Universal keysym-to-Unicode** (ADR-034) -- 828-entry table replaces 70-entry Cyrillic, all X11 scripts |
 | **v0.37.5** | 2026-05-17 | **AltGr/Level3 fix** (#233) -- XkbModifierStateMask subscription, guillemets work |
 | **v0.37.4** | 2026-05-17 | **X11 layout switch fix** (#233) -- lockedGroup uint8 bug + Wayland pattern for effective group |

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -2425,12 +2425,6 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		// Dispatch keyboard event
 		w.dispatchKeyEvent(key, mods, true)
 
-		// ESC to close (convenience)
-		if wParam == vkEscape {
-			w.shouldClose = true
-			p.queueEvent(Event{Type: EventClose, WindowID: w.id})
-		}
-
 		// For WM_SYSKEYDOWN: let DefWindowProc handle Alt+F4, Alt+Tab
 		// but suppress menu activation on Alt alone
 		if message == wmSysKeydown {


### PR DESCRIPTION
Removed hardcoded ESC=close. App decides. winit/GLFW/SDL3 pattern. Closes #254.