### PR TITLE
docs: update README + ARCHITECTURE for ADR-038

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@
 
 ## Overview
 
-**GoGPU** is a GPU computing framework for Go that provides a high-level API for graphics and compute operations. It supports dual backends: a high-performance Rust backend (wgpu-native) and a pure Go backend for zero-dependency builds.
+**GoGPU** is a GPU computing framework for Go that provides a high-level API for graphics and compute operations. Built on [gogpu/wgpu](https://github.com/gogpu/wgpu) — the unified Go WebGPU package with three backends: Pure Go (default), Rust FFI (`-tags rust`), and Browser WASM.
 
 ### Key Features
 
 | Category | Capabilities |
 |----------|--------------|
-| **Backends** | Rust (wgpu-native) or Pure Go (gogpu/wgpu) |
+| **Backends** | Pure Go (default), Rust FFI (`-tags rust`), Browser WASM — via [gogpu/wgpu](https://github.com/gogpu/wgpu) |
 | **Graphics API** | Runtime selection: Vulkan, DX12, Metal, GLES, Software |
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal), Browser/WASM (WebGPU) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), zero-copy surface rendering, damage-aware presentation |
@@ -92,43 +92,32 @@ func main() {
 
 ---
 
-## Backend Selection
+## Backend Selection (ADR-038)
 
-GoGPU supports two WebGPU implementations, selectable at compile time or runtime.
-
-### Build Tags
+Backend selection is handled inside [gogpu/wgpu](https://github.com/gogpu/wgpu) via build tags. gogpu uses `wgpu.CreateInstance()` — the build tag determines which implementation runs.
 
 ```bash
-# Pure Go backend (default, zero dependencies)
+# Pure Go (default, zero dependencies)
 go build ./...
 
-# Enable Rust backend (requires wgpu-native shared library)
+# Rust FFI (requires wgpu-native v29 shared library)
 go build -tags rust ./...
+
+# Download wgpu-native automatically:
+go run github.com/go-webgpu/webgpu/cmd/setup@latest
 ```
 
-### Runtime Selection
+| Backend | Build Tag | Use Case |
+|---------|-----------|----------|
+| **Pure Go** | (default) | Zero deps, cross-compile, air-gapped deploy |
+| **Rust FFI** | `-tags rust` | Battle-tested GPU drivers, max compatibility |
+| **Browser** | `GOOS=js GOARCH=wasm` | Web applications |
 
-```go
-// Auto-select best available (default)
-app := gogpu.NewApp(gogpu.DefaultConfig())
-
-// Explicit Rust backend
-app := gogpu.NewApp(gogpu.DefaultConfig().WithBackend(gogpu.BackendRust))
-
-// Explicit Pure Go backend
-app := gogpu.NewApp(gogpu.DefaultConfig().WithBackend(gogpu.BackendGo))
-```
-
-| Backend | Build Tag | Library | Use Case |
-|---------|-----------|---------|----------|
-| **Native Go** | (default) | gogpu/wgpu | Zero dependencies, simple deployment |
-| **Rust** | `-tags rust` | wgpu-native via FFI | Maximum performance (all platforms) |
-
-> **Note:** Rust backend requires [wgpu-native](https://github.com/gfx-rs/wgpu-native/releases) DLL.
+> **Note:** Rust backend requires [wgpu-native](https://github.com/gfx-rs/wgpu-native/releases/tag/v29.0.0.0). See [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) for setup.
 
 ### Graphics API Selection
 
-Backend (Rust/Native) and Graphics API (Vulkan/DX12/Metal/GLES) are independent choices:
+Graphics API (Vulkan/DX12/Metal/GLES) is selected independently from the backend:
 
 ```go
 // Force Vulkan on Windows (instead of auto-detected default)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document describes the architecture of the GoGPU ecosystem.
 
 ## Overview
 
-GoGPU is a Pure Go GPU computing ecosystem with dual-backend WebGPU support.
+GoGPU is a GPU computing ecosystem for Go with triple-backend WebGPU support (ADR-038).
 
 ```
 ┌────────────────────────────────────────────────────────────────────┐
@@ -18,37 +18,32 @@ GoGPU is a Pure Go GPU computing ecosystem with dual-backend WebGPU support.
        │  Framework  │  (device sharing)  │ 2D Graphics │
        └──────┬──────┘                    └──────┬──────┘
               │                                  │
-              │ Uses wgpu.Device/Queue           │
-              │ (wgpu public API)                │
-              │                    ┌─────────────┼──────────────┐
-              │                    │             │              │
-              │             ┌──────▼────┐  ┌─────▼─────┐  ┌─────▼─────┐
-              │             │gg/internal│  │gg/internal│  │  gg/gpu   │
-              │             │  /raster/ │  │   /gpu/   │  │ (opt-in   │
-              │             │ CPU Core  │  │ GPU Accel │  │  import)  │
-              │             └───────────┘  └─────┬─────┘  └───────────┘
+              │ Uses *wgpu.Device / *wgpu.Queue  │
+              │ (unified wgpu public API)        │
               │                                  │
-              └──────────────────────────────────┘
-                              │
-                       ┌──────▼──────┐
-                       │  wgpu API   │  ◄── public API (typed wrappers)
-                       └──────┬──────┘
-                              │
-                       ┌──────▼──────┐
-                       │  wgpu/core  │  ◄── validation, state machine, lifecycle
-                       └──────┬──────┘
-                              │
-                       ┌──────▼──────┐
-                       │  wgpu/hal   │  ◄── GPU API interfaces (advanced users)
-                       └──────┬──────┘
-                              │
-           ┌──────────┬───────┼───────┬──────────┐
-           │          │       │       │          │
-      ┌────▼───┐ ┌────▼──┐ ┌──▼──┐ ┌──▼───┐ ┌────▼────┐
-      │ Vulkan │ │ Metal │ │DX12 │ │ GLES │ │Software │
-      │(Win/   │ │(macOS)│ │(Win)│ │(Win/ │ │ (CPU)   │
-      │ Lin)   │ │       │ │     │ │ Lin) │ │         │
-      └────────┘ └───────┘ └─────┘ └──────┘ └─────────┘
+              └──────────────┬───────────────────┘
+                             │
+                      ┌──────▼──────┐
+                      │  wgpu API   │  ◄── same types on all backends
+                      └──┬────┬──┬──┘
+                         │    │  │
+          ┌──────────────┘    │  └──────────────────┐
+          │ (default)         │ (-tags rust)         │ (js,wasm)
+          │ *_native.go       │ *_rust.go            │ *_browser.go
+   ┌──────▼──────┐    ┌──────▼──────────┐    ┌──────▼──────────┐
+   │  wgpu/core  │    │ go-webgpu/webgpu│    │ internal/browser│
+   │  validation │    │ → wgpu-native   │    │ → syscall/js    │
+   └──────┬──────┘    │   v29 (Rust)    │    │ → Browser WebGPU│
+          │           └─────────────────┘    └─────────────────┘
+   ┌──────▼──────┐
+   │  wgpu/hal   │
+   └──────┬──────┘
+          │
+   ┌──────┼──────┬───────┬──────────┐
+   │      │      │       │          │
+┌──▼───┐┌─▼──┐┌──▼──┐┌───▼──┐┌─────▼───┐
+│Vulkan││Metal││DX12 ││ GLES ││Software │
+└──────┘└─────┘└─────┘└──────┘└─────────┘
 ```
 
 ## Projects
@@ -59,7 +54,7 @@ GoGPU is a Pure Go GPU computing ecosystem with dual-backend WebGPU support.
 | **gputypes**  | Shared WebGPU types (ZERO deps)      | [gogpu/gputypes](https://github.com/gogpu/gputypes)  |
 | **gpucontext**| Shared interfaces (imports gputypes) | [gogpu/gpucontext](https://github.com/gogpu/gpucontext) |
 | **gg**        | 2D graphics library (Canvas API)     | [gogpu/gg](https://github.com/gogpu/gg)              |
-| **wgpu**      | Pure Go WebGPU implementation        | [gogpu/wgpu](https://github.com/gogpu/wgpu)          |
+| **wgpu**      | Unified Go WebGPU (3 backends)       | [gogpu/wgpu](https://github.com/gogpu/wgpu)          |
 | **naga**      | WGSL shader compiler                 | [gogpu/naga](https://github.com/gogpu/naga)          |
 | **ui**        | GUI toolkit (22+ widgets, 4 themes)  | [gogpu/ui](https://github.com/gogpu/ui)              |
 | **g3d**       | 3D rendering (scene graph, PBR, GLTF)| [gogpu/g3d](https://github.com/gogpu/g3d)            |
@@ -87,16 +82,17 @@ The ecosystem uses two shared packages to ensure type compatibility:
 
 See the internal research document GPUCONTEXT_GPUTYPES_DECISION.md for full rationale.
 
-## Backend System
+## Backend System (ADR-038)
 
-### gogpu Backends
+### wgpu Triple-Backend Architecture
 
-The renderer uses `*wgpu.Device`/`*wgpu.Queue` through the wgpu public API. All GPU operations go through the three-layer stack: wgpu API → wgpu/core → wgpu/hal.
+Backend selection is inside wgpu via build tags. gogpu always uses `wgpu.CreateInstance()` — the build tag determines the implementation.
 
-| Backend      | Description                | Build Tag      | GPU Required |
-|--------------|----------------------------|----------------|--------------|
-| **Native**   | Pure Go via wgpu API → core → hal | (default)      | Yes          |
-| **Rust**     | wgpu-native via FFI        | `-tags rust`   | Yes          |
+| Backend      | Description                              | Build Tag      | GPU Required |
+|--------------|------------------------------------------|----------------|--------------|
+| **Pure Go**  | wgpu/core → wgpu/hal → Vulkan/Metal/DX12/GLES/Software | (default)      | Yes          |
+| **Rust FFI** | go-webgpu/webgpu → wgpu-native v29       | `-tags rust`   | Yes          |
+| **Browser**  | syscall/js → Browser WebGPU API          | `js,wasm`      | Yes (WebGPU) |
 
 ### gg: CPU Core + GPU Accelerator (ARCH-008)
 


### PR DESCRIPTION
Update public docs for triple-backend architecture (ADR-038). Remove stale WithBackend(BackendRust) examples, add setup tool reference, update architecture diagram.