### PR TITLE
docs: CHANGELOG + ROADMAP for v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.38.0] - 2026-05-21
 
 ### Added
 
 - **macOS system menu API** (#242, @lkmavi) -- `SetMenu()`, `GetSystemMenu()`, `MenuRole` for native macOS menu bar. Role-based item mapping (About, Preferences, Quit, Minimize, Zoom, etc.). `SetAppName()` / `WithAppName()` for menu display. Pending menu support (set before `Run()`). New `examples/menu/` demo.
+- **Custom dynamic menus** (#264, @lkmavi) -- `SetCustomMenu(name, menu)` for additional menu bar entries. `NewMenuWithTitle(title)` constructor. `MenuItem.Submenu *Menu` for recursive nested menus. Insertion-order preserved via ordered slice. `NewMenu()` backward compatible (no args).
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.38.0** | 2026-05-21 | **macOS menu API** (#242, @lkmavi) + **custom dynamic menus** (#264, @lkmavi) — SetMenu, SetCustomMenu, MenuRole, Submenu. **Renderer decoupling** (LIFECYCLE Phase 2) — SurfaceState, per-window platWindow. PlatformProvider delegation (ADR-024). deps: wgpu v0.28.6 (GLES hidden window) |
 | **v0.37.12** | 2026-05-21 | **PlatformProvider delegation** (ADR-024) -- GPUContextAdapter implements PlatformProvider, LCD auto-detection works. deps: wgpu v0.28.6 (GLES hidden window) |
 | **v0.37.11** | 2026-05-21 | **deps:** wgpu v0.28.5 (indirect validation nil guard, Metal present fixes) |
 | **v0.37.10** | 2026-05-19 | **timerfd key repeat** (#240) -- goroutine→timerfd in Poll set, fixes GUI freeze + xkb data race |


### PR DESCRIPTION
Release documentation for v0.38.0: macOS menu API, custom dynamic menus, renderer decoupling (Phase 2).