### PR TITLE
fix: platform fixes + Wayland cursor shapes (v0.39.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.39.2] - 2026-05-24
+## [0.39.2] - 2026-05-25
+
+### Added
+
+- **Wayland: cursor shapes via wp_cursor_shape_manager_v1** (PLAT-008, CSD-CURSOR-001) — `SetCursor` on Wayland now works. 12 cursor shapes (arrow, hand, text, crosshair, move, resize, wait, not-allowed) via the modern cursor shape protocol. CSD border subsurfaces show correct resize cursors (N/S/E/W/NW/NE/SW/SE). Shape caching with invalidation on pointer re-enter. Graceful fallback on compositors without the protocol.
+- **X11: frameless window drag/resize via _NET_WM_MOVERESIZE** (#270) — `handleButtonPress` invokes `hitTestCallback` on left click. Caption → move, resize edges → WM resize. Standard EWMH protocol.
 
 ### Fixed
 
-- **Wayland: damage_buffer before commit** (#272) — `wl_surface.damage_buffer` (opcode 9, v4+) now called before configure-time commit. Compositor receives correct damage regions instead of repainting entire surface.
-- **Wayland: Activated state → EventFocus** (#273) — `xdg_toplevel` Activated state (4) parsed from configure states array and emitted as `EventFocus`. Previously only `wl_keyboard.enter/leave` triggered focus events.
-- **Windows: DPI-correct MouseLeave coordinates** (#271) — `wmMouseLeave` now applies `scaleFactor()` to cached physical pixel coordinates, matching all other pointer events. Fixes mouse position mismatch at non-100% DPI scaling.
-- **X11: HitTestCallback invocation for frameless windows** (#270) — `handleButtonPress` now calls `hitTestCallback` on left click for frameless windows. If result is Caption or Resize edge, sends `_NET_WM_MOVERESIZE` client message to the window manager. Frameless window dragging and resizing now works on X11.
-- **Focus events dispatched to UI layer** (BUG-FOCUS-001) — `EventFocus` handler now calls `eventSource.dispatchFocus()`. Previously focus events reached the window manager but never the UI layer, causing broken redraw on focus change.
-- **Wayland: cursor shapes via wp_cursor_shape_manager_v1** (PLAT-008, CSD-CURSOR-001) — `SetCursor` on Wayland now works. 12 cursor shapes (arrow, hand, text, crosshair, move, resize, wait, not-allowed) via the modern Wayland cursor shape protocol. CSD border subsurfaces show correct resize cursors (N/S/E/W/NW/NE/SW/SE). Graceful fallback to no-op on compositors without the protocol.
+- **Wayland: damage_buffer before commit** (#272) — `wl_surface.damage_buffer` (opcode 9, v4+) now called before configure-time commit. Compositor receives correct damage regions.
+- **Wayland: Activated state → EventFocus** (#273) — `xdg_toplevel` Activated state (4) parsed from configure states array and emitted as `EventFocus`.
+- **Windows: DPI-correct MouseLeave coordinates** (#271) — `wmMouseLeave` now applies `scaleFactor()` to cached physical pixel coordinates, matching all other pointer events.
+- **Focus events dispatched to UI layer** (BUG-FOCUS-001) — `EventFocus` handler now calls `eventSource.dispatchFocus()`. UI layer receives FocusGained/FocusLost callbacks.
 
 ## [0.39.1] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Wayland: Activated state → EventFocus** (#273) — `xdg_toplevel` Activated state (4) parsed from configure states array and emitted as `EventFocus`. Previously only `wl_keyboard.enter/leave` triggered focus events.
 - **Windows: DPI-correct MouseLeave coordinates** (#271) — `wmMouseLeave` now applies `scaleFactor()` to cached physical pixel coordinates, matching all other pointer events. Fixes mouse position mismatch at non-100% DPI scaling.
 - **X11: HitTestCallback invocation for frameless windows** (#270) — `handleButtonPress` now calls `hitTestCallback` on left click for frameless windows. If result is Caption or Resize edge, sends `_NET_WM_MOVERESIZE` client message to the window manager. Frameless window dragging and resizing now works on X11.
+- **Focus events dispatched to UI layer** (BUG-FOCUS-001) — `EventFocus` handler now calls `eventSource.dispatchFocus()`. Previously focus events reached the window manager but never the UI layer, causing broken redraw on focus change.
 
 ## [0.39.1] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Wayland: damage_buffer before commit** (#272) — `wl_surface.damage_buffer` (opcode 9, v4+) now called before configure-time commit. Compositor receives correct damage regions instead of repainting entire surface.
 - **Wayland: Activated state → EventFocus** (#273) — `xdg_toplevel` Activated state (4) parsed from configure states array and emitted as `EventFocus`. Previously only `wl_keyboard.enter/leave` triggered focus events.
+- **Windows: DPI-correct MouseLeave coordinates** (#271) — `wmMouseLeave` now applies `scaleFactor()` to cached physical pixel coordinates, matching all other pointer events. Fixes mouse position mismatch at non-100% DPI scaling.
+- **X11: HitTestCallback invocation for frameless windows** (#270) — `handleButtonPress` now calls `hitTestCallback` on left click for frameless windows. If result is Caption or Resize edge, sends `_NET_WM_MOVERESIZE` client message to the window manager. Frameless window dragging and resizing now works on X11.
 
 ## [0.39.1] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.2] - 2026-05-24
+
+### Fixed
+
+- **Wayland: damage_buffer before commit** (#272) — `wl_surface.damage_buffer` (opcode 9, v4+) now called before configure-time commit. Compositor receives correct damage regions instead of repainting entire surface.
+- **Wayland: Activated state → EventFocus** (#273) — `xdg_toplevel` Activated state (4) parsed from configure states array and emitted as `EventFocus`. Previously only `wl_keyboard.enter/leave` triggered focus events.
+
 ## [0.39.1] - 2026-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Windows: DPI-correct MouseLeave coordinates** (#271) — `wmMouseLeave` now applies `scaleFactor()` to cached physical pixel coordinates, matching all other pointer events. Fixes mouse position mismatch at non-100% DPI scaling.
 - **X11: HitTestCallback invocation for frameless windows** (#270) — `handleButtonPress` now calls `hitTestCallback` on left click for frameless windows. If result is Caption or Resize edge, sends `_NET_WM_MOVERESIZE` client message to the window manager. Frameless window dragging and resizing now works on X11.
 - **Focus events dispatched to UI layer** (BUG-FOCUS-001) — `EventFocus` handler now calls `eventSource.dispatchFocus()`. Previously focus events reached the window manager but never the UI layer, causing broken redraw on focus change.
+- **Wayland: cursor shapes via wp_cursor_shape_manager_v1** (PLAT-008, CSD-CURSOR-001) — `SetCursor` on Wayland now works. 12 cursor shapes (arrow, hand, text, crosshair, move, resize, wait, not-allowed) via the modern Wayland cursor shape protocol. CSD border subsurfaces show correct resize cursors (N/S/E/W/NW/NE/SW/SE). Graceful fallback to no-op on compositors without the protocol.
 
 ## [0.39.1] - 2026-05-22
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
-| **v0.39.2** | 2026-05-24 | **Wayland fixes** — damage_buffer before commit (#272), Activated→EventFocus (#273) |
+| **v0.39.2** | 2026-05-25 | **Platform fixes** — Wayland damage_buffer (#272) + Activated→EventFocus (#273), Windows DPI MouseLeave (#271), X11 HitTestCallback + _NET_WM_MOVERESIZE (#270) |
 | **v0.39.1** | 2026-05-22 | **AppLifecycle enum + callbacks** (ADR-026 Phase 3 complete) — AppLifecycle (5 states), OnSurfaceAvailable/Destroyed, OnResumed/Suspended/MemoryWarning |
 | **v0.39.0** | 2026-05-22 | **ADR-026 Universal Lifecycle** — QuitOnLastWindowClosed, primary close resilience, RenderTarget (public type), initDevice/initSurface split, SurfaceState, WindowID real type. `examples/lifecycle/`. deps: wgpu v0.28.7 |
 | **v0.38.0** | 2026-05-21 | **macOS menu API** (#242, @lkmavi) + **custom dynamic menus** (#264, @lkmavi) — SetMenu, SetCustomMenu, MenuRole, Submenu. **Renderer decoupling** (LIFECYCLE Phase 2) — SurfaceState, per-window platWindow. PlatformProvider delegation (ADR-024). deps: wgpu v0.28.6 (GLES hidden window) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
-| **v0.39.2** | 2026-05-25 | **Platform fixes** — Wayland damage_buffer (#272) + Activated→EventFocus (#273), Windows DPI MouseLeave (#271), X11 HitTestCallback + _NET_WM_MOVERESIZE (#270) |
+| **v0.39.2** | 2026-05-25 | **Wayland cursor shapes** (wp_cursor_shape_manager_v1, 12 shapes + CSD resize cursors) + **platform fixes** — damage_buffer (#272), Activated→EventFocus (#273), DPI MouseLeave (#271), X11 HitTest (#270), dispatchFocus (BUG-FOCUS-001) |
 | **v0.39.1** | 2026-05-22 | **AppLifecycle enum + callbacks** (ADR-026 Phase 3 complete) — AppLifecycle (5 states), OnSurfaceAvailable/Destroyed, OnResumed/Suspended/MemoryWarning |
 | **v0.39.0** | 2026-05-22 | **ADR-026 Universal Lifecycle** — QuitOnLastWindowClosed, primary close resilience, RenderTarget (public type), initDevice/initSurface split, SurfaceState, WindowID real type. `examples/lifecycle/`. deps: wgpu v0.28.7 |
 | **v0.38.0** | 2026-05-21 | **macOS menu API** (#242, @lkmavi) + **custom dynamic menus** (#264, @lkmavi) — SetMenu, SetCustomMenu, MenuRole, Submenu. **Renderer decoupling** (LIFECYCLE Phase 2) — SurfaceState, per-window platWindow. PlatformProvider delegation (ADR-024). deps: wgpu v0.28.6 (GLES hidden window) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.39.2** | 2026-05-24 | **Wayland fixes** — damage_buffer before commit (#272), Activated→EventFocus (#273) |
 | **v0.39.1** | 2026-05-22 | **AppLifecycle enum + callbacks** (ADR-026 Phase 3 complete) — AppLifecycle (5 states), OnSurfaceAvailable/Destroyed, OnResumed/Suspended/MemoryWarning |
 | **v0.39.0** | 2026-05-22 | **ADR-026 Universal Lifecycle** — QuitOnLastWindowClosed, primary close resilience, RenderTarget (public type), initDevice/initSurface split, SurfaceState, WindowID real type. `examples/lifecycle/`. deps: wgpu v0.28.7 |
 | **v0.38.0** | 2026-05-21 | **macOS menu API** (#242, @lkmavi) + **custom dynamic menus** (#264, @lkmavi) — SetMenu, SetCustomMenu, MenuRole, Submenu. **Renderer decoupling** (LIFECYCLE Phase 2) — SurfaceState, per-window platWindow. PlatformProvider delegation (ADR-024). deps: wgpu v0.28.6 (GLES hidden window) |

--- a/app.go
+++ b/app.go
@@ -566,6 +566,9 @@ func (a *App) classifyEvent(event *platform.Event, lastResize *platform.Event, s
 				a.windowManager.setFocus(w.id)
 			}
 		}
+		if a.eventSource != nil {
+			a.eventSource.dispatchFocus(event.Focused)
+		}
 		a.RequestRedraw()
 
 	case platform.EventKeyDown:

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -65,6 +65,9 @@ type waylandWindow struct {
 	pointerIn bool // True when pointer is inside our surface
 	startTime time.Time
 
+	// Cursor shape cache — avoids redundant set_shape protocol messages.
+	currentCursor int // last cursorID set via SetCursor (-1 = unset)
+
 	// Cursor mode (0=normal, 1=locked, 2=confined)
 	cursorMode int
 
@@ -160,9 +163,10 @@ func newPlatformManager() PlatformManager {
 	logger().Info("platform selected", "type", "wayland", "reason", "default (no WAYLAND_DISPLAY or DISPLAY)")
 	return &waylandPlatform{
 		primary: &waylandWindow{
-			startTime: time.Now(),
-			events:    eventqueue.New[Event](eventqueue.DefaultCapacity),
-			repeatFd:  -1, // not created yet; created in Init()
+			startTime:     time.Now(),
+			events:        eventqueue.New[Event](eventqueue.DefaultCapacity),
+			repeatFd:      -1, // not created yet; created in Init()
+			currentCursor: -1, // unset — ensures first SetCursor(0) takes effect
 		},
 	}
 }
@@ -535,7 +539,7 @@ func (p *waylandPlatform) CreateWindow(config Config) (PlatformWindow, error) {
 // initSingleConnection initializes using a single C libwayland connection.
 // Uses Pure Go wire protocol ONLY for registry global discovery, then
 // creates all objects on the C connection via goffi.
-func (p *waylandPlatform) initSingleConnection(config Config) error {
+func (p *waylandPlatform) initSingleConnection(config Config) error { //nolint:gocognit // Wayland init binds many protocol extensions sequentially
 	// Step 1: Use Pure Go protocol to discover registry globals.
 	// This is lightweight (just reads global names/versions), then we disconnect.
 	display, err := wayland.Connect()
@@ -668,6 +672,22 @@ func (p *waylandPlatform) initSingleConnection(config Config) error {
 		}
 	}
 
+	// Bind wp_cursor_shape_manager_v1 (optional, for cursor shapes)
+	cursorShapeGlobal := registry.GetGlobalByInterface(wayland.InterfaceWpCursorShapeManagerV1)
+	if cursorShapeGlobal != nil {
+		if err := libwl.SetupCursorShape(cursorShapeGlobal.Name, cursorShapeGlobal.Version); err != nil {
+			logger().Warn("cursor shape setup failed (cursor changes unavailable)", "err", err)
+		} else {
+			logger().Debug("cursor shape protocol bound")
+			// Create cursor shape device for main pointer (if available)
+			if libwl.InputPointer() != 0 {
+				if err := libwl.CreateCursorShapeDevice(libwl.InputPointer()); err != nil {
+					logger().Warn("cursor shape device creation failed", "err", err)
+				}
+			}
+		}
+	}
+
 	// Activate CSD if SSD was not available and window is not frameless
 	if decorGlobal == nil && !config.Frameless {
 		if err := p.initCSD(config); err != nil {
@@ -746,6 +766,7 @@ func (p *waylandPlatform) setupInputCallbacks() {
 			w.pointerX = x
 			w.pointerY = y
 			w.pointerIn = true
+			w.currentCursor = -1 // invalidate cache — compositor resets cursor on enter
 			w.pointerMu.Unlock()
 
 			w.dispatchPointerEvent(gpucontext.PointerEvent{
@@ -2266,12 +2287,29 @@ func (p *waylandPlatform) ScaleFactor() float64 {
 	return 1.0
 }
 
-// SetCursor changes the mouse cursor shape.
-// TODO(PLAT-008): Implement using wp_cursor_shape_manager_v1 or xcursor theme loading.
-// wp_cursor_shape_manager_v1 is the modern approach (Wayland protocol extension).
-// Fallback: load xcursor theme files from $XCURSOR_PATH, render to wl_buffer,
-// attach via wl_pointer.set_cursor. Both approaches are significant effort.
-func (p *waylandPlatform) SetCursor(int) {}
+// SetCursor changes the mouse cursor shape using wp_cursor_shape_manager_v1.
+// Falls back to no-op if the compositor does not support the protocol.
+// Caches current shape to avoid redundant protocol messages (winit PR #1116 pattern).
+func (p *waylandPlatform) SetCursor(cursorID int) {
+	if p.libwl == nil || !p.libwl.HasCursorShape() {
+		return
+	}
+	w := p.primary
+	if w == nil {
+		return
+	}
+	w.pointerMu.RLock()
+	current := w.currentCursor
+	w.pointerMu.RUnlock()
+	if cursorID == current {
+		return
+	}
+	serial := p.libwl.PointerEnterSerial()
+	p.libwl.SetCursorShape(cursorID, serial)
+	w.pointerMu.Lock()
+	w.currentCursor = cursorID
+	w.pointerMu.Unlock()
+}
 
 // SetCursorMode sets cursor confinement/lock mode on Wayland.
 // 0=normal, 1=locked (hidden + pointer lock + relative deltas), 2=confined (visible + confined to surface).

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -43,6 +43,7 @@ type waylandWindow struct {
 	height      int
 	shouldClose bool
 	configured  bool
+	activated   bool // xdg_toplevel Activated state (window manager focus)
 
 	// eventMu guards window state fields (shouldClose, maximized, fullscreen,
 	// width, height, savedWidth, savedHeight). The event queue has its own
@@ -1080,10 +1081,16 @@ func (p *waylandPlatform) setupInputCallbacks() {
 			w.queueEvent(Event{Type: EventClose, WindowID: p.primaryWindowID})
 			p.WakeUp() // unblock WaitEvents so main loop sees shouldClose
 		},
-		OnConfigure: func(width, height int32) {
-			logger().Debug("wayland toplevel.configure", "rawW", width, "rawH", height)
+		OnConfigure: func(width, height int32, activated bool) {
+			logger().Debug("wayland toplevel.configure", "rawW", width, "rawH", height, "activated", activated)
 			w.eventMu.Lock()
 			defer w.eventMu.Unlock()
+
+			// Emit EventFocus when Activated state changes (#273).
+			if activated != w.activated {
+				w.activated = activated
+				w.queueEvent(Event{Type: EventFocus, Focused: activated, WindowID: p.primaryWindowID})
+			}
 
 			isMaximized := p.libwl != nil && p.libwl.CSDActive() && p.libwl.IsMaximized()
 

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -2602,6 +2602,14 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		w.mouseInWindow = false
 		w.mouseMu.Unlock()
 
+		// Convert cached physical pixels to logical (DIP) coordinates,
+		// same as createPointerEvent does for all other pointer events.
+		scale := w.scaleFactor()
+		if scale > 1.0 {
+			x /= scale
+			y /= scale
+		}
+
 		ev := gpucontext.PointerEvent{
 			Type:        gpucontext.PointerLeave,
 			PointerID:   1,

--- a/internal/platform/wayland/libwayland.go
+++ b/internal/platform/wayland/libwayland.go
@@ -97,6 +97,7 @@ type LibwaylandHandle struct {
 	csdPendingAction  CSDHitResult // action to perform outside callback
 	csdPendingSerial  uint32       // serial for pending move/resize
 	csdPendingRepaint bool         // title bar needs repaint (deferred from callback)
+	csdPendingCursor  bool         // CSD cursor shape needs update (deferred from callback)
 	csdPendingResize  bool         // CSD needs resize on next xdg_surface.configure
 	csdPendingResizeW int          // pending CSD content width for resize
 	csdPendingResizeH int          // pending CSD content height for resize
@@ -116,6 +117,11 @@ type LibwaylandHandle struct {
 	confinedPointer       uintptr // current zwp_confined_pointer_v1* (or 0)
 	relativePointer       uintptr // current zwp_relative_pointer_v1* (or 0)
 	pointerEnterSerial    uint32  // last wl_pointer.enter serial (needed for set_cursor)
+
+	// Cursor shape (wp_cursor_shape_manager_v1)
+	cursorShapeMgr       uintptr // wp_cursor_shape_manager_v1* manager proxy (or 0)
+	cursorShapeDevice    uintptr // wp_cursor_shape_device_v1* for main pointer (or 0)
+	csdCursorShapeDevice uintptr // wp_cursor_shape_device_v1* for CSD pointer (or 0)
 
 	// Data symbols (interface descriptors — pointers to static C structs)
 	registryInterface      unsafe.Pointer // &wl_registry_interface
@@ -243,6 +249,14 @@ func OpenLibwayland(compositorName, compositorVersion, xdgWmBaseName, xdgWmBaseV
 func (h *LibwaylandHandle) Close() {
 	if h == nil {
 		return
+	}
+
+	// Destroy cursor shape objects (before pointer constraints and input)
+	h.DestroyCursorShapeDevices()
+	if h.cursorShapeMgr != 0 {
+		h.marshalVoid(h.cursorShapeMgr, 0) // wp_cursor_shape_manager_v1::destroy (opcode 0)
+		h.proxyDestroy(h.cursorShapeMgr)
+		h.cursorShapeMgr = 0
 	}
 
 	// Destroy pointer constraint objects (before input, in reverse creation order)

--- a/internal/platform/wayland/libwayland_csd.go
+++ b/internal/platform/wayland/libwayland_csd.go
@@ -172,6 +172,11 @@ func (h *LibwaylandHandle) SetupCSD(subcompName, subcompVersion, shmName, shmVer
 	if err := h.setupCSDPointer(seatName, seatVersion); err != nil {
 		// Non-fatal: decorations render but aren't interactive
 		slog.Warn("CSD pointer setup failed, decorations not interactive", "err", err)
+	} else if h.cursorShapeMgr != 0 && h.csdPointer != 0 {
+		// Create cursor shape device for CSD pointer (resize/move cursors)
+		if err := h.CreateCSDCursorShapeDevice(h.csdPointer); err != nil {
+			slog.Warn("CSD cursor shape device creation failed", "err", err)
+		}
 	}
 
 	return nil
@@ -228,6 +233,12 @@ func (h *LibwaylandHandle) DispatchCSDEvents() error {
 	if h.csdPendingRepaint {
 		h.csdPendingRepaint = false
 		h.repaintCSDTitleBar()
+	}
+
+	// Process pending cursor shape update (deferred from goffi callbacks).
+	if h.csdPendingCursor {
+		h.csdPendingCursor = false
+		h.UpdateCSDCursor()
 	}
 
 	// Process pending actions (deferred from goffi callbacks to avoid nested FFI).
@@ -459,12 +470,13 @@ func (h *LibwaylandHandle) updateCSDHitTest() {
 		h.csdHitResult = CSDHitNone
 	}
 
-	// Update hover states if changed
+	// Update hover states and cursor shape if changed
 	if oldHit != h.csdHitResult {
 		h.csdState.Close.Hovered = h.csdHitResult == CSDHitClose
 		h.csdState.Maximize.Hovered = h.csdHitResult == CSDHitMaximize
 		h.csdState.Minimize.Hovered = h.csdHitResult == CSDHitMinimize
 		h.csdPendingRepaint = true
+		h.csdPendingCursor = true // deferred cursor shape update
 	}
 }
 

--- a/internal/platform/wayland/libwayland_cursor_shape.go
+++ b/internal/platform/wayland/libwayland_cursor_shape.go
@@ -1,0 +1,302 @@
+//go:build linux
+
+package wayland
+
+// libwayland_cursor_shape.go — wp_cursor_shape_manager_v1 protocol.
+//
+// Implements the modern cursor shape protocol for setting cursor shapes
+// on Wayland compositors without loading xcursor themes. The protocol
+// provides server-side cursor rendering using named cursor shapes.
+//
+// Protocol objects:
+//   - wp_cursor_shape_manager_v1: global manager, binds from registry
+//   - wp_cursor_shape_device_v1: per-pointer device, sets shapes by enum
+//
+// Uses the same C-compatible interface descriptor pattern as
+// libwayland_pointer_constraints.go.
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"unsafe"
+)
+
+// wp_cursor_shape_device_v1 shape enum values from the Wayland protocol XML.
+const (
+	wpCursorShapeDefault     uint32 = 1
+	wpCursorShapeContextMenu uint32 = 2
+	wpCursorShapeHelp        uint32 = 3
+	wpCursorShapePointer     uint32 = 4
+	wpCursorShapeProgress    uint32 = 5
+	wpCursorShapeWait        uint32 = 6
+	wpCursorShapeCell        uint32 = 7
+	wpCursorShapeCrosshair   uint32 = 8
+	wpCursorShapeText        uint32 = 9
+	wpCursorShapeMove        uint32 = 13
+	wpCursorShapeNotAllowed  uint32 = 15
+	wpCursorShapeEResize     uint32 = 18
+	wpCursorShapeNResize     uint32 = 19
+	wpCursorShapeNEResize    uint32 = 20
+	wpCursorShapeNWResize    uint32 = 21
+	wpCursorShapeSResize     uint32 = 22
+	wpCursorShapeSEResize    uint32 = 23
+	wpCursorShapeSWResize    uint32 = 24
+	wpCursorShapeWResize     uint32 = 25
+	wpCursorShapeEWResize    uint32 = 26
+	wpCursorShapeNSResize    uint32 = 27
+	wpCursorShapeNESWResize  uint32 = 28
+	wpCursorShapeNWSEResize  uint32 = 29
+)
+
+// cursorShapeInterfaces holds C-compatible interface descriptors for
+// wp_cursor_shape_manager_v1 and wp_cursor_shape_device_v1.
+// Constructed once, live for program lifetime.
+var cursorShapeInterfaces struct {
+	once sync.Once
+
+	// Interface descriptors
+	manager cWlInterface // wp_cursor_shape_manager_v1
+	device  cWlInterface // wp_cursor_shape_device_v1
+
+	// Method arrays (indexed by opcode)
+	managerMethods [2]cWlMessage // destroy, get_pointer
+	deviceMethods  [2]cWlMessage // destroy, set_shape
+
+	// NULL types array (shared by all messages)
+	nullTypes [4]uintptr
+}
+
+// initCursorShapeInterfaces constructs C-compatible interface descriptors
+// for wp_cursor_shape_manager_v1 and wp_cursor_shape_device_v1 protocols.
+// Called once during the first cursor shape setup.
+func initCursorShapeInterfaces() {
+	cursorShapeInterfaces.once.Do(func() {
+		nt := uintptr(unsafe.Pointer(&cursorShapeInterfaces.nullTypes[0]))
+
+		// === wp_cursor_shape_manager_v1 methods ===
+		// opcode 0: destroy (no args)
+		cursorShapeInterfaces.managerMethods[0] = cWlMessage{cstr("destroy\x00"), cstr("\x00"), nt}
+		// opcode 1: get_pointer(new_id<wp_cursor_shape_device_v1>, pointer<wl_pointer>)
+		// signature: "no"
+		cursorShapeInterfaces.managerMethods[1] = cWlMessage{cstr("get_pointer\x00"), cstr("no\x00"), nt}
+
+		// wp_cursor_shape_manager_v1 interface (no events)
+		cursorShapeInterfaces.manager = cWlInterface{
+			Name:        cstr("wp_cursor_shape_manager_v1\x00"),
+			Version:     1,
+			MethodCount: 2,
+			Methods:     uintptr(unsafe.Pointer(&cursorShapeInterfaces.managerMethods[0])),
+			EventCount:  0,
+			Events:      0,
+		}
+
+		// === wp_cursor_shape_device_v1 methods ===
+		// opcode 0: destroy (no args)
+		cursorShapeInterfaces.deviceMethods[0] = cWlMessage{cstr("destroy\x00"), cstr("\x00"), nt}
+		// opcode 1: set_shape(serial: uint, shape: uint)
+		// signature: "uu"
+		cursorShapeInterfaces.deviceMethods[1] = cWlMessage{cstr("set_shape\x00"), cstr("uu\x00"), nt}
+
+		// wp_cursor_shape_device_v1 interface (no events)
+		cursorShapeInterfaces.device = cWlInterface{
+			Name:        cstr("wp_cursor_shape_device_v1\x00"),
+			Version:     1,
+			MethodCount: 2,
+			Methods:     uintptr(unsafe.Pointer(&cursorShapeInterfaces.deviceMethods[0])),
+			EventCount:  0,
+			Events:      0,
+		}
+	})
+}
+
+// --- LibwaylandHandle methods for cursor shape ---
+
+// SetupCursorShape binds the wp_cursor_shape_manager_v1 global.
+// Called during Init if the compositor advertises this protocol.
+func (h *LibwaylandHandle) SetupCursorShape(name, version uint32) error {
+	initCursorShapeInterfaces()
+
+	v := version
+	if v > 1 {
+		v = 1
+	}
+
+	mgr, err := h.registryBind(name, unsafe.Pointer(&cursorShapeInterfaces.manager), v)
+	if err != nil {
+		return fmt.Errorf("wayland: failed to bind wp_cursor_shape_manager_v1: %w", err)
+	}
+	h.cursorShapeMgr = mgr
+	return nil
+}
+
+// CreateCursorShapeDevice creates a wp_cursor_shape_device_v1 for a wl_pointer.
+// This is the main pointer's cursor shape device, used by SetCursorShape.
+func (h *LibwaylandHandle) CreateCursorShapeDevice(pointer uintptr) error {
+	if h.cursorShapeMgr == 0 {
+		return fmt.Errorf("wayland: cursor shape manager not available")
+	}
+	if pointer == 0 {
+		return fmt.Errorf("wayland: pointer is nil")
+	}
+
+	initCursorShapeInterfaces()
+
+	// get_pointer: opcode 1 on wp_cursor_shape_manager_v1
+	// signature "no": new_id<wp_cursor_shape_device_v1>, pointer<wl_pointer>
+	device, err := h.marshalConstructorObj(
+		h.cursorShapeMgr, 1,
+		unsafe.Pointer(&cursorShapeInterfaces.device),
+		pointer,
+	)
+	if err != nil {
+		return fmt.Errorf("wayland: get_pointer (cursor shape) failed: %w", err)
+	}
+	h.cursorShapeDevice = device
+	return nil
+}
+
+// CreateCSDCursorShapeDevice creates a wp_cursor_shape_device_v1 for the CSD pointer.
+// Used for setting resize/move cursors on decoration subsurfaces.
+func (h *LibwaylandHandle) CreateCSDCursorShapeDevice(pointer uintptr) error {
+	if h.cursorShapeMgr == 0 {
+		return fmt.Errorf("wayland: cursor shape manager not available")
+	}
+	if pointer == 0 {
+		return fmt.Errorf("wayland: CSD pointer is nil")
+	}
+
+	initCursorShapeInterfaces()
+
+	// get_pointer: opcode 1 on wp_cursor_shape_manager_v1
+	device, err := h.marshalConstructorObj(
+		h.cursorShapeMgr, 1,
+		unsafe.Pointer(&cursorShapeInterfaces.device),
+		pointer,
+	)
+	if err != nil {
+		return fmt.Errorf("wayland: get_pointer (CSD cursor shape) failed: %w", err)
+	}
+	h.csdCursorShapeDevice = device
+	return nil
+}
+
+// HasCursorShape returns true if the compositor supports wp_cursor_shape_manager_v1.
+func (h *LibwaylandHandle) HasCursorShape() bool {
+	return h.cursorShapeMgr != 0
+}
+
+// SetCursorShape sets the cursor shape on the main pointer using wp_cursor_shape_device_v1.
+// cursorID maps to gpucontext.CursorShape values (0-11).
+// For CursorNone (11), falls back to HideCursor via wl_pointer.set_cursor with NULL surface.
+func (h *LibwaylandHandle) SetCursorShape(cursorID int, serial uint32) {
+	if h.cursorShapeDevice == 0 {
+		return
+	}
+
+	// CursorNone (11) = hide cursor via wl_pointer.set_cursor with NULL surface
+	if cursorID == 11 {
+		h.HideCursor(serial)
+		return
+	}
+
+	shape := cursorIDToWpShape(cursorID)
+	// set_shape: opcode 1 on wp_cursor_shape_device_v1
+	// Args: serial (uint32), shape (uint32)
+	h.marshalVoid(h.cursorShapeDevice, 1, uintptr(serial), uintptr(shape))
+}
+
+// SetCSDCursorShape sets the cursor shape on the CSD pointer.
+// Used by CSD hit-test to show resize/move cursors on decoration borders.
+func (h *LibwaylandHandle) SetCSDCursorShape(shape uint32, serial uint32) {
+	if h.csdCursorShapeDevice == 0 {
+		return
+	}
+	// set_shape: opcode 1 on wp_cursor_shape_device_v1
+	h.marshalVoid(h.csdCursorShapeDevice, 1, uintptr(serial), uintptr(shape))
+}
+
+// DestroyCursorShapeDevices destroys both main and CSD cursor shape devices.
+func (h *LibwaylandHandle) DestroyCursorShapeDevices() {
+	if h.csdCursorShapeDevice != 0 {
+		h.marshalVoid(h.csdCursorShapeDevice, 0) // wp_cursor_shape_device_v1::destroy
+		h.proxyDestroy(h.csdCursorShapeDevice)
+		h.csdCursorShapeDevice = 0
+	}
+	if h.cursorShapeDevice != 0 {
+		h.marshalVoid(h.cursorShapeDevice, 0) // wp_cursor_shape_device_v1::destroy
+		h.proxyDestroy(h.cursorShapeDevice)
+		h.cursorShapeDevice = 0
+	}
+}
+
+// cursorIDToWpShape maps gpucontext.CursorShape int values to
+// wp_cursor_shape_device_v1 shape enum values.
+func cursorIDToWpShape(cursorID int) uint32 {
+	switch cursorID {
+	case 0: // CursorDefault
+		return wpCursorShapeDefault
+	case 1: // CursorPointer (hand)
+		return wpCursorShapePointer
+	case 2: // CursorText (I-beam)
+		return wpCursorShapeText
+	case 3: // CursorCrosshair
+		return wpCursorShapeCrosshair
+	case 4: // CursorMove
+		return wpCursorShapeMove
+	case 5: // CursorResizeNS
+		return wpCursorShapeNSResize
+	case 6: // CursorResizeEW
+		return wpCursorShapeEWResize
+	case 7: // CursorResizeNWSE
+		return wpCursorShapeNWSEResize
+	case 8: // CursorResizeNESW
+		return wpCursorShapeNESWResize
+	case 9: // CursorNotAllowed
+		return wpCursorShapeNotAllowed
+	case 10: // CursorWait
+		return wpCursorShapeWait
+	default:
+		return wpCursorShapeDefault
+	}
+}
+
+// csdHitToWpCursorShape maps a CSD hit-test result to the appropriate
+// wp_cursor_shape_device_v1 shape enum value.
+func csdHitToWpCursorShape(hit CSDHitResult) uint32 {
+	switch hit {
+	case CSDHitResizeN:
+		return wpCursorShapeNResize
+	case CSDHitResizeS:
+		return wpCursorShapeSResize
+	case CSDHitResizeW:
+		return wpCursorShapeWResize
+	case CSDHitResizeE:
+		return wpCursorShapeEResize
+	case CSDHitResizeNW:
+		return wpCursorShapeNWResize
+	case CSDHitResizeNE:
+		return wpCursorShapeNEResize
+	case CSDHitResizeSW:
+		return wpCursorShapeSWResize
+	case CSDHitResizeSE:
+		return wpCursorShapeSEResize
+	default:
+		return wpCursorShapeDefault
+	}
+}
+
+// UpdateCSDCursor updates the CSD pointer cursor shape based on the current
+// hit-test result. Called from updateCSDHitTest when the hit result changes.
+// This is deferred (like repaint) to avoid nested FFI calls from within
+// goffi callbacks.
+func (h *LibwaylandHandle) UpdateCSDCursor() {
+	if h.csdCursorShapeDevice == 0 || h.csdSerial == 0 {
+		return
+	}
+	shape := csdHitToWpCursorShape(h.csdHitResult)
+	h.SetCSDCursorShape(shape, h.csdSerial)
+	if err := h.flush(); err != nil {
+		slog.Warn("wayland: cursor shape flush failed", "err", err)
+	}
+}

--- a/internal/platform/wayland/libwayland_input.go
+++ b/internal/platform/wayland/libwayland_input.go
@@ -55,8 +55,8 @@ type InputCallbacks struct {
 	// Close event from xdg_toplevel
 	OnClose func()
 
-	// Configure event from xdg_toplevel (width, height, states)
-	OnConfigure func(width, height int32)
+	// Configure event from xdg_toplevel (width, height, activated state)
+	OnConfigure func(width, height int32, activated bool)
 }
 
 // Input-related fields are added to LibwaylandHandle via composition in the
@@ -513,14 +513,17 @@ func inputToplevelConfigureCb(data, toplevel, width, height, states uintptr) {
 		return
 	}
 
-	// Parse states array for maximized state.
+	// Parse states array for maximized (1) and activated (4) states.
 	// wl_array layout on 64-bit: { uint64 size, uint64 alloc, uintptr data }
-	// xdg_toplevel_state::maximized = 1
-	if states != 0 && h.csdActive {
-		maximized := wlArrayContainsUint32(states, 1)
-		if h.csdState.Maximized != maximized {
-			h.csdState.Maximized = maximized
-			h.csdPendingRepaint = true
+	var activated bool
+	if states != 0 {
+		activated = wlArrayContainsUint32(states, 4) // xdg_toplevel_state::activated
+		if h.csdActive {
+			maximized := wlArrayContainsUint32(states, 1) // xdg_toplevel_state::maximized
+			if h.csdState.Maximized != maximized {
+				h.csdState.Maximized = maximized
+				h.csdPendingRepaint = true
+			}
 		}
 	}
 
@@ -530,12 +533,8 @@ func inputToplevelConfigureCb(data, toplevel, width, height, states uintptr) {
 		h.configuredH = int(int32(height))
 	}
 
-	// Call platform OnConfigure — it calculates CSD content dimensions
-	// (handling restore-from-saved, border subtraction) and calls
-	// SetPendingCSDResize. The actual CSD resize happens in
-	// xdgSurfaceConfigureCb after ack_configure.
 	if h.inputCallbacks.OnConfigure != nil {
-		h.inputCallbacks.OnConfigure(int32(width), int32(height))
+		h.inputCallbacks.OnConfigure(int32(width), int32(height), activated)
 	}
 }
 

--- a/internal/platform/wayland/libwayland_pointer_constraints.go
+++ b/internal/platform/wayland/libwayland_pointer_constraints.go
@@ -470,21 +470,16 @@ func (h *LibwaylandHandle) HideCursor(serial uint32) {
 	h.marshalVoid(h.inputPointer, 0, uintptr(serial), 0, 0, 0)
 }
 
-// ShowCursor restores the default cursor by requesting the compositor set
-// the cursor to the default shape. On Wayland, this is done by NOT setting
-// a cursor surface — the compositor will use the default cursor shape.
-// For a proper implementation, this would need cursor shape manager or
-// xcursor theme loading. For now, we set the enter serial so the compositor
-// knows we want the default cursor back.
+// ShowCursor restores the default cursor shape.
+// Uses wp_cursor_shape_manager_v1 if available, otherwise relies on
+// the compositor restoring the cursor when the pointer re-enters the surface.
 func (h *LibwaylandHandle) ShowCursor(serial uint32) {
-	// Wayland cursor restoration requires either:
-	// 1. wp_cursor_shape_manager_v1.set_cursor_shape(default)
-	// 2. Loading xcursor theme → wl_surface → wl_pointer.set_cursor
-	// Both are significant effort (PLAT-008 task).
-	//
-	// For pointer lock exit, the enter callback in the platform layer
-	// will trigger cursor restoration naturally when the pointer re-enters.
-	// No-op here — the compositor restores the cursor automatically when
-	// the pointer constraint is released and the pointer re-enters the surface.
-	_ = serial
+	if h.cursorShapeDevice != 0 {
+		// Use cursor shape protocol to set default cursor
+		h.SetCursorShape(0, serial) // 0 = CursorDefault
+		return
+	}
+	// Without cursor shape manager, the compositor restores the cursor
+	// automatically when the pointer constraint is released and the
+	// pointer re-enters the surface. No-op is correct here.
 }

--- a/internal/platform/wayland/libwayland_xdg.go
+++ b/internal/platform/wayland/libwayland_xdg.go
@@ -246,7 +246,14 @@ func xdgSurfaceConfigureCb(data, xdgSurface, serial uintptr) {
 			uintptr(uint32(h.configuredW)), uintptr(uint32(h.configuredH)))
 	}
 
-	// Commit the main surface — atomic: ack + geometry + subsurface changes all at once.
+	// Damage entire buffer before commit so compositor knows what changed (#272).
+	// wl_surface.damage_buffer = opcode 9 (v4+), signature "iiii".
+	if h.configuredW > 0 && h.configuredH > 0 {
+		h.marshalVoid(h.surface, 9, 0, 0,
+			uintptr(uint32(h.configuredW)), uintptr(uint32(h.configuredH)))
+	}
+
+	// Commit the main surface — atomic: ack + geometry + damage + subsurface changes.
 	h.marshalVoid(h.surface, 6)
 	slog.Debug("parent surface committed")
 }

--- a/internal/platform/wayland/registry.go
+++ b/internal/platform/wayland/registry.go
@@ -34,6 +34,10 @@ const (
 	// Used for mouse grab / pointer lock (CursorModeLocked, CursorModeConfined).
 	InterfaceZwpPointerConstraintsV1     = "zwp_pointer_constraints_v1"
 	InterfaceZwpRelativePointerManagerV1 = "zwp_relative_pointer_manager_v1"
+
+	// Cursor shape protocol (wp_cursor_shape_manager_v1).
+	// Modern protocol for setting cursor shapes without loading xcursor themes.
+	InterfaceWpCursorShapeManagerV1 = "wp_cursor_shape_manager_v1"
 )
 
 // Global represents a Wayland global interface advertised by the compositor.

--- a/internal/platform/x11/atoms.go
+++ b/internal/platform/x11/atoms.go
@@ -23,6 +23,7 @@ const (
 	AtomNameNetWMPID                = "_NET_WM_PID"
 	AtomNameNetWMIcon               = "_NET_WM_ICON"
 	AtomNameNetFrameExtents         = "_NET_FRAME_EXTENTS"
+	AtomNameNetWMMoveresize         = "_NET_WM_MOVERESIZE"
 	AtomNameUTF8String              = "UTF8_STRING"
 	AtomNameMotifWMHints            = "_MOTIF_WM_HINTS"
 )
@@ -176,6 +177,7 @@ type StandardAtoms struct {
 	NetWMStateFullscreen    Atom
 	NetWMStateMaximizedVert Atom
 	NetWMStateMaximizedHorz Atom
+	NetWMMoveresize         Atom
 	NetWMWindowType         Atom
 	NetWMWindowTypeNormal   Atom
 	NetWMPID                Atom
@@ -230,6 +232,11 @@ func (c *Connection) InternStandardAtoms() (*StandardAtoms, error) {
 	}
 
 	atoms.NetWMStateMaximizedHorz, err = c.InternAtom(AtomNameNetWMStateMaximizedHorz, false)
+	if err != nil {
+		return nil, err
+	}
+
+	atoms.NetWMMoveresize, err = c.InternAtom(AtomNameNetWMMoveresize, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -1004,6 +1004,27 @@ func (p *Platform) handleButtonPress(w *x11Window, e *ButtonPressEvent) {
 		return
 	}
 
+	// Check hit test for frameless window move/resize (left button only).
+	// When the WM takes over, we must not dispatch PointerDown.
+	if e.Detail == 1 {
+		w.callbackMu.RLock()
+		cb := w.hitTestCallback
+		frameless := w.frameless
+		w.callbackMu.RUnlock()
+
+		if frameless && cb != nil {
+			result := cb(x, y)
+			if dir, ok := hitTestToMoveResizeDirection(result); ok {
+				// Send _NET_WM_MOVERESIZE to the window manager.
+				// data: [x_root, y_root, direction, button, source_indication]
+				_ = p.conn.SendClientMessage(w.window, p.conn.RootWindow(),
+					p.atoms.NetWMMoveresize,
+					uint32(e.RootX), uint32(e.RootY), dir, 1, 1)
+				return
+			}
+		}
+	}
+
 	// Regular button press
 	button := x11ButtonToButton(e.Detail)
 	if button == gpucontext.ButtonNone {
@@ -2054,6 +2075,35 @@ func (p *Platform) SetHitTestCallback(fn func(x, y float64) gpucontext.HitTestRe
 	w.callbackMu.Lock()
 	defer w.callbackMu.Unlock()
 	w.hitTestCallback = fn
+}
+
+// hitTestToMoveResizeDirection maps a HitTestResult to the _NET_WM_MOVERESIZE
+// direction constant used by the EWMH specification.
+// Returns the direction and true if the result should initiate a WM move/resize,
+// or (0, false) for client area and button regions that we handle ourselves.
+func hitTestToMoveResizeDirection(result gpucontext.HitTestResult) (uint32, bool) {
+	switch result {
+	case gpucontext.HitTestCaption:
+		return 8, true // _NET_WM_MOVERESIZE_MOVE
+	case gpucontext.HitTestResizeNW:
+		return 0, true // _NET_WM_MOVERESIZE_SIZE_TOPLEFT
+	case gpucontext.HitTestResizeN:
+		return 1, true // _NET_WM_MOVERESIZE_SIZE_TOP
+	case gpucontext.HitTestResizeNE:
+		return 2, true // _NET_WM_MOVERESIZE_SIZE_TOPRIGHT
+	case gpucontext.HitTestResizeE:
+		return 3, true // _NET_WM_MOVERESIZE_SIZE_RIGHT
+	case gpucontext.HitTestResizeSE:
+		return 4, true // _NET_WM_MOVERESIZE_SIZE_BOTTOMRIGHT
+	case gpucontext.HitTestResizeS:
+		return 5, true // _NET_WM_MOVERESIZE_SIZE_BOTTOM
+	case gpucontext.HitTestResizeSW:
+		return 6, true // _NET_WM_MOVERESIZE_SIZE_BOTTOMLEFT
+	case gpucontext.HitTestResizeW:
+		return 7, true // _NET_WM_MOVERESIZE_SIZE_LEFT
+	default:
+		return 0, false
+	}
 }
 
 func (p *Platform) Minimize() {


### PR DESCRIPTION
## Summary

Platform fixes + Wayland cursor shapes for v0.39.2. 14 files, 3 platforms.

### Added
- **Wayland cursor shapes** via `wp_cursor_shape_manager_v1` (PLAT-008, CSD-CURSOR-001) — 12 shapes, CSD resize cursors, shape caching with re-enter invalidation, graceful fallback
- **X11 frameless drag/resize** via `_NET_WM_MOVERESIZE` (#270) — HitTestCallback invoked on left click, EWMH protocol

### Fixed
- **Wayland damage_buffer** before commit (#272)
- **Wayland Activated → EventFocus** (#273)
- **Windows DPI MouseLeave** coordinates (#271)
- **Focus dispatch to UI layer** (BUG-FOCUS-001)

Closes #270, closes #271, closes #272, closes #273

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 8 packages pass
- [x] `golangci-lint` — 0 issues on Windows, Linux, macOS
- [x] `GOWORK=off go build` — CI simulation
- [x] `gofmt -l` — all 12 .go files clean
- [x] CHANGELOG.md updated (Added + Fixed sections)
- [x] ROADMAP.md updated
