### PR TITLE
fix/264-add-custom-menu : Add custom menu

### DIFF
--- a/app.go
+++ b/app.go
@@ -71,6 +71,7 @@ type App struct {
 	primaryWindow *Window
 
 	menu                   *Menu
+	customMenus            map[string]*Menu
 	pendingSystemMenuItems map[SystemMenu][]MenuItem
 }
 
@@ -308,8 +309,8 @@ func (a *App) initPlatform() (platform.PlatformWindow, error) {
 	}
 
 	// Apply any menu set before Run().
-	if a.menu != nil {
-		a.SetMenu(a.menu)
+	if a.menu != nil || len(a.customMenus) > 0 {
+		a.updateNativeMenu()
 	}
 	// Apply pending system menu items.
 	if a.pendingSystemMenuItems != nil {
@@ -1035,22 +1036,74 @@ func (a *App) Close() {
 // On macOS this modifies the menu bar; on other platforms it's a no-op.
 func (a *App) SetMenu(menu *Menu) {
 	a.menu = menu
+	a.updateNativeMenu()
+}
+
+// AddCustomMenu adds an additional menu to the main menu bar.
+// If the menu is initially empty, it will not be displayed until items are added.
+func (a *App) AddCustomMenu(name string, menu *Menu) {
+	if a.customMenus == nil {
+		a.customMenus = make(map[string]*Menu)
+	}
+	a.customMenus[name] = menu
+	a.updateNativeMenu()
+}
+
+// UpdateCustomMenu updates an existing custom menu.
+func (a *App) UpdateCustomMenu(name string, menu *Menu) {
+	if a.customMenus == nil {
+		a.customMenus = make(map[string]*Menu)
+	}
+	a.customMenus[name] = menu
+	a.updateNativeMenu()
+}
+
+func (a *App) updateNativeMenu() {
 	if a.manager == nil {
 		return
 	}
-	if mgr, ok := a.manager.(platform.PlatMenuManager); ok {
-		items := make([]platform.MenuItem, len(menu.Items))
-		for i, it := range menu.Items {
-			items[i] = platform.MenuItem{
-				Title:     it.Title,
-				Action:    it.Action,
-				Disabled:  it.Disabled,
-				Separator: it.Separator,
-				Role:      platform.MenuRole(it.Role),
-			}
-		}
-		mgr.SetApplicationMenu(items)
+	mgr, ok := a.manager.(platform.PlatMenuManager)
+	if !ok {
+		return
 	}
+
+	var allItems []platform.MenuItem
+
+	// Add items from the main menu
+	if a.menu != nil {
+		allItems = append(allItems, a.convertMenuToPlatformItems(a.menu.Items)...)
+	}
+
+	// Add items from custom menus
+	for _, menu := range a.customMenus {
+		// Each custom menu at the top level should be its own menu item with a submenu
+		// in the native menu bar, unless it's intended to be merged (but the PR description
+		// implies they appear "next to File").
+		// To make it appear "next to File", it must be a MenuItem with a Submenu at the top level of NSMenu.
+		allItems = append(allItems, platform.MenuItem{
+			Title:   menu.Title,
+			Submenu: a.convertMenuToPlatformItems(menu.Items),
+		})
+	}
+
+	mgr.SetApplicationMenu(allItems)
+}
+
+func (a *App) convertMenuToPlatformItems(items []MenuItem) []platform.MenuItem {
+	res := make([]platform.MenuItem, len(items))
+	for i, it := range items {
+		res[i] = platform.MenuItem{
+			Title:     it.Title,
+			Action:    it.Action,
+			Disabled:  it.Disabled,
+			Separator: it.Separator,
+			Role:      platform.MenuRole(it.Role),
+		}
+		if it.Submenu != nil {
+			res[i].Submenu = a.convertMenuToPlatformItems(it.Submenu.Items)
+		}
+	}
+	return res
 }
 
 // GetSystemMenu returns a handle to a standard system menu (e.g., the Apple menu).

--- a/app.go
+++ b/app.go
@@ -71,8 +71,13 @@ type App struct {
 	primaryWindow *Window
 
 	menu                   *Menu
-	customMenus            map[string]*Menu
+	customMenus            []customMenuEntry
 	pendingSystemMenuItems map[SystemMenu][]MenuItem
+}
+
+type customMenuEntry struct {
+	name string
+	menu *Menu
 }
 
 // NewApp creates a new application with the given configuration.
@@ -1039,22 +1044,18 @@ func (a *App) SetMenu(menu *Menu) {
 	a.updateNativeMenu()
 }
 
-// AddCustomMenu adds an additional menu to the main menu bar.
+// SetCustomMenu adds or updates an additional menu in the main menu bar.
 // If the menu is initially empty, it will not be displayed until items are added.
-func (a *App) AddCustomMenu(name string, menu *Menu) {
-	if a.customMenus == nil {
-		a.customMenus = make(map[string]*Menu)
+// Insertion order is preserved for display in the native menu bar.
+func (a *App) SetCustomMenu(name string, menu *Menu) {
+	for i, entry := range a.customMenus {
+		if entry.name == name {
+			a.customMenus[i].menu = menu
+			a.updateNativeMenu()
+			return
+		}
 	}
-	a.customMenus[name] = menu
-	a.updateNativeMenu()
-}
-
-// UpdateCustomMenu updates an existing custom menu.
-func (a *App) UpdateCustomMenu(name string, menu *Menu) {
-	if a.customMenus == nil {
-		a.customMenus = make(map[string]*Menu)
-	}
-	a.customMenus[name] = menu
+	a.customMenus = append(a.customMenus, customMenuEntry{name: name, menu: menu})
 	a.updateNativeMenu()
 }
 
@@ -1075,14 +1076,14 @@ func (a *App) updateNativeMenu() {
 	}
 
 	// Add items from custom menus
-	for _, menu := range a.customMenus {
+	for _, entry := range a.customMenus {
 		// Each custom menu at the top level should be its own menu item with a submenu
 		// in the native menu bar, unless it's intended to be merged (but the PR description
 		// implies they appear "next to File").
 		// To make it appear "next to File", it must be a MenuItem with a Submenu at the top level of NSMenu.
 		allItems = append(allItems, platform.MenuItem{
-			Title:   menu.Title,
-			Submenu: a.convertMenuToPlatformItems(menu.Items),
+			Title:   entry.menu.Title,
+			Submenu: a.convertMenuToPlatformItems(entry.menu.Items),
 		})
 	}
 

--- a/examples/menu/main.go
+++ b/examples/menu/main.go
@@ -9,20 +9,16 @@ import (
 func main() {
 	app := gogpu.NewApp(gogpu.DefaultConfig().WithTitle("My App").WithAppName("Example App"))
 
-	// Replacing the main menu
-	app.SetMenu(gogpu.NewMenu().
-		AddItem(gogpu.MenuItem{Title: "App", Role: gogpu.RoleNone}). // Placeholder for app name on some platforms
-		AddItem(gogpu.MenuItem{Title: "About My App", Role: gogpu.RoleAbout}).
-		AddItem(gogpu.MenuItem{Separator: true}).
-		AddItem(gogpu.MenuItem{Title: "Preferences…", Role: gogpu.RolePreferences}).
-		AddItem(gogpu.MenuItem{Title: "Services", Role: gogpu.RoleServices}).
-		AddItem(gogpu.MenuItem{Separator: true}).
-		AddItem(gogpu.MenuItem{Title: "Hide My App", Role: gogpu.RoleHide}).
-		AddItem(gogpu.MenuItem{Title: "Hide Others", Role: gogpu.RoleHideOthers}).
-		AddItem(gogpu.MenuItem{Title: "Show All", Role: gogpu.RoleShowAll}).
-		AddItem(gogpu.MenuItem{Separator: true}).
-		AddItem(gogpu.MenuItem{Title: "Quit", Role: gogpu.RoleQuit}),
-	)
+	// Additional custom menu (initially empty, will not be displayed until items added)
+	toolsMenu := gogpu.NewMenu("Tools")
+	app.AddCustomMenu("tools", toolsMenu)
+
+	// Later we add items to it
+	toolsMenu.AddItem(gogpu.MenuItem{
+		Title:  "Settings",
+		Action: func() { log.Println("Tools -> Settings clicked") },
+	})
+	app.UpdateCustomMenu("tools", toolsMenu)
 
 	// Add items to the Window menu using roles
 	if windowMenu := app.GetSystemMenu(gogpu.SystemMenuWindow); windowMenu != nil {

--- a/examples/menu/main.go
+++ b/examples/menu/main.go
@@ -9,16 +9,31 @@ import (
 func main() {
 	app := gogpu.NewApp(gogpu.DefaultConfig().WithTitle("My App").WithAppName("Example App"))
 
+	// Replacing the main menu
+	app.SetMenu(gogpu.NewMenu().
+		AddItem(gogpu.MenuItem{Title: "App", Role: gogpu.RoleNone}). // Placeholder for app name on some platforms
+		AddItem(gogpu.MenuItem{Title: "About My App", Role: gogpu.RoleAbout}).
+		AddItem(gogpu.MenuItem{Separator: true}).
+		AddItem(gogpu.MenuItem{Title: "Preferences…", Role: gogpu.RolePreferences}).
+		AddItem(gogpu.MenuItem{Title: "Services", Role: gogpu.RoleServices}).
+		AddItem(gogpu.MenuItem{Separator: true}).
+		AddItem(gogpu.MenuItem{Title: "Hide My App", Role: gogpu.RoleHide}).
+		AddItem(gogpu.MenuItem{Title: "Hide Others", Role: gogpu.RoleHideOthers}).
+		AddItem(gogpu.MenuItem{Title: "Show All", Role: gogpu.RoleShowAll}).
+		AddItem(gogpu.MenuItem{Separator: true}).
+		AddItem(gogpu.MenuItem{Title: "Quit", Role: gogpu.RoleQuit}),
+	)
+
 	// Additional custom menu (initially empty, will not be displayed until items added)
-	toolsMenu := gogpu.NewMenu("Tools")
-	app.AddCustomMenu("tools", toolsMenu)
+	toolsMenu := gogpu.NewMenuWithTitle("Tools")
+	app.SetCustomMenu("tools", toolsMenu)
 
 	// Later we add items to it
 	toolsMenu.AddItem(gogpu.MenuItem{
 		Title:  "Settings",
 		Action: func() { log.Println("Tools -> Settings clicked") },
 	})
-	app.UpdateCustomMenu("tools", toolsMenu)
+	app.SetCustomMenu("tools", toolsMenu)
 
 	// Add items to the Window menu using roles
 	if windowMenu := app.GetSystemMenu(gogpu.SystemMenuWindow); windowMenu != nil {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -269,6 +269,7 @@ type MenuItem struct {
 	Role      MenuRole
 	Disabled  bool
 	Separator bool
+	Submenu   []MenuItem
 }
 
 // NewManager creates a platform-specific PlatformManager.

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -1368,32 +1368,44 @@ func (p *darwinPlatform) applyMenu(items []MenuItem) {
 		mainMenu.SendPtr(darwin.RegisterSelector("addItem:"), appMenuItem.Ptr())
 	}
 
-	// Add custom items as separate menu items.
+	// Add items as separate menu items.
 	for _, item := range items {
-		if item.Separator {
-			continue
-		}
+		p.addPlatformItem(mainMenu, item)
+	}
+}
 
-		if item.Role != MenuRoleNone {
-			roleStr := roleToString(item.Role)
-			if roleStr != "" {
-				darwin.AddMenuItemWithRole(mainMenu, item.Title, roleStr)
-				continue
-			}
-		}
+func (p *darwinPlatform) addPlatformItem(parentMenu darwin.ID, item MenuItem) {
+	if item.Separator {
+		darwin.AddSeparatorItem(parentMenu)
+		return
+	}
 
+	if item.Role != MenuRoleNone {
+		roleStr := roleToString(item.Role)
+		if roleStr != "" {
+			darwin.AddMenuItemWithRole(parentMenu, item.Title, roleStr)
+			return
+		}
+	}
+
+	if len(item.Submenu) > 0 {
 		submenu := darwin.NewMenuWithTitle(item.Title)
 		if submenu.IsNil() {
-			continue
+			return
 		}
 
-		darwin.AddMenuItemWithCallback(submenu, item.Title, item.Action, "")
+		for _, sub := range item.Submenu {
+			p.addPlatformItem(submenu, sub)
+		}
 
 		menuItem := darwin.NewMenuItemWithSubmenu(item.Title, submenu)
 		if !menuItem.IsNil() {
-			mainMenu.SendPtr(darwin.RegisterSelector("addItem:"), menuItem.Ptr())
+			parentMenu.SendPtr(darwin.RegisterSelector("addItem:"), menuItem.Ptr())
 		}
+		return
 	}
+
+	darwin.AddMenuItemWithCallback(parentMenu, item.Title, item.Action, "")
 }
 
 // roleToString converts a MenuRole value to its corresponding string representation for OS-specific menu integration.

--- a/menu.go
+++ b/menu.go
@@ -2,7 +2,7 @@ package gogpu
 
 import "github.com/gogpu/gogpu/internal/platform"
 
-// MenuRole maps to standard macOS menu items.
+// MenuRole maps to standard menu items.
 type MenuRole int
 
 const (
@@ -28,6 +28,7 @@ type MenuItem struct {
 	Role      MenuRole
 	Disabled  bool
 	Separator bool
+	Submenu   *Menu
 }
 
 // Menu represents a top-level menu.
@@ -36,9 +37,9 @@ type Menu struct {
 	Items []MenuItem
 }
 
-// NewMenu creates an empty menu.
-func NewMenu() *Menu {
-	return &Menu{}
+// NewMenu creates an empty menu with the specified title.
+func NewMenu(title string) *Menu {
+	return &Menu{Title: title}
 }
 
 // AddItem appends an item to the menu and returns the menu for chaining.

--- a/menu.go
+++ b/menu.go
@@ -37,8 +37,13 @@ type Menu struct {
 	Items []MenuItem
 }
 
-// NewMenu creates an empty menu with the specified title.
-func NewMenu(title string) *Menu {
+// NewMenu creates an empty menu.
+func NewMenu() *Menu {
+	return &Menu{}
+}
+
+// NewMenuWithTitle creates an empty menu with the specified title.
+func NewMenuWithTitle(title string) *Menu {
 	return &Menu{Title: title}
 }
 

--- a/menu_test.go
+++ b/menu_test.go
@@ -1,13 +1,18 @@
 package gogpu
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gogpu/gogpu/internal/platform"
+	"github.com/gogpu/gpucontext"
 )
 
 // mockMenuManager implements platform.PlatMenuManager
 type mockMenuManager struct {
+	setApplicationMenuCalled bool
+	setApplicationMenuItems  []platform.MenuItem
+
 	addToSystemMenuCalled bool
 	addToSystemMenuMenu   platform.SystemMenu
 	addToSystemMenuItems  []platform.MenuItem
@@ -15,7 +20,8 @@ type mockMenuManager struct {
 }
 
 func (m *mockMenuManager) SetApplicationMenu(items []platform.MenuItem) {
-	// Not needed for these tests
+	m.setApplicationMenuCalled = true
+	m.setApplicationMenuItems = items
 }
 
 func (m *mockMenuManager) AddToSystemMenu(menu platform.SystemMenu, items []platform.MenuItem) bool {
@@ -25,11 +31,33 @@ func (m *mockMenuManager) AddToSystemMenu(menu platform.SystemMenu, items []plat
 	return m.addToSystemMenuResult
 }
 
+// Ensure mockMenuManager implements platform.PlatformManager (partially)
+// and PlatMenuManager.
+func (m *mockMenuManager) Init() error { return nil }
+func (m *mockMenuManager) Destroy()    {}
+func (m *mockMenuManager) CreateWindow(platform.Config) (platform.PlatformWindow, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (m *mockMenuManager) PollEvents() platform.Event                { return platform.Event{} }
+func (m *mockMenuManager) WaitEvents()                               {}
+func (m *mockMenuManager) WakeUp()                                   {}
+func (m *mockMenuManager) ClipboardRead() (string, error)            { return "", nil }
+func (m *mockMenuManager) ClipboardWrite(string) error               { return nil }
+func (m *mockMenuManager) DarkMode() bool                            { return false }
+func (m *mockMenuManager) ReduceMotion() bool                        { return false }
+func (m *mockMenuManager) HighContrast() bool                        { return false }
+func (m *mockMenuManager) FontScale() float32                        { return 1.0 }
+func (m *mockMenuManager) SubpixelLayout() gpucontext.SubpixelLayout { return 0 }
+func (m *mockMenuManager) SetAppName(string)                         {}
+
 // TestNewMenu checks that NewMenu is not nil and that the menu is empty.
 func TestNewMenu(t *testing.T) {
-	menu := NewMenu()
+	menu := NewMenu("Test")
 	if menu == nil {
 		t.Fatal("NewMenu returned nil")
+	}
+	if menu.Title != "Test" {
+		t.Errorf("expected title Test, got %q", menu.Title)
 	}
 	if len(menu.Items) != 0 {
 		t.Fatalf("expected empty menu, got %d items", len(menu.Items))
@@ -38,7 +66,7 @@ func TestNewMenu(t *testing.T) {
 
 // TestAddItem checks for the addition of elements and chained returns.
 func TestAddItem(t *testing.T) {
-	menu := NewMenu()
+	menu := NewMenu("")
 	result := menu.AddItem(MenuItem{Title: "Item 1"})
 	if result != menu {
 		t.Error("AddItem did not return the same menu for chaining")
@@ -156,5 +184,61 @@ func TestSystemMenuHandleNoApp(t *testing.T) {
 	ok = handle.AddItem(MenuItem{Title: "Noop"})
 	if ok {
 		t.Error("expected false when both manager and app are nil")
+	}
+}
+
+func TestCustomMenus(t *testing.T) {
+	mgr := &mockMenuManager{}
+	app := &App{
+		manager: mgr,
+	}
+
+	// Initial main menu
+	mainMenu := NewMenu("").AddItem(MenuItem{Title: "File"})
+	app.SetMenu(mainMenu)
+
+	if !mgr.setApplicationMenuCalled {
+		t.Fatal("SetApplicationMenu was not called")
+	}
+	if len(mgr.setApplicationMenuItems) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(mgr.setApplicationMenuItems))
+	}
+	if mgr.setApplicationMenuItems[0].Title != "File" {
+		t.Errorf("expected File, got %q", mgr.setApplicationMenuItems[0].Title)
+	}
+
+	// Add custom menu
+	mgr.setApplicationMenuCalled = false
+	customMenu := NewMenu("Tools").AddItem(MenuItem{Title: "Setting 1"})
+	app.AddCustomMenu("tools", customMenu)
+
+	if !mgr.setApplicationMenuCalled {
+		t.Fatal("SetApplicationMenu was not called after AddCustomMenu")
+	}
+	// Items should be combined: "File" from main, "Tools" as a submenu
+	if len(mgr.setApplicationMenuItems) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(mgr.setApplicationMenuItems))
+	}
+	if mgr.setApplicationMenuItems[1].Title != "Tools" {
+		t.Errorf("expected Tools, got %q", mgr.setApplicationMenuItems[1].Title)
+	}
+	if len(mgr.setApplicationMenuItems[1].Submenu) != 1 {
+		t.Fatalf("expected 1 submenu item, got %d", len(mgr.setApplicationMenuItems[1].Submenu))
+	}
+
+	// Update custom menu
+	mgr.setApplicationMenuCalled = false
+	customMenu.AddItem(MenuItem{Title: "Setting 2"})
+	app.UpdateCustomMenu("tools", customMenu)
+
+	if !mgr.setApplicationMenuCalled {
+		t.Fatal("SetApplicationMenu was not called after UpdateCustomMenu")
+	}
+	// Now should have 2 top-level items, but the second one has 2 items in submenu
+	if len(mgr.setApplicationMenuItems) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(mgr.setApplicationMenuItems))
+	}
+	if len(mgr.setApplicationMenuItems[1].Submenu) != 2 {
+		t.Fatalf("expected 2 submenu items, got %d", len(mgr.setApplicationMenuItems[1].Submenu))
 	}
 }

--- a/menu_test.go
+++ b/menu_test.go
@@ -52,9 +52,9 @@ func (m *mockMenuManager) SetAppName(string)                         {}
 
 // TestNewMenu checks that NewMenu is not nil and that the menu is empty.
 func TestNewMenu(t *testing.T) {
-	menu := NewMenu("Test")
+	menu := NewMenuWithTitle("Test")
 	if menu == nil {
-		t.Fatal("NewMenu returned nil")
+		t.Fatal("NewMenuWithTitle returned nil")
 	}
 	if menu.Title != "Test" {
 		t.Errorf("expected title Test, got %q", menu.Title)
@@ -62,11 +62,16 @@ func TestNewMenu(t *testing.T) {
 	if len(menu.Items) != 0 {
 		t.Fatalf("expected empty menu, got %d items", len(menu.Items))
 	}
+
+	menu2 := NewMenu()
+	if menu2.Title != "" {
+		t.Errorf("expected empty title, got %q", menu2.Title)
+	}
 }
 
 // TestAddItem checks for the addition of elements and chained returns.
 func TestAddItem(t *testing.T) {
-	menu := NewMenu("")
+	menu := NewMenu()
 	result := menu.AddItem(MenuItem{Title: "Item 1"})
 	if result != menu {
 		t.Error("AddItem did not return the same menu for chaining")
@@ -194,7 +199,7 @@ func TestCustomMenus(t *testing.T) {
 	}
 
 	// Initial main menu
-	mainMenu := NewMenu("").AddItem(MenuItem{Title: "File"})
+	mainMenu := NewMenu().AddItem(MenuItem{Title: "File"})
 	app.SetMenu(mainMenu)
 
 	if !mgr.setApplicationMenuCalled {
@@ -207,13 +212,13 @@ func TestCustomMenus(t *testing.T) {
 		t.Errorf("expected File, got %q", mgr.setApplicationMenuItems[0].Title)
 	}
 
-	// Add custom menu
+	// Set custom menu
 	mgr.setApplicationMenuCalled = false
-	customMenu := NewMenu("Tools").AddItem(MenuItem{Title: "Setting 1"})
-	app.AddCustomMenu("tools", customMenu)
+	customMenu := NewMenuWithTitle("Tools").AddItem(MenuItem{Title: "Setting 1"})
+	app.SetCustomMenu("tools", customMenu)
 
 	if !mgr.setApplicationMenuCalled {
-		t.Fatal("SetApplicationMenu was not called after AddCustomMenu")
+		t.Fatal("SetApplicationMenu was not called after SetCustomMenu")
 	}
 	// Items should be combined: "File" from main, "Tools" as a submenu
 	if len(mgr.setApplicationMenuItems) != 2 {
@@ -224,21 +229,5 @@ func TestCustomMenus(t *testing.T) {
 	}
 	if len(mgr.setApplicationMenuItems[1].Submenu) != 1 {
 		t.Fatalf("expected 1 submenu item, got %d", len(mgr.setApplicationMenuItems[1].Submenu))
-	}
-
-	// Update custom menu
-	mgr.setApplicationMenuCalled = false
-	customMenu.AddItem(MenuItem{Title: "Setting 2"})
-	app.UpdateCustomMenu("tools", customMenu)
-
-	if !mgr.setApplicationMenuCalled {
-		t.Fatal("SetApplicationMenu was not called after UpdateCustomMenu")
-	}
-	// Now should have 2 top-level items, but the second one has 2 items in submenu
-	if len(mgr.setApplicationMenuItems) != 2 {
-		t.Fatalf("expected 2 items, got %d", len(mgr.setApplicationMenuItems))
-	}
-	if len(mgr.setApplicationMenuItems[1].Submenu) != 2 {
-		t.Fatalf("expected 2 submenu items, got %d", len(mgr.setApplicationMenuItems[1].Submenu))
 	}
 }


### PR DESCRIPTION
@kolkov So, I added the ability to add an additional menu. I also had the idea to add functionality for deleting the standard menu. For example, if we want to remove and add only our own items, then the CLEAR method would be useful.

<img width="311" height="186" alt="Снимок экрана 2026-05-21 в 20 09 32" src="https://github.com/user-attachments/assets/2638df5c-be51-42ed-9a72-029ee3007562" />


Unrelated to the task, but I'm getting an error with smoke tests.

Perhaps this is just me?

starting TestDarwinAppRunPanicOnDrawNoTriangle
2026/05/21 19:59:48 INFO adapter selected name="Apple M3 Max" type=DiscreteGPU
panic: forced draw panic