### PR TITLE
feat: Win32 menus + docs update (v0.41.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.0] - 2026-06-01
+
+### Added
+
+- **Win32 native menu bar** (ADR-040 Phase 1, #282, @lkmavi) — `HMENU` via user32.dll, `WM_COMMAND` dispatch, thread-safe rebuild via `WM_APP+1`. Supports submenus, separators, disabled items, `RoleQuit` with proper ADR-026 lifecycle. Command IDs from 0x1000 (no systray collision). ~200 LOC + 370 LOC tests (19 tests).
+
+### Fixed
+
+- **Menu lint cleanup** — `sync.Map.Clear()` (Go 1.23+), gocritic truncateCmp fix in tests, uint16 limit comment.
+
 ## [0.40.2] - 2026-05-31
 
 ### Added
@@ -13,7 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Browser/WASM build** — added missing `SetAppName`, `ShowOpenFileDialog`, `ShowSaveFileDialog` stubs to `browserPlatform`. WASM build was broken since menu/dialog interface expansion.
+- **Browser/WASM build** — added missing `SetAppName`, `ShowOpenFileDialog`, `ShowSaveFileDialog` stubs to `browserPlatform`.
+
+## [0.40.1] - 2026-05-31
+
+### Added
+
+- **Native file dialogs** (ADR-036 Phase 1, #241, @lkmavi) — `ShowOpenFileDialog` / `ShowSaveFileDialog` for macOS (NSOpenPanel/NSSavePanel via ObjC runtime) and Windows (IFileOpenDialog COM). Linux stubs. UTType migration for macOS 12+.
+
+### Fixed
+
+- **DrawTexture default clear color** (BUG-RENDERER-001, discussion #276) — default clear changed from opaque black to transparent black.
 
 ## [0.40.0] - 2026-05-27
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 | **Graphics API** | Runtime selection: Vulkan, DX12, Metal, GLES, Software |
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal), Browser/WASM (WebGPU) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), zero-copy surface rendering, damage-aware presentation |
-| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference, native macOS window tabbing, native macOS system menu (role-based) |
+| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference, native macOS window tabbing, native system menus (macOS + Windows), native file dialogs (macOS + Windows + Linux D-Bus/zenity/kdialog) |
 | **Scroll** | ScrollPhase + IsMomentum for macOS trackpad momentum detection (ADR-032), pixel/line/page delta modes |
 | **Sound** | Platform system sounds for UI feedback (winmm, NSSound, canberra/PulseAudio) |
 | **Compute** | Full compute shader support |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -686,15 +686,16 @@ Log levels across the ecosystem:
 The logger is stored atomically and is safe for concurrent use. Accelerators
 inherit the logger configuration when registered.
 
-## Platform Support
+## Platform Features
 
-| Platform | Status       | GPU Backends                   | Input |
-|----------|--------------|--------------------------------|-------|
-| Windows  | Full support | Vulkan, DX12, GLES, Software   | Keyboard, mouse, pointer lock |
-| macOS    | Full support | Metal, Software (in progress)  | Keyboard, mouse |
-| Linux X11 | Full support | Vulkan, GLES, Software (in progress) | Keyboard, mouse, pointer lock, multi-touch (XInput2) |
-| Linux Wayland | Full support | Vulkan, GLES | Keyboard, mouse, pointer lock (`zwp_pointer_constraints_v1`), CSD |
-| Web      | Planned      | WebGPU                         | — |
+| Feature | Windows | macOS | Linux X11 | Linux Wayland | Browser |
+|---------|:-------:|:-----:|:---------:|:-------------:|:-------:|
+| **GPU Backends** | Vulkan, DX12, GLES, Software | Metal, Software | Vulkan, GLES, Software | Vulkan, GLES | WebGPU |
+| **Input** | Keyboard, mouse, pointer lock | Keyboard, mouse | Keyboard, mouse, pointer lock | Keyboard, mouse, pointer lock, CSD | Planned |
+| **File Dialogs** | ✅ IFileOpenDialog COM | ✅ NSOpenPanel/NSSavePanel | ✅ D-Bus portal + zenity/kdialog | ✅ D-Bus portal + zenity/kdialog | Stub |
+| **Native Menus** | ✅ Win32 HMENU | ✅ NSMenu | No-op (Phase 2: D-Bus AppMenu) | No-op (Phase 2: D-Bus AppMenu) | — |
+| **Clipboard** | ✅ | ✅ | ✅ ICCCM | ✅ wl_data_device | ✅ Clipboard API |
+| **System Sounds** | ✅ winmm | ✅ NSSound | ✅ canberra/PulseAudio | ✅ canberra/PulseAudio | — |
 
 ## See Also
 

--- a/internal/platform/menu_windows.go
+++ b/internal/platform/menu_windows.go
@@ -43,6 +43,7 @@ func init() {
 // nextMenuCmdID allocates and returns the next command ID for a menu item.
 // Thread-safe via atomic increment. IDs begin at 0x1000 to avoid colliding
 // with the systray range 0x0001–0x0FFF when both subsystems run together.
+// Practical limit: ~61K items before uint16 wraps (astronomically beyond real usage).
 func nextMenuCmdID() uint16 {
 	// Add returns the post-increment value; subtract 1 to get the allocated slot.
 	return uint16(menuCmdIDCounter.Add(1) - 1)
@@ -86,10 +87,7 @@ func (p *windowsPlatform) applyMenu() {
 		procDestroyMenu.Call(uintptr(p.hMenu))
 		p.hMenu = 0
 	}
-	menuActions.Range(func(k, _ any) bool {
-		menuActions.Delete(k)
-		return true
-	})
+	menuActions.Clear()
 
 	hwnd := uintptr(0)
 	if p.primary != nil {
@@ -145,7 +143,7 @@ func appendMenuItem(hMenu uintptr, item MenuItem) {
 
 	if len(item.Submenu) > 0 {
 		subPopup := buildMenuPopup(item.Submenu)
-		title, _ := windows.UTF16PtrFromString(item.Title)
+		title, _ := windows.UTF16PtrFromString(item.Title) // only fails on NUL in string
 		flags := uintptr(mfPopup)
 		if item.Disabled {
 			flags |= mfGrayed
@@ -177,7 +175,7 @@ func appendMenuItem(hMenu uintptr, item MenuItem) {
 		menuActions.Store(id, item.Action)
 	}
 
-	title, _ := windows.UTF16PtrFromString(item.Title)
+	title, _ := windows.UTF16PtrFromString(item.Title) // only fails on NUL in string
 	procAppendMenuW.Call(hMenu, flags, uintptr(id), uintptr(unsafe.Pointer(title)))
 }
 

--- a/internal/platform/menu_windows_test.go
+++ b/internal/platform/menu_windows_test.go
@@ -19,10 +19,7 @@ func menuItemCount(hMenu uintptr) int {
 // clearMenuActions removes all entries from the package-level menuActions map.
 func clearMenuActions(t *testing.T) {
 	t.Helper()
-	menuActions.Range(func(k, _ any) bool {
-		menuActions.Delete(k)
-		return true
-	})
+	menuActions.Clear()
 }
 
 // --- Command ID allocation ---
@@ -223,7 +220,7 @@ func TestBuildMenuPopup_ActionRegistered(t *testing.T) {
 	after := menuCmdIDCounter.Load()
 
 	// Dispatch every ID allocated during the build and verify the action fires.
-	for id := uint16(before); id < uint16(after); id++ {
+	for id := uint16(before); id < uint16(after); id++ { //nolint:gocritic // safe: counter range 0x1000–0xFFFF fits uint16
 		dispatchMenuCommand(id)
 	}
 	if !called {
@@ -246,7 +243,7 @@ func TestBuildMenuPopup_NoAction_NotRegistered(t *testing.T) {
 	defer procDestroyMenu.Call(hPopup)
 	after := menuCmdIDCounter.Load()
 
-	for id := uint16(before); id < uint16(after); id++ {
+	for id := uint16(before); id < uint16(after); id++ { //nolint:gocritic // safe: counter range 0x1000–0xFFFF fits uint16
 		if _, ok := menuActions.Load(id); ok {
 			t.Errorf("action unexpectedly registered for item with no Action/Role (id=%#x)", id)
 		}
@@ -291,7 +288,7 @@ func TestBuildMenuPopup_RoleQuit_UserActionCalled(t *testing.T) {
 
 	// globalPlatform is nil in unit tests so WM_CLOSE is not posted, but the
 	// user-supplied action must still be called.
-	for id := uint16(before); id < uint16(after); id++ {
+	for id := uint16(before); id < uint16(after); id++ { //nolint:gocritic // safe: counter range 0x1000–0xFFFF fits uint16
 		if fn, ok := menuActions.Load(id); ok {
 			fn.(func())()
 		}
@@ -317,7 +314,7 @@ func TestBuildMenuPopup_RoleQuit_NoUserAction_NoPanic(t *testing.T) {
 	after := menuCmdIDCounter.Load()
 
 	// Invoking the registered closure with nil globalPlatform must not panic.
-	for id := uint16(before); id < uint16(after); id++ {
+	for id := uint16(before); id < uint16(after); id++ { //nolint:gocritic // safe: counter range 0x1000–0xFFFF fits uint16
 		if fn, ok := menuActions.Load(id); ok {
 			fn.(func())()
 		}
@@ -343,7 +340,7 @@ func TestBuildMenuPopup_RoleQuit_Registered(t *testing.T) {
 	after := menuCmdIDCounter.Load()
 
 	found := false
-	for id := uint16(before); id < uint16(after); id++ {
+	for id := uint16(before); id < uint16(after); id++ { //nolint:gocritic // safe: counter range 0x1000–0xFFFF fits uint16
 		if _, ok := menuActions.Load(id); ok {
 			found = true
 		}


### PR DESCRIPTION
Win32 native menu bar (ADR-040 Phase 1, @lkmavi PR #286). Menu lint cleanup. CHANGELOG/README/ARCHITECTURE updated for v0.41.0.