### PR TITLE
feat/adr-36 : Add native file dialog for MacOS and Windows

### DIFF
--- a/app.go
+++ b/app.go
@@ -926,6 +926,30 @@ func (a *App) ClipboardWrite(text string) error {
 	return nil
 }
 
+// FileDialogOptions configures a native file open or save dialog.
+type FileDialogOptions = platform.FileDialogOptions
+
+// FileTypeFilter restricts the visible files in a dialog by extension.
+type FileTypeFilter = platform.FileTypeFilter
+
+// ShowOpenFileDialog opens a native file picker dialog on the primary window.
+// Returns nil, nil if the user cancels without making a selection.
+func (a *App) ShowOpenFileDialog(opts FileDialogOptions) ([]string, error) {
+	if a.manager != nil {
+		return a.manager.ShowOpenFileDialog(opts)
+	}
+	return nil, nil
+}
+
+// ShowSaveFileDialog opens a native file save dialog on the primary window.
+// Returns "", nil if the user cancels.
+func (a *App) ShowSaveFileDialog(opts FileDialogOptions) (string, error) {
+	if a.manager != nil {
+		return a.manager.ShowSaveFileDialog(opts)
+	}
+	return "", nil
+}
+
 // SetCursor changes the mouse cursor shape.
 // Implements gpucontext.PlatformProvider.
 func (a *App) SetCursor(cursor gpucontext.CursorShape) {

--- a/examples/file_dialog/main.go
+++ b/examples/file_dialog/main.go
@@ -1,0 +1,127 @@
+// Demonstrates native file open/save dialogs via keyboard shortcuts.
+// Run the app and press the keys shown in stdout to trigger each dialog variant.
+// Results are printed to stdout.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gogpu/gogpu"
+	"github.com/gogpu/gpucontext"
+)
+
+func main() {
+	app := gogpu.NewApp(
+		gogpu.DefaultConfig().
+			WithTitle("File Dialog Demo").
+			WithSize(640, 400),
+	)
+
+	imageFilter := gogpu.FileTypeFilter{
+		Name:       "Images",
+		Extensions: []string{"*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp"},
+	}
+	textFilter := gogpu.FileTypeFilter{
+		Name:       "Text files",
+		Extensions: []string{"*.txt", "*.md"},
+	}
+
+	openOne := func() {
+		paths, err := app.ShowOpenFileDialog(gogpu.FileDialogOptions{
+			Title:   "Open File",
+			Filters: []gogpu.FileTypeFilter{imageFilter, textFilter},
+		})
+		if err != nil {
+			log.Println("open error:", err)
+			return
+		}
+		if len(paths) == 0 {
+			fmt.Println("open canceled")
+			return
+		}
+		fmt.Println("opened:", paths[0])
+	}
+
+	openMany := func() {
+		paths, err := app.ShowOpenFileDialog(gogpu.FileDialogOptions{
+			Title:    "Open Files",
+			Filters:  []gogpu.FileTypeFilter{imageFilter},
+			Multiple: true,
+		})
+		if err != nil {
+			log.Println("open-many error:", err)
+			return
+		}
+		if len(paths) == 0 {
+			fmt.Println("open-many canceled")
+			return
+		}
+		fmt.Printf("opened %d file(s):\n", len(paths))
+		for _, p := range paths {
+			fmt.Println(" ", p)
+		}
+	}
+
+	openDir := func() {
+		paths, err := app.ShowOpenFileDialog(gogpu.FileDialogOptions{
+			Title:     "Choose Directory",
+			Directory: true,
+		})
+		if err != nil {
+			log.Println("open-dir error:", err)
+			return
+		}
+		if len(paths) == 0 {
+			fmt.Println("open-dir canceled")
+			return
+		}
+		fmt.Println("directory:", paths[0])
+	}
+
+	saveFile := func() {
+		path, err := app.ShowSaveFileDialog(gogpu.FileDialogOptions{
+			Title:           "Save File",
+			Filters:         []gogpu.FileTypeFilter{textFilter},
+			DefaultFilename: "output.txt",
+		})
+		if err != nil {
+			log.Println("save error:", err)
+			return
+		}
+		if path == "" {
+			fmt.Println("save canceled")
+			return
+		}
+		fmt.Println("save path:", path)
+	}
+
+	fmt.Println("File Dialog Demo — keyboard shortcuts:")
+	fmt.Println("  1  Open File")
+	fmt.Println("  2  Open Files (multi-select)")
+	fmt.Println("  3  Open Directory")
+	fmt.Println("  4  Save File")
+	fmt.Println("  Q  Quit")
+
+	app.EventSource().OnKeyPress(func(key gpucontext.Key, _ gpucontext.Modifiers) {
+		switch key {
+		case gpucontext.Key1:
+			openOne()
+		case gpucontext.Key2:
+			openMany()
+		case gpucontext.Key3:
+			openDir()
+		case gpucontext.Key4:
+			saveFile()
+		case gpucontext.KeyQ:
+			app.Quit()
+		default:
+		}
+	})
+
+	app.OnUpdate(func(dt float64) {})
+
+	if err := app.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/platform/dialog_darwin.go
+++ b/internal/platform/dialog_darwin.go
@@ -1,0 +1,147 @@
+//go:build darwin
+
+package platform
+
+import (
+	"strings"
+	"unsafe"
+
+	"github.com/gogpu/gogpu/internal/platform/darwin"
+)
+
+// nsModalResponseOK is the return value of NSPanel.runModal on user confirmation.
+const nsModalResponseOK int64 = 1
+
+func showOpenFileDialog(opts FileDialogOptions) ([]string, error) {
+	panel := darwin.GetClass("NSOpenPanel").Send(darwin.RegisterSelector("openPanel"))
+	if panel.IsNil() {
+		return nil, nil
+	}
+
+	applyDialogCommon(panel, opts)
+	panel.SendBool(darwin.RegisterSelector("setCanChooseFiles:"), !opts.Directory)
+	panel.SendBool(darwin.RegisterSelector("setCanChooseDirectories:"), opts.Directory)
+	panel.SendBool(darwin.RegisterSelector("setAllowsMultipleSelection:"), opts.Multiple)
+
+	if panel.GetInt64(darwin.RegisterSelector("runModal")) != nsModalResponseOK {
+		return nil, nil
+	}
+
+	urls := panel.Send(darwin.RegisterSelector("URLs"))
+	if urls.IsNil() {
+		return nil, nil
+	}
+	count := urls.GetUint64(darwin.RegisterSelector("count"))
+	paths := make([]string, 0, int(count))
+	for i := uint64(0); i < count; i++ {
+		url := urls.SendUint(darwin.RegisterSelector("objectAtIndex:"), i)
+		if path := darwinNSStringToGo(url.Send(darwin.RegisterSelector("path"))); path != "" {
+			paths = append(paths, path)
+		}
+	}
+	return paths, nil
+}
+
+func showSaveFileDialog(opts FileDialogOptions) (string, error) {
+	panel := darwin.GetClass("NSSavePanel").Send(darwin.RegisterSelector("savePanel"))
+	if panel.IsNil() {
+		return "", nil
+	}
+
+	applyDialogCommon(panel, opts)
+
+	if opts.DefaultFilename != "" {
+		ns := darwin.NewNSString(opts.DefaultFilename)
+		if ns != nil {
+			defer ns.Release()
+			panel.SendPtr(darwin.RegisterSelector("setNameFieldStringValue:"), uintptr(ns.ID()))
+		}
+	}
+
+	if panel.GetInt64(darwin.RegisterSelector("runModal")) != nsModalResponseOK {
+		return "", nil
+	}
+
+	url := panel.Send(darwin.RegisterSelector("URL"))
+	if url.IsNil() {
+		return "", nil
+	}
+	return darwinNSStringToGo(url.Send(darwin.RegisterSelector("path"))), nil
+}
+
+// applyDialogCommon sets title, initial directory, and file type filters on a panel.
+func applyDialogCommon(panel darwin.ID, opts FileDialogOptions) {
+	if opts.Title != "" {
+		ns := darwin.NewNSString(opts.Title)
+		if ns != nil {
+			defer ns.Release()
+			panel.SendPtr(darwin.RegisterSelector("setTitle:"), uintptr(ns.ID()))
+		}
+	}
+
+	if opts.InitialDirectory != "" {
+		pathNS := darwin.NewNSString(opts.InitialDirectory)
+		if pathNS != nil {
+			defer pathNS.Release()
+			urlClass := darwin.ID(darwin.GetClass("NSURL"))
+			dirURL := urlClass.SendPtr(darwin.RegisterSelector("fileURLWithPath:"), uintptr(pathNS.ID()))
+			if !dirURL.IsNil() {
+				panel.SendPtr(darwin.RegisterSelector("setDirectoryURL:"), uintptr(dirURL))
+			}
+		}
+	}
+
+	if len(opts.Filters) > 0 && !opts.Directory {
+		if arr := darwinBuildExtArray(opts.Filters); !arr.IsNil() {
+			panel.SendPtr(darwin.RegisterSelector("setAllowedFileTypes:"), uintptr(arr))
+		}
+	}
+}
+
+// darwinBuildExtArray builds an NSMutableArray of extension NSStrings for setAllowedFileTypes:.
+// Extensions are stripped of "*." or "." prefixes; e.g. "*.png" → "png".
+func darwinBuildExtArray(filters []FileTypeFilter) darwin.ID {
+	arr := darwin.ID(darwin.GetClass("NSMutableArray")).Send(darwin.RegisterSelector("array"))
+	if arr.IsNil() {
+		return 0
+	}
+	added := 0
+	for _, f := range filters {
+		for _, e := range f.Extensions {
+			e = strings.TrimPrefix(e, "*")
+			e = strings.TrimPrefix(e, ".")
+			if e == "" {
+				continue
+			}
+			ns := darwin.NewNSString(e)
+			if ns == nil {
+				continue
+			}
+			arr.SendPtr(darwin.RegisterSelector("addObject:"), uintptr(ns.ID()))
+			ns.Release()
+			added++
+		}
+	}
+	if added == 0 {
+		return 0
+	}
+	return arr
+}
+
+// darwinNSStringToGo converts an ObjC NSString to a Go string.
+func darwinNSStringToGo(nsstr darwin.ID) string {
+	utf8Ptr := darwin.NSStringUTF8Ptr(nsstr)
+	if utf8Ptr == 0 {
+		return ""
+	}
+	length := darwin.NSStringLength(nsstr)
+	if length == 0 {
+		return ""
+	}
+	data := unsafe.Slice((*byte)(unsafe.Pointer(utf8Ptr)), length*4) //nolint:govet // ObjC UTF8String pointer, bounded by NSString length
+	end := 0
+	for end < len(data) && data[end] != 0 {
+		end++
+	}
+	return string(data[:end])
+}

--- a/internal/platform/dialog_darwin_test.go
+++ b/internal/platform/dialog_darwin_test.go
@@ -1,0 +1,118 @@
+//go:build darwin
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/gogpu/gogpu/internal/platform/darwin"
+)
+
+// TestDarwinNSStringToGo verifies conversion of ObjC NSString to Go string.
+func TestDarwinNSStringToGo(t *testing.T) {
+	t.Run("nil ID returns empty string", func(t *testing.T) {
+		if got := darwinNSStringToGo(0); got != "" {
+			t.Errorf("darwinNSStringToGo(0) = %q, want empty", got)
+		}
+	})
+
+	t.Run("ASCII round-trip", func(t *testing.T) {
+		ns := darwin.NewNSString("hello")
+		if ns == nil {
+			t.Fatal("NewNSString returned nil")
+		}
+		defer ns.Release()
+		if got := darwinNSStringToGo(ns.ID()); got != "hello" {
+			t.Errorf("darwinNSStringToGo = %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("Unicode round-trip", func(t *testing.T) {
+		const input = "こんにちは 🌏"
+		ns := darwin.NewNSString(input)
+		if ns == nil {
+			t.Fatal("NewNSString returned nil")
+		}
+		defer ns.Release()
+		if got := darwinNSStringToGo(ns.ID()); got != input {
+			t.Errorf("darwinNSStringToGo = %q, want %q", got, input)
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		ns := darwin.NewNSString("")
+		if ns == nil {
+			t.Fatal("NewNSString returned nil")
+		}
+		defer ns.Release()
+		if got := darwinNSStringToGo(ns.ID()); got != "" {
+			t.Errorf("darwinNSStringToGo(\"\") = %q, want empty", got)
+		}
+	})
+}
+
+// TestDarwinBuildExtArray verifies NSMutableArray construction from FileTypeFilter slices.
+func TestDarwinBuildExtArray(t *testing.T) {
+	t.Run("nil filters returns nil ID", func(t *testing.T) {
+		arr := darwinBuildExtArray(nil)
+		if !arr.IsNil() {
+			t.Error("expected nil ID for nil filters")
+		}
+	})
+
+	t.Run("empty filters returns nil ID", func(t *testing.T) {
+		arr := darwinBuildExtArray([]FileTypeFilter{})
+		if !arr.IsNil() {
+			t.Error("expected nil ID for empty filters")
+		}
+	})
+
+	t.Run("filters with no valid extensions returns nil ID", func(t *testing.T) {
+		arr := darwinBuildExtArray([]FileTypeFilter{
+			{Name: "Nothing", Extensions: []string{"", "*.", "."}},
+		})
+		if !arr.IsNil() {
+			t.Error("expected nil ID when all extensions are blank")
+		}
+	})
+
+	t.Run("extensions are stripped and dedotted", func(t *testing.T) {
+		filters := []FileTypeFilter{
+			{Name: "Images", Extensions: []string{"*.png", "jpg", ".gif"}},
+		}
+		arr := darwinBuildExtArray(filters)
+		if arr.IsNil() {
+			t.Fatal("expected non-nil NSArray")
+		}
+
+		count := arr.GetUint64(darwin.RegisterSelector("count"))
+		if count != 3 {
+			t.Fatalf("array count = %d, want 3", count)
+		}
+
+		want := []string{"png", "jpg", "gif"}
+		for i, w := range want {
+			elem := arr.SendUint(darwin.RegisterSelector("objectAtIndex:"), uint64(i))
+			got := darwinNSStringToGo(elem)
+			if got != w {
+				t.Errorf("element[%d] = %q, want %q", i, got, w)
+			}
+		}
+	})
+
+	t.Run("multiple filters are merged into one array", func(t *testing.T) {
+		filters := []FileTypeFilter{
+			{Name: "Images", Extensions: []string{"png", "jpg"}},
+			{Name: "Docs", Extensions: []string{"pdf", "md"}},
+		}
+		arr := darwinBuildExtArray(filters)
+		if arr.IsNil() {
+			t.Fatal("expected non-nil NSArray")
+		}
+
+		count := arr.GetUint64(darwin.RegisterSelector("count"))
+		if count != 4 {
+			t.Fatalf("array count = %d, want 4", count)
+		}
+	})
+}

--- a/internal/platform/dialog_linux.go
+++ b/internal/platform/dialog_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package platform
+
+import "fmt"
+
+func showOpenFileDialog(_ FileDialogOptions) ([]string, error) {
+	return nil, fmt.Errorf("file dialog: not yet implemented on Linux (xdg-portal support planned)")
+}
+
+func showSaveFileDialog(_ FileDialogOptions) (string, error) {
+	return "", fmt.Errorf("file dialog: not yet implemented on Linux (xdg-portal support planned)")
+}

--- a/internal/platform/dialog_windows.go
+++ b/internal/platform/dialog_windows.go
@@ -1,0 +1,304 @@
+//go:build windows
+
+package platform
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// COM constants
+const (
+	coinitApartmentThreaded uintptr = 0x2
+	clsctxInprocServer      uintptr = 0x1
+	comSOK                  uintptr = 0
+	comSFalse               uintptr = 1
+	hresultCancelled        uintptr = 0x800704C7
+
+	// IFileDialog option flags
+	fosFOS_PICKFOLDERS      uint32 = 0x00000020
+	fosFOS_ALLOWMULTISELECT uint32 = 0x00000200
+	fosFOS_FORCEFILESYSTEM  uint32 = 0x00000040
+
+	// IFileDialog vtable indices (IUnknown=0-2, IModalWindow=3, IFileDialog=4-26)
+	vtblDlgRelease      = 2
+	vtblDlgShow         = 3
+	vtblDlgSetFileTypes = 4
+	vtblDlgSetOptions   = 9
+	vtblDlgGetOptions   = 10
+	vtblDlgSetFolder    = 12
+	vtblDlgSetFileName  = 15
+	vtblDlgSetTitle     = 17
+	vtblDlgGetResult    = 20
+	// IFileOpenDialog additional (index 27)
+	vtblOpenDlgGetResults = 27
+	// IShellItemArray vtable indices (IUnknown=0-2, then array methods)
+	vtblSIAGetCount  = 7
+	vtblSIAGetItemAt = 8
+	// IShellItem vtable indices
+	vtblSIGetDisplayName = 5
+
+	// SIGDN_FILESYSPATH
+	sigdnFileSysPath uintptr = 0x80058000
+)
+
+var (
+	// CLSID_FileOpenDialog: {DC1C5A9C-E88A-4DDE-A5A1-60F82A20AEF7}
+	clsidFileOpenDialog = windows.GUID{
+		Data1: 0xDC1C5A9C, Data2: 0xE88A, Data3: 0x4DDE,
+		Data4: [8]byte{0xA5, 0xA1, 0x60, 0xF8, 0x2A, 0x20, 0xAE, 0xF7},
+	}
+	// CLSID_FileSaveDialog: {C0B4E2F3-BA21-4773-8DBA-335EC946EB8B}
+	clsidFileSaveDialog = windows.GUID{
+		Data1: 0xC0B4E2F3, Data2: 0xBA21, Data3: 0x4773,
+		Data4: [8]byte{0x8D, 0xBA, 0x33, 0x5E, 0xC9, 0x46, 0xEB, 0x8B},
+	}
+	// IID_IFileOpenDialog: {D57C7288-D4AD-4768-BE02-9D969532D960}
+	iidIFileOpenDialog = windows.GUID{
+		Data1: 0xD57C7288, Data2: 0xD4AD, Data3: 0x4768,
+		Data4: [8]byte{0xBE, 0x02, 0x9D, 0x96, 0x95, 0x32, 0xD9, 0x60},
+	}
+	// IID_IFileSaveDialog: {84BCCD23-5FDE-4CDB-AEA4-AF64B83D78AB}
+	iidIFileSaveDialog = windows.GUID{
+		Data1: 0x84BCCD23, Data2: 0x5FDE, Data3: 0x4CDB,
+		Data4: [8]byte{0xAE, 0xA4, 0xAF, 0x64, 0xB8, 0x3D, 0x78, 0xAB},
+	}
+	// IID_IShellItem: {43826D1E-E718-42EE-BC55-A1E261C37BFE}
+	iidIShellItem = windows.GUID{
+		Data1: 0x43826D1E, Data2: 0xE718, Data3: 0x42EE,
+		Data4: [8]byte{0xBC, 0x55, 0xA1, 0xE2, 0x61, 0xC3, 0x7B, 0xFE},
+	}
+
+	ole32                           = windows.NewLazyDLL("ole32.dll")
+	shell32                         = windows.NewLazyDLL("shell32.dll")
+	procCoInitializeEx              = ole32.NewProc("CoInitializeEx")
+	procCoUninitialize              = ole32.NewProc("CoUninitialize")
+	procCoCreateInstance            = ole32.NewProc("CoCreateInstance")
+	procCoTaskMemFree               = ole32.NewProc("CoTaskMemFree")
+	procSHCreateItemFromParsingName = shell32.NewProc("SHCreateItemFromParsingName")
+)
+
+// comdlgFilterSpec mirrors the Win32 COMDLG_FILTERSPEC struct.
+type comdlgFilterSpec struct {
+	pszName *uint16
+	pszSpec *uint16
+}
+
+func showOpenFileDialog(hwnd uintptr, opts FileDialogOptions) ([]string, error) {
+	hr, _, _ := procCoInitializeEx.Call(0, coinitApartmentThreaded)
+	if hr == comSOK || hr == comSFalse {
+		defer procCoUninitialize.Call()
+	}
+
+	var dialog uintptr
+	hr, _, _ = procCoCreateInstance.Call(
+		uintptr(unsafe.Pointer(&clsidFileOpenDialog)), //nolint:govet // GUID passed by address to COM
+		0,
+		clsctxInprocServer,
+		uintptr(unsafe.Pointer(&iidIFileOpenDialog)), //nolint:govet // IID passed by address to COM
+		uintptr(unsafe.Pointer(&dialog)),
+	)
+	if hr != comSOK {
+		return nil, fmt.Errorf("file dialog: CoCreateInstance(FileOpenDialog) failed (0x%08X)", uint32(hr))
+	}
+	defer comRelease(dialog)
+
+	setDlgCommonOptions(dialog, hwnd, opts)
+
+	hr, _, _ = syscall.SyscallN(comVtbl(dialog)[vtblDlgShow], dialog, hwnd)
+	if hr == hresultCancelled {
+		return nil, nil
+	}
+	if hr != comSOK {
+		return nil, fmt.Errorf("file dialog: Show failed (0x%08X)", uint32(hr))
+	}
+
+	var results uintptr
+	hr, _, _ = syscall.SyscallN(comVtbl(dialog)[vtblOpenDlgGetResults], dialog, uintptr(unsafe.Pointer(&results)))
+	if hr != comSOK {
+		return nil, fmt.Errorf("file dialog: GetResults failed (0x%08X)", uint32(hr))
+	}
+	defer comRelease(results)
+
+	var count uint32
+	syscall.SyscallN(comVtbl(results)[vtblSIAGetCount], results, uintptr(unsafe.Pointer(&count)))
+
+	paths := make([]string, 0, int(count))
+	for i := uint32(0); i < count; i++ {
+		var item uintptr
+		hr, _, _ = syscall.SyscallN(comVtbl(results)[vtblSIAGetItemAt], results, uintptr(i), uintptr(unsafe.Pointer(&item)))
+		if hr != comSOK {
+			continue
+		}
+		if p := shellItemPath(item); p != "" {
+			paths = append(paths, p)
+		}
+		comRelease(item)
+	}
+	return paths, nil
+}
+
+func showSaveFileDialog(hwnd uintptr, opts FileDialogOptions) (string, error) {
+	hr, _, _ := procCoInitializeEx.Call(0, coinitApartmentThreaded)
+	if hr == comSOK || hr == comSFalse {
+		defer procCoUninitialize.Call()
+	}
+
+	var dialog uintptr
+	hr, _, _ = procCoCreateInstance.Call(
+		uintptr(unsafe.Pointer(&clsidFileSaveDialog)), //nolint:govet // GUID passed by address to COM
+		0,
+		clsctxInprocServer,
+		uintptr(unsafe.Pointer(&iidIFileSaveDialog)), //nolint:govet // IID passed by address to COM
+		uintptr(unsafe.Pointer(&dialog)),
+	)
+	if hr != comSOK {
+		return "", fmt.Errorf("file dialog: CoCreateInstance(FileSaveDialog) failed (0x%08X)", uint32(hr))
+	}
+	defer comRelease(dialog)
+
+	setDlgCommonOptions(dialog, hwnd, opts)
+
+	if opts.DefaultFilename != "" {
+		nameW, err := windows.UTF16PtrFromString(opts.DefaultFilename)
+		if err == nil {
+			syscall.SyscallN(comVtbl(dialog)[vtblDlgSetFileName], dialog, uintptr(unsafe.Pointer(nameW)))
+		}
+	}
+
+	hr, _, _ = syscall.SyscallN(comVtbl(dialog)[vtblDlgShow], dialog, hwnd)
+	if hr == hresultCancelled {
+		return "", nil
+	}
+	if hr != comSOK {
+		return "", fmt.Errorf("file dialog: Show failed (0x%08X)", uint32(hr))
+	}
+
+	var item uintptr
+	hr, _, _ = syscall.SyscallN(comVtbl(dialog)[vtblDlgGetResult], dialog, uintptr(unsafe.Pointer(&item)))
+	if hr != comSOK {
+		return "", fmt.Errorf("file dialog: GetResult failed (0x%08X)", uint32(hr))
+	}
+	defer comRelease(item)
+
+	return shellItemPath(item), nil
+}
+
+// setDlgCommonOptions applies title, folder, option flags, and file type filters.
+func setDlgCommonOptions(dialog, hwnd uintptr, opts FileDialogOptions) {
+	_ = hwnd // reserved for future per-window modality
+
+	if opts.Title != "" {
+		titleW, err := windows.UTF16PtrFromString(opts.Title)
+		if err == nil {
+			syscall.SyscallN(comVtbl(dialog)[vtblDlgSetTitle], dialog, uintptr(unsafe.Pointer(titleW)))
+		}
+	}
+
+	var flags uint32
+	syscall.SyscallN(comVtbl(dialog)[vtblDlgGetOptions], dialog, uintptr(unsafe.Pointer(&flags)))
+	flags |= fosFOS_FORCEFILESYSTEM
+	if opts.Directory {
+		flags |= fosFOS_PICKFOLDERS
+	}
+	if opts.Multiple {
+		flags |= fosFOS_ALLOWMULTISELECT
+	}
+	syscall.SyscallN(comVtbl(dialog)[vtblDlgSetOptions], dialog, uintptr(flags))
+
+	if opts.InitialDirectory != "" {
+		pathW, err := windows.UTF16PtrFromString(opts.InitialDirectory)
+		if err == nil {
+			var si uintptr
+			hr, _, _ := procSHCreateItemFromParsingName.Call(
+				uintptr(unsafe.Pointer(pathW)),
+				0,
+				uintptr(unsafe.Pointer(&iidIShellItem)), //nolint:govet // IID passed by address to COM
+				uintptr(unsafe.Pointer(&si)),
+			)
+			if hr == comSOK && si != 0 {
+				syscall.SyscallN(comVtbl(dialog)[vtblDlgSetFolder], dialog, si)
+				comRelease(si)
+			}
+		}
+	}
+
+	if len(opts.Filters) > 0 {
+		setDlgFileTypes(dialog, opts.Filters)
+	}
+}
+
+// setDlgFileTypes sets the COMDLG_FILTERSPEC array on the dialog.
+func setDlgFileTypes(dialog uintptr, filters []FileTypeFilter) {
+	specs := make([]comdlgFilterSpec, 0, len(filters))
+	// Keep UTF-16 backing slices alive for the duration of the vtable call.
+	var backing [][]uint16
+
+	for _, f := range filters {
+		nameW, err := windows.UTF16FromString(f.Name)
+		if err != nil {
+			continue
+		}
+		specW, err := windows.UTF16FromString(dlgBuildFilterSpec(f.Extensions))
+		if err != nil {
+			continue
+		}
+		backing = append(backing, nameW, specW)
+		specs = append(specs, comdlgFilterSpec{pszName: &nameW[0], pszSpec: &specW[0]})
+	}
+	if len(specs) == 0 {
+		return
+	}
+	syscall.SyscallN(comVtbl(dialog)[vtblDlgSetFileTypes],
+		dialog,
+		uintptr(len(specs)),
+		uintptr(unsafe.Pointer(&specs[0])),
+	)
+	_ = backing // prevent GC before vtable call completes
+}
+
+// dlgBuildFilterSpec converts extension slice to a Windows filter spec like "*.png;*.jpg".
+func dlgBuildFilterSpec(exts []string) string {
+	parts := make([]string, 0, len(exts))
+	for _, e := range exts {
+		e = strings.TrimPrefix(e, "*")
+		e = strings.TrimPrefix(e, ".")
+		if e != "" {
+			parts = append(parts, "*."+e)
+		}
+	}
+	if len(parts) == 0 {
+		return "*.*"
+	}
+	return strings.Join(parts, ";")
+}
+
+// comVtbl returns the vtable of a COM interface pointer.
+func comVtbl(obj uintptr) *[64]uintptr {
+	return (*[64]uintptr)(unsafe.Pointer(*(*uintptr)(unsafe.Pointer(obj)))) //nolint:govet // COM vtable dereference
+}
+
+// comRelease calls IUnknown::Release on a COM interface pointer.
+func comRelease(obj uintptr) {
+	if obj != 0 {
+		syscall.SyscallN(comVtbl(obj)[vtblDlgRelease], obj)
+	}
+}
+
+// shellItemPath extracts the filesystem path from an IShellItem via GetDisplayName.
+func shellItemPath(item uintptr) string {
+	if item == 0 {
+		return ""
+	}
+	var pszPath uintptr
+	hr, _, _ := syscall.SyscallN(comVtbl(item)[vtblSIGetDisplayName], item, sigdnFileSysPath, uintptr(unsafe.Pointer(&pszPath)))
+	if hr != comSOK || pszPath == 0 {
+		return ""
+	}
+	defer procCoTaskMemFree.Call(pszPath)
+	return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(pszPath))) //nolint:govet // CoTaskMem pointer from IShellItem
+}

--- a/internal/platform/dialog_windows_test.go
+++ b/internal/platform/dialog_windows_test.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package platform
+
+import "testing"
+
+func TestDlgBuildFilterSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		exts []string
+		want string
+	}{
+		{
+			name: "already glob-prefixed",
+			exts: []string{"*.png", "*.jpg"},
+			want: "*.png;*.jpg",
+		},
+		{
+			name: "bare extensions",
+			exts: []string{"png", "jpg"},
+			want: "*.png;*.jpg",
+		},
+		{
+			name: "dot-prefixed",
+			exts: []string{".png", ".gif"},
+			want: "*.png;*.gif",
+		},
+		{
+			name: "mixed formats",
+			exts: []string{"*.png", "jpg", ".gif"},
+			want: "*.png;*.jpg;*.gif",
+		},
+		{
+			name: "single extension",
+			exts: []string{"pdf"},
+			want: "*.pdf",
+		},
+		{
+			name: "nil slice falls back to wildcard",
+			exts: nil,
+			want: "*.*",
+		},
+		{
+			name: "empty slice falls back to wildcard",
+			exts: []string{},
+			want: "*.*",
+		},
+		{
+			name: "blank entries are skipped",
+			exts: []string{"", "*.", "."},
+			want: "*.*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dlgBuildFilterSpec(tt.exts)
+			if got != tt.want {
+				t.Errorf("dlgBuildFilterSpec(%v) = %q, want %q", tt.exts, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -97,6 +97,22 @@ type PixelBlitter interface {
 	BlitPixels(pixels []byte, width, height int) error
 }
 
+// FileDialogOptions configures a native file open or save dialog.
+type FileDialogOptions struct {
+	Title            string
+	Filters          []FileTypeFilter
+	Directory        bool   // pick a directory instead of a file
+	Multiple         bool   // allow multi-selection (open only)
+	InitialDirectory string // starting directory (optional)
+	DefaultFilename  string // suggested filename for save dialog (optional)
+}
+
+// FileTypeFilter restricts visible files in the dialog.
+type FileTypeFilter struct {
+	Name       string   // e.g. "Images"
+	Extensions []string // e.g. ["*.png", "*.jpg"] or ["png", "jpg"]
+}
+
 // PlatformManager handles process-level platform operations.
 // One per application. Manages window lifecycle and event loop.
 type PlatformManager interface {
@@ -139,6 +155,14 @@ type PlatformManager interface {
 
 	// SetAppName sets the application name (displayed in menus).
 	SetAppName(name string)
+
+	// ShowOpenFileDialog opens a native file picker dialog.
+	// Returns nil, nil if the user cancels.
+	ShowOpenFileDialog(opts FileDialogOptions) ([]string, error)
+
+	// ShowSaveFileDialog opens a native file save dialog.
+	// Returns "", nil if the user cancels.
+	ShowSaveFileDialog(opts FileDialogOptions) (string, error)
 
 	// Destroy releases all platform resources.
 	Destroy()

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -1561,3 +1561,11 @@ func detectModifierKeyChange(keyCode uint16, flags darwin.NSEventModifierFlags) 
 	pressed := (flags & flagMask) != 0
 	return key, pressed
 }
+
+func (p *darwinPlatform) ShowOpenFileDialog(opts FileDialogOptions) ([]string, error) {
+	return showOpenFileDialog(opts)
+}
+
+func (p *darwinPlatform) ShowSaveFileDialog(opts FileDialogOptions) (string, error) {
+	return showSaveFileDialog(opts)
+}

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -2541,3 +2541,19 @@ func (p *waylandPlatform) CloseWindow() {
 }
 
 func (p *waylandPlatform) SetAppName(name string) {}
+
+func (p *x11Platform) ShowOpenFileDialog(opts FileDialogOptions) ([]string, error) {
+	return showOpenFileDialog(opts)
+}
+
+func (p *x11Platform) ShowSaveFileDialog(opts FileDialogOptions) (string, error) {
+	return showSaveFileDialog(opts)
+}
+
+func (p *waylandPlatform) ShowOpenFileDialog(opts FileDialogOptions) ([]string, error) {
+	return showOpenFileDialog(opts)
+}
+
+func (p *waylandPlatform) ShowSaveFileDialog(opts FileDialogOptions) (string, error) {
+	return showSaveFileDialog(opts)
+}

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -2785,3 +2785,19 @@ func (w *win32Window) BlitPixels(pixels []byte, width, height int) error {
 
 	return nil
 }
+
+func (p *windowsPlatform) ShowOpenFileDialog(opts FileDialogOptions) ([]string, error) {
+	hwnd := uintptr(0)
+	if p.primary != nil {
+		hwnd = uintptr(p.primary.hwnd)
+	}
+	return showOpenFileDialog(hwnd, opts)
+}
+
+func (p *windowsPlatform) ShowSaveFileDialog(opts FileDialogOptions) (string, error) {
+	hwnd := uintptr(0)
+	if p.primary != nil {
+		hwnd = uintptr(p.primary.hwnd)
+	}
+	return showSaveFileDialog(hwnd, opts)
+}

--- a/menu_test.go
+++ b/menu_test.go
@@ -49,6 +49,12 @@ func (m *mockMenuManager) HighContrast() bool                        { return fa
 func (m *mockMenuManager) FontScale() float32                        { return 1.0 }
 func (m *mockMenuManager) SubpixelLayout() gpucontext.SubpixelLayout { return 0 }
 func (m *mockMenuManager) SetAppName(string)                         {}
+func (m *mockMenuManager) ShowOpenFileDialog(platform.FileDialogOptions) ([]string, error) {
+	return nil, nil
+}
+func (m *mockMenuManager) ShowSaveFileDialog(platform.FileDialogOptions) (string, error) {
+	return "", nil
+}
 
 // TestNewMenu checks that NewMenu is not nil and that the menu is empty.
 func TestNewMenu(t *testing.T) {

--- a/platform_provider_test.go
+++ b/platform_provider_test.go
@@ -75,6 +75,12 @@ type mockManager struct {
 	highContrast   bool
 	fontScale      float32
 	subpixelLayout gpucontext.SubpixelLayout
+
+	// dialog stubs — set these to control what ShowOpen/SaveFileDialog return
+	openDialogPaths []string
+	saveDialogPath  string
+	// last opts received — inspected in delegation tests
+	lastDialogOpts platform.FileDialogOptions
 }
 
 func (m *mockManager) Init() error { return nil }
@@ -92,8 +98,16 @@ func (m *mockManager) HighContrast() bool                        { return m.high
 func (m *mockManager) FontScale() float32                        { return m.fontScale }
 func (m *mockManager) SubpixelLayout() gpucontext.SubpixelLayout { return m.subpixelLayout }
 func (m *mockManager) SetAppName(name string)                    {}
-func (m *mockManager) Destroy()                                  {}
-func (m *mockWindow) SetOnClose(fn func() bool)                  { m.closeFn = fn }
+func (m *mockManager) ShowOpenFileDialog(opts platform.FileDialogOptions) ([]string, error) {
+	m.lastDialogOpts = opts
+	return m.openDialogPaths, nil
+}
+func (m *mockManager) ShowSaveFileDialog(opts platform.FileDialogOptions) (string, error) {
+	m.lastDialogOpts = opts
+	return m.saveDialogPath, nil
+}
+func (m *mockManager) Destroy()                 {}
+func (m *mockWindow) SetOnClose(fn func() bool) { m.closeFn = fn }
 
 // TestWindowProviderInterface verifies App implements gpucontext.WindowProvider.
 func TestWindowProviderInterface(t *testing.T) {
@@ -315,6 +329,138 @@ func TestPlatformProviderDelegation(t *testing.T) {
 			t.Errorf("SubpixelLayout() = %v, want SubpixelBGR", sl)
 		}
 	})
+}
+
+// TestFileDialogNilPlatform verifies ShowOpen/SaveFileDialog are safe when manager is nil.
+func TestFileDialogNilPlatform(t *testing.T) {
+	app := NewApp(DefaultConfig())
+
+	t.Run("ShowOpenFileDialog", func(t *testing.T) {
+		paths, err := app.ShowOpenFileDialog(FileDialogOptions{Title: "Open"})
+		if err != nil {
+			t.Errorf("ShowOpenFileDialog() error = %v, want nil", err)
+		}
+		if paths != nil {
+			t.Errorf("ShowOpenFileDialog() = %v, want nil", paths)
+		}
+	})
+
+	t.Run("ShowSaveFileDialog", func(t *testing.T) {
+		path, err := app.ShowSaveFileDialog(FileDialogOptions{Title: "Save"})
+		if err != nil {
+			t.Errorf("ShowSaveFileDialog() error = %v, want nil", err)
+		}
+		if path != "" {
+			t.Errorf("ShowSaveFileDialog() = %q, want empty", path)
+		}
+	})
+}
+
+// TestFileDialogDelegation verifies App forwards options and returns results from the manager.
+func TestFileDialogDelegation(t *testing.T) {
+	mgr := &mockManager{
+		openDialogPaths: []string{"/tmp/a.png", "/tmp/b.png"},
+		saveDialogPath:  "/tmp/out.txt",
+	}
+	app := &App{manager: mgr}
+
+	openOpts := FileDialogOptions{
+		Title:    "Pick images",
+		Multiple: true,
+		Filters: []FileTypeFilter{
+			{Name: "Images", Extensions: []string{"*.png", "*.jpg"}},
+		},
+	}
+
+	t.Run("ShowOpenFileDialog delegates opts and returns paths", func(t *testing.T) {
+		paths, err := app.ShowOpenFileDialog(openOpts)
+		if err != nil {
+			t.Fatalf("ShowOpenFileDialog() error = %v", err)
+		}
+		if len(paths) != 2 || paths[0] != "/tmp/a.png" || paths[1] != "/tmp/b.png" {
+			t.Errorf("ShowOpenFileDialog() = %v, want [/tmp/a.png /tmp/b.png]", paths)
+		}
+		if mgr.lastDialogOpts.Title != "Pick images" {
+			t.Errorf("delegated Title = %q, want %q", mgr.lastDialogOpts.Title, "Pick images")
+		}
+		if !mgr.lastDialogOpts.Multiple {
+			t.Error("delegated Multiple should be true")
+		}
+		if len(mgr.lastDialogOpts.Filters) != 1 {
+			t.Errorf("delegated Filters len = %d, want 1", len(mgr.lastDialogOpts.Filters))
+		}
+	})
+
+	saveOpts := FileDialogOptions{
+		Title:           "Save log",
+		DefaultFilename: "out.txt",
+	}
+
+	t.Run("ShowSaveFileDialog delegates opts and returns path", func(t *testing.T) {
+		path, err := app.ShowSaveFileDialog(saveOpts)
+		if err != nil {
+			t.Fatalf("ShowSaveFileDialog() error = %v", err)
+		}
+		if path != "/tmp/out.txt" {
+			t.Errorf("ShowSaveFileDialog() = %q, want %q", path, "/tmp/out.txt")
+		}
+		if mgr.lastDialogOpts.Title != "Save log" {
+			t.Errorf("delegated Title = %q, want %q", mgr.lastDialogOpts.Title, "Save log")
+		}
+		if mgr.lastDialogOpts.DefaultFilename != "out.txt" {
+			t.Errorf("delegated DefaultFilename = %q, want %q", mgr.lastDialogOpts.DefaultFilename, "out.txt")
+		}
+	})
+
+	t.Run("ShowOpenFileDialog cancel returns nil nil", func(t *testing.T) {
+		mgr.openDialogPaths = nil
+		paths, err := app.ShowOpenFileDialog(FileDialogOptions{})
+		if err != nil || paths != nil {
+			t.Errorf("ShowOpenFileDialog() = (%v, %v), want (nil, nil)", paths, err)
+		}
+	})
+
+	t.Run("ShowSaveFileDialog cancel returns empty nil", func(t *testing.T) {
+		mgr.saveDialogPath = ""
+		path, err := app.ShowSaveFileDialog(FileDialogOptions{})
+		if err != nil || path != "" {
+			t.Errorf("ShowSaveFileDialog() = (%q, %v), want (\"\", nil)", path, err)
+		}
+	})
+}
+
+// TestFileDialogOptions verifies struct fields round-trip correctly.
+func TestFileDialogOptions(t *testing.T) {
+	opts := FileDialogOptions{
+		Title:            "My Dialog",
+		Directory:        true,
+		Multiple:         true,
+		InitialDirectory: "/home/user",
+		DefaultFilename:  "report.pdf",
+		Filters: []FileTypeFilter{
+			{Name: "PDF", Extensions: []string{"*.pdf"}},
+			{Name: "All", Extensions: []string{"*"}},
+		},
+	}
+
+	if opts.Title != "My Dialog" {
+		t.Errorf("Title = %q", opts.Title)
+	}
+	if !opts.Directory {
+		t.Error("Directory should be true")
+	}
+	if !opts.Multiple {
+		t.Error("Multiple should be true")
+	}
+	if opts.InitialDirectory != "/home/user" {
+		t.Errorf("InitialDirectory = %q", opts.InitialDirectory)
+	}
+	if opts.DefaultFilename != "report.pdf" {
+		t.Errorf("DefaultFilename = %q", opts.DefaultFilename)
+	}
+	if len(opts.Filters) != 2 || opts.Filters[0].Name != "PDF" {
+		t.Errorf("Filters = %v", opts.Filters)
+	}
 }
 
 // TestPlatformProviderFalseValues verifies delegation when platform returns false/default values.


### PR DESCRIPTION
Summary
---
- Added internal/platform/dialog_darwin.go
- Added internal/platform/dialog_windows.go
- Added internal/platform/dialog_linux.go (stubs)
- Added interfaces to internal/platform/platform_darwin.go, internal/platform/platform_linux.go, internal/platform/platform_windows.go
- Added api in app.go
- Added examples/file_dialog/main.go

Test plan
---
- [x] go build ./... passes
- [x] go test ./...  passes
- [x] golangci-lint run — 0 issues
- [x] running the example on Mac OS (ARM)
- [x] running the example on Windows 11 (ARM)

Demo
---
MacOS
---
https://github.com/user-attachments/assets/db049d0d-8cb0-4515-9db3-bd0837b251c7

Windows
---
https://github.com/user-attachments/assets/6dad9f91-9a63-4116-8c9d-abfac4052be7


