### PR TITLE
feat/adr-36 : Fix on after rewiew

### DIFF
--- a/internal/platform/dialog_darwin.go
+++ b/internal/platform/dialog_darwin.go
@@ -91,20 +91,28 @@ func applyDialogCommon(panel darwin.ID, opts FileDialogOptions) {
 		}
 	}
 
+	// Filters are skipped in directory mode: the panel restricts to folders, not file types.
 	if len(opts.Filters) > 0 && !opts.Directory {
-		if arr := darwinBuildExtArray(opts.Filters); !arr.IsNil() {
-			panel.SendPtr(darwin.RegisterSelector("setAllowedFileTypes:"), uintptr(arr))
+		if arr := darwinBuildContentTypesArray(opts.Filters); !arr.IsNil() {
+			panel.SendPtr(darwin.RegisterSelector("setAllowedContentTypes:"), uintptr(arr))
 		}
 	}
 }
 
-// darwinBuildExtArray builds an NSMutableArray of extension NSStrings for setAllowedFileTypes:.
-// Extensions are stripped of "*." or "." prefixes; e.g. "*.png" → "png".
-func darwinBuildExtArray(filters []FileTypeFilter) darwin.ID {
+// darwinBuildContentTypesArray builds an NSMutableArray<UTType> for setAllowedContentTypes:.
+// UTType is guaranteed available on the project's minimum macOS (12, go.mod: go 1.25).
+func darwinBuildContentTypesArray(filters []FileTypeFilter) darwin.ID {
+	utTypeClass := darwin.GetClass("UTType")
+	if utTypeClass == 0 {
+		return 0
+	}
+
 	arr := darwin.ID(darwin.GetClass("NSMutableArray")).Send(darwin.RegisterSelector("array"))
 	if arr.IsNil() {
 		return 0
 	}
+
+	sel := darwin.RegisterSelector("typeWithFilenameExtension:")
 	added := 0
 	for _, f := range filters {
 		for _, e := range f.Extensions {
@@ -117,9 +125,12 @@ func darwinBuildExtArray(filters []FileTypeFilter) darwin.ID {
 			if ns == nil {
 				continue
 			}
-			arr.SendPtr(darwin.RegisterSelector("addObject:"), uintptr(ns.ID()))
+			utType := darwin.ID(utTypeClass).SendPtr(sel, uintptr(ns.ID()))
 			ns.Release()
-			added++
+			if !utType.IsNil() {
+				arr.SendPtr(darwin.RegisterSelector("addObject:"), uintptr(utType))
+				added++
+			}
 		}
 	}
 	if added == 0 {

--- a/internal/platform/dialog_darwin_test.go
+++ b/internal/platform/dialog_darwin_test.go
@@ -51,68 +51,56 @@ func TestDarwinNSStringToGo(t *testing.T) {
 	})
 }
 
-// TestDarwinBuildExtArray verifies NSMutableArray construction from FileTypeFilter slices.
-func TestDarwinBuildExtArray(t *testing.T) {
+// TestDarwinBuildContentTypesArray verifies NSArray<UTType> construction.
+// UTType is guaranteed available on the project's minimum macOS (12, go.mod: go 1.25).
+func TestDarwinBuildContentTypesArray(t *testing.T) {
 	t.Run("nil filters returns nil ID", func(t *testing.T) {
-		arr := darwinBuildExtArray(nil)
-		if !arr.IsNil() {
-			t.Error("expected nil ID for nil filters")
+		if arr := darwinBuildContentTypesArray(nil); !arr.IsNil() {
+			t.Error("expected nil array for nil filters")
 		}
 	})
 
 	t.Run("empty filters returns nil ID", func(t *testing.T) {
-		arr := darwinBuildExtArray([]FileTypeFilter{})
-		if !arr.IsNil() {
-			t.Error("expected nil ID for empty filters")
+		if arr := darwinBuildContentTypesArray([]FileTypeFilter{}); !arr.IsNil() {
+			t.Error("expected nil array for empty filters")
 		}
 	})
 
 	t.Run("filters with no valid extensions returns nil ID", func(t *testing.T) {
-		arr := darwinBuildExtArray([]FileTypeFilter{
+		arr := darwinBuildContentTypesArray([]FileTypeFilter{
 			{Name: "Nothing", Extensions: []string{"", "*.", "."}},
 		})
 		if !arr.IsNil() {
-			t.Error("expected nil ID when all extensions are blank")
+			t.Error("expected nil array when all extensions are blank")
 		}
 	})
 
-	t.Run("extensions are stripped and dedotted", func(t *testing.T) {
+	t.Run("known extensions produce non-nil UTType array", func(t *testing.T) {
 		filters := []FileTypeFilter{
-			{Name: "Images", Extensions: []string{"*.png", "jpg", ".gif"}},
+			{Name: "Images", Extensions: []string{"*.png", "jpg"}},
 		}
-		arr := darwinBuildExtArray(filters)
+		arr := darwinBuildContentTypesArray(filters)
 		if arr.IsNil() {
-			t.Fatal("expected non-nil NSArray")
+			t.Fatal("expected non-nil NSArray for known extensions")
 		}
-
 		count := arr.GetUint64(darwin.RegisterSelector("count"))
-		if count != 3 {
-			t.Fatalf("array count = %d, want 3", count)
-		}
-
-		want := []string{"png", "jpg", "gif"}
-		for i, w := range want {
-			elem := arr.SendUint(darwin.RegisterSelector("objectAtIndex:"), uint64(i))
-			got := darwinNSStringToGo(elem)
-			if got != w {
-				t.Errorf("element[%d] = %q, want %q", i, got, w)
-			}
+		if count == 0 {
+			t.Error("expected at least one UTType in array")
 		}
 	})
 
-	t.Run("multiple filters are merged into one array", func(t *testing.T) {
+	t.Run("multiple filters merged into one array", func(t *testing.T) {
 		filters := []FileTypeFilter{
 			{Name: "Images", Extensions: []string{"png", "jpg"}},
-			{Name: "Docs", Extensions: []string{"pdf", "md"}},
+			{Name: "Docs", Extensions: []string{"pdf"}},
 		}
-		arr := darwinBuildExtArray(filters)
+		arr := darwinBuildContentTypesArray(filters)
 		if arr.IsNil() {
 			t.Fatal("expected non-nil NSArray")
 		}
-
 		count := arr.GetUint64(darwin.RegisterSelector("count"))
-		if count != 4 {
-			t.Fatalf("array count = %d, want 4", count)
+		if count == 0 {
+			t.Error("expected UTType entries for known extensions")
 		}
 	})
 }

--- a/internal/platform/dialog_windows.go
+++ b/internal/platform/dialog_windows.go
@@ -4,6 +4,7 @@ package platform
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -20,9 +21,11 @@ const (
 	hresultCancelled        uintptr = 0x800704C7
 
 	// IFileDialog option flags
-	fosFOS_PICKFOLDERS      uint32 = 0x00000020
-	fosFOS_ALLOWMULTISELECT uint32 = 0x00000200
-	fosFOS_FORCEFILESYSTEM  uint32 = 0x00000040
+	fosPickFolders      uint32 = 0x00000020
+	fosAllowMultiselect uint32 = 0x00000200
+	fosForceFilesystem  uint32 = 0x00000040
+
+	defaultFilterPattern = "*.*"
 
 	// IFileDialog vtable indices (IUnknown=0-2, IModalWindow=3, IFileDialog=4-26)
 	vtblDlgRelease      = 2
@@ -96,10 +99,10 @@ func showOpenFileDialog(hwnd uintptr, opts FileDialogOptions) ([]string, error) 
 
 	var dialog uintptr
 	hr, _, _ = procCoCreateInstance.Call(
-		uintptr(unsafe.Pointer(&clsidFileOpenDialog)), //nolint:govet // GUID passed by address to COM
+		uintptr(unsafe.Pointer(&clsidFileOpenDialog)),
 		0,
 		clsctxInprocServer,
-		uintptr(unsafe.Pointer(&iidIFileOpenDialog)), //nolint:govet // IID passed by address to COM
+		uintptr(unsafe.Pointer(&iidIFileOpenDialog)),
 		uintptr(unsafe.Pointer(&dialog)),
 	)
 	if hr != comSOK {
@@ -107,7 +110,7 @@ func showOpenFileDialog(hwnd uintptr, opts FileDialogOptions) ([]string, error) 
 	}
 	defer comRelease(dialog)
 
-	setDlgCommonOptions(dialog, hwnd, opts)
+	setDlgCommonOptions(dialog, hwnd, opts, true)
 
 	hr, _, _ = syscall.SyscallN(comVtbl(dialog)[vtblDlgShow], dialog, hwnd)
 	if hr == hresultCancelled {
@@ -125,7 +128,10 @@ func showOpenFileDialog(hwnd uintptr, opts FileDialogOptions) ([]string, error) 
 	defer comRelease(results)
 
 	var count uint32
-	syscall.SyscallN(comVtbl(results)[vtblSIAGetCount], results, uintptr(unsafe.Pointer(&count)))
+	hr, _, _ = syscall.SyscallN(comVtbl(results)[vtblSIAGetCount], results, uintptr(unsafe.Pointer(&count)))
+	if hr != comSOK {
+		return nil, fmt.Errorf("file dialog: GetCount failed (0x%08X)", uint32(hr))
+	}
 
 	paths := make([]string, 0, int(count))
 	for i := uint32(0); i < count; i++ {
@@ -150,10 +156,10 @@ func showSaveFileDialog(hwnd uintptr, opts FileDialogOptions) (string, error) {
 
 	var dialog uintptr
 	hr, _, _ = procCoCreateInstance.Call(
-		uintptr(unsafe.Pointer(&clsidFileSaveDialog)), //nolint:govet // GUID passed by address to COM
+		uintptr(unsafe.Pointer(&clsidFileSaveDialog)),
 		0,
 		clsctxInprocServer,
-		uintptr(unsafe.Pointer(&iidIFileSaveDialog)), //nolint:govet // IID passed by address to COM
+		uintptr(unsafe.Pointer(&iidIFileSaveDialog)),
 		uintptr(unsafe.Pointer(&dialog)),
 	)
 	if hr != comSOK {
@@ -161,7 +167,7 @@ func showSaveFileDialog(hwnd uintptr, opts FileDialogOptions) (string, error) {
 	}
 	defer comRelease(dialog)
 
-	setDlgCommonOptions(dialog, hwnd, opts)
+	setDlgCommonOptions(dialog, hwnd, opts, false)
 
 	if opts.DefaultFilename != "" {
 		nameW, err := windows.UTF16PtrFromString(opts.DefaultFilename)
@@ -189,7 +195,8 @@ func showSaveFileDialog(hwnd uintptr, opts FileDialogOptions) (string, error) {
 }
 
 // setDlgCommonOptions applies title, folder, option flags, and file type filters.
-func setDlgCommonOptions(dialog, hwnd uintptr, opts FileDialogOptions) {
+// isOpen must be true for IFileOpenDialog (Multiple selection is open-only).
+func setDlgCommonOptions(dialog, hwnd uintptr, opts FileDialogOptions, isOpen bool) {
 	_ = hwnd // reserved for future per-window modality
 
 	if opts.Title != "" {
@@ -201,12 +208,12 @@ func setDlgCommonOptions(dialog, hwnd uintptr, opts FileDialogOptions) {
 
 	var flags uint32
 	syscall.SyscallN(comVtbl(dialog)[vtblDlgGetOptions], dialog, uintptr(unsafe.Pointer(&flags)))
-	flags |= fosFOS_FORCEFILESYSTEM
+	flags |= fosForceFilesystem
 	if opts.Directory {
-		flags |= fosFOS_PICKFOLDERS
+		flags |= fosPickFolders
 	}
-	if opts.Multiple {
-		flags |= fosFOS_ALLOWMULTISELECT
+	if isOpen && opts.Multiple {
+		flags |= fosAllowMultiselect
 	}
 	syscall.SyscallN(comVtbl(dialog)[vtblDlgSetOptions], dialog, uintptr(flags))
 
@@ -217,7 +224,7 @@ func setDlgCommonOptions(dialog, hwnd uintptr, opts FileDialogOptions) {
 			hr, _, _ := procSHCreateItemFromParsingName.Call(
 				uintptr(unsafe.Pointer(pathW)),
 				0,
-				uintptr(unsafe.Pointer(&iidIShellItem)), //nolint:govet // IID passed by address to COM
+				uintptr(unsafe.Pointer(&iidIShellItem)),
 				uintptr(unsafe.Pointer(&si)),
 			)
 			if hr == comSOK && si != 0 {
@@ -258,7 +265,7 @@ func setDlgFileTypes(dialog uintptr, filters []FileTypeFilter) {
 		uintptr(len(specs)),
 		uintptr(unsafe.Pointer(&specs[0])),
 	)
-	_ = backing // prevent GC before vtable call completes
+	runtime.KeepAlive(backing)
 }
 
 // dlgBuildFilterSpec converts extension slice to a Windows filter spec like "*.png;*.jpg".
@@ -272,7 +279,7 @@ func dlgBuildFilterSpec(exts []string) string {
 		}
 	}
 	if len(parts) == 0 {
-		return "*.*"
+		return defaultFilterPattern
 	}
 	return strings.Join(parts, ";")
 }

--- a/internal/platform/dialog_windows_test.go
+++ b/internal/platform/dialog_windows_test.go
@@ -38,17 +38,17 @@ func TestDlgBuildFilterSpec(t *testing.T) {
 		{
 			name: "nil slice falls back to wildcard",
 			exts: nil,
-			want: "*.*",
+			want: defaultFilterPattern,
 		},
 		{
 			name: "empty slice falls back to wildcard",
 			exts: []string{},
-			want: "*.*",
+			want: defaultFilterPattern,
 		},
 		{
 			name: "blank entries are skipped",
 			exts: []string{"", "*.", "."},
-			want: "*.*",
+			want: defaultFilterPattern,
 		},
 	}
 


### PR DESCRIPTION
1. fix Lines 282 and 303 — uintptr → unsafe.Pointer via syscall.SyscallN. Nolints are needed, so they are left in.
<img width="670" height="75" alt="Снимок экрана 2026-05-29 в 15 41 27" src="https://github.com/user-attachments/assets/41fea42c-f5ef-4f38-a2ab-7127da40f1c3" />

2. fix const
3. fix add const
4. migration setAllowedContentTypes:
5. runtime.KeepAlive instead of _ = backing
6. The HRESULT for IShellItemArray.GetCount was not checked.Status:  Now returns an error on failure.
