### PR TITLE
fix: default clear color transparent black (BUG-RENDERER-001, #276, v0.40.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.1] - 2026-05-31
+
+### Fixed
+
+- **DrawTexture default clear color** (BUG-RENDERER-001, discussion #276) — default clear changed from opaque black `{0,0,0,1}` to transparent black `{0,0,0,0}`, matching WebGPU spec and Rust wgpu `Color::default()`. Fixes ggcanvas transparency when compositing via `DrawTexture`/`RenderTo`.
+
+### Added
+
+- **Native file dialogs** (ADR-036 Phase 1, #241, @lkmavi) — `ShowOpenFileDialog` / `ShowSaveFileDialog` for macOS (NSOpenPanel/NSSavePanel via ObjC runtime) and Windows (IFileOpenDialog COM). Linux stubs with descriptive error. UTType migration for macOS 12+.
+
 ## [0.40.0] - 2026-05-27
 
 ### Removed

--- a/renderer.go
+++ b/renderer.go
@@ -987,8 +987,10 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 	}
 
 	// Determine LoadOp: consume pending clear if available, otherwise preserve content.
+	// Default clear = transparent black (WebGPU spec, Rust wgpu Color::default).
+	// Opaque black (A:1) would destroy alpha for compositing (ggcanvas, DrawTexture).
 	loadOp := gputypes.LoadOpClear
-	clearValue := gputypes.Color{R: 0, G: 0, B: 0, A: 1}
+	clearValue := gputypes.Color{R: 0, G: 0, B: 0, A: 0}
 	if ws.hasPendingClear {
 		clearValue = ws.pendingClearColor
 		ws.hasPendingClear = false


### PR DESCRIPTION
## Summary

Default clear color in `drawTexturedQuad` changed from opaque black `{0,0,0,1}` to transparent black `{0,0,0,0}`.

**Root cause:** WebGPU spec defaults clearValue to `{0,0,0,0}`. Rust wgpu `Color::default()` = transparent. Our A:1 default destroyed alpha channel for compositing (ggcanvas transparency broken when using DrawTexture/RenderTo).

**Research:** Verified against WebGPU W3C spec, Rust wgpu, Skia, Ebiten — all use transparent black for default clear. No scenario where A:1 is a better default.

**Impact:** One line change (`renderer.go:991`). Blend state and shader already correct for premultiplied alpha.

Fixes discussion #276.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues