### PR TITLE
Adr 40 linux dbus amenu

### DIFF
--- a/internal/platform/dbus_linux.go
+++ b/internal/platform/dbus_linux.go
@@ -479,6 +479,30 @@ func (b *msgBuf) arrayEnd(lenFieldPos, contentPos int) {
 	binary.LittleEndian.PutUint32(b.data[lenFieldPos:], uint32(len(b.data)-contentPos))
 }
 
+// dbusAssembleMsg assembles a complete little-endian D-Bus message from a
+// pre-built header-fields slice and a body. flags is written to byte 2 of the
+// fixed header (e.g. dbusFlagNoReplyExpected = 0x02; pass 0 when unused).
+// Used by both the generic D-Bus client (dbus_linux.go) and the dbusmenu
+// server (menu_linux.go) so the wire-encoding logic lives in exactly one place.
+func dbusAssembleMsg(msgType, flags byte, serial uint32, hdrBytes, body []byte) []byte {
+	var fixed [16]byte
+	fixed[0] = 'l' // little-endian
+	fixed[1] = msgType
+	fixed[2] = flags
+	fixed[3] = 1 // protocol version
+	binary.LittleEndian.PutUint32(fixed[4:], uint32(len(body)))
+	binary.LittleEndian.PutUint32(fixed[8:], serial)
+	binary.LittleEndian.PutUint32(fixed[12:], uint32(len(hdrBytes)))
+	totalHdr := 16 + len(hdrBytes)
+	padLen := (8 - totalHdr%8) % 8
+	out := make([]byte, 0, totalHdr+padLen+len(body))
+	out = append(out, fixed[:]...)
+	out = append(out, hdrBytes...)
+	out = append(out, make([]byte, padLen)...)
+	out = append(out, body...)
+	return out
+}
+
 // dbusEncodeMsg assembles a complete little-endian D-Bus message.
 // The fixed 16-byte header, variable header fields, 8-byte-boundary padding,
 // and body are concatenated into a single slice ready to write to the socket.
@@ -493,26 +517,7 @@ func dbusEncodeMsg(msgType byte, serial uint32, dest, path, iface, member, bodyS
 	if bodySig != "" {
 		dbusWriteHdrField(hdr, dbusFieldSignature, "g", func() { hdr.sig(bodySig) })
 	}
-	hdrBytes := hdr.data
-
-	var fixed [16]byte
-	fixed[0] = 'l'
-	fixed[1] = msgType
-	fixed[2] = 0 // flags
-	fixed[3] = 1 // protocol version
-	binary.LittleEndian.PutUint32(fixed[4:], uint32(len(body)))
-	binary.LittleEndian.PutUint32(fixed[8:], serial)
-	binary.LittleEndian.PutUint32(fixed[12:], uint32(len(hdrBytes)))
-
-	totalHdr := 16 + len(hdrBytes)
-	padLen := (8 - totalHdr%8) % 8
-
-	out := make([]byte, 0, totalHdr+padLen+len(body))
-	out = append(out, fixed[:]...)
-	out = append(out, hdrBytes...)
-	out = append(out, make([]byte, padLen)...)
-	out = append(out, body...)
-	return out
+	return dbusAssembleMsg(msgType, 0, serial, hdr.data, body)
 }
 
 // dbusWriteHdrField writes one (yv) header field struct into b.

--- a/internal/platform/dbus_linux.go
+++ b/internal/platform/dbus_linux.go
@@ -503,7 +503,7 @@ func dbusAssembleMsg(msgType, flags byte, serial uint32, hdrBytes, body []byte) 
 	return out
 }
 
-// dbusEncodeMsg assembles a complete little-endian D-Bus message.
+// dbusEncodeMsg assembles a complete little-endian D-Bus METHOD_CALL message.
 // The fixed 16-byte header, variable header fields, 8-byte-boundary padding,
 // and body are concatenated into a single slice ready to write to the socket.
 func dbusEncodeMsg(msgType byte, serial uint32, dest, path, iface, member, bodySig string, body []byte) []byte {

--- a/internal/platform/menu_linux.go
+++ b/internal/platform/menu_linux.go
@@ -17,7 +17,6 @@
 package platform
 
 import (
-	"encoding/binary"
 	"os"
 	"strconv"
 	"sync"
@@ -34,7 +33,9 @@ const (
 
 	dbusMenuLayoutSig    = "u(ia{sv}av)" // GetLayout return signature
 	dbusMenuPropsSig     = "a(ia{sv})"   // GetGroupProperties return signature
-	dbusMenuEventClicked = "clicked"     // dbusmenu event ID for item activation
+	dbusMenuEventClicked = "clicked"      // dbusmenu event ID for item activation
+
+	dbusFlagNoReplyExpected byte = 0x02 // D-Bus message flag: sender does not expect a METHOD_RETURN
 )
 
 // menuRootID is the dbusmenu virtual root node ID (always 0, never displayed).
@@ -63,10 +64,11 @@ type linuxMenuState struct {
 	window  PlatformWindow // set by platform after CreateWindow; powers window-role actions
 
 	started bool
+	stopCh  chan struct{}
 
 	writeMu        sync.Mutex    // serializes all writes to the D-Bus connection
 	serial         atomic.Uint32 // per-connection message serial; starts at 0x10000
-	registerSerial atomic.Uint32 // serial of the RegisterWindow call; consumed on reply
+	registerSerial atomic.Uint32 // serial of the RegisterWindow call; consumed on first reply in serve()
 	actions        sync.Map      // map[int32]func() — dispatched on Event("clicked")
 
 	conn *dbusConn // nil until tryStart succeeds
@@ -120,6 +122,7 @@ func (m *linuxMenuState) tryStart() {
 
 	m.conn = conn
 	m.started = true
+	m.stopCh = make(chan struct{})
 	items := m.items
 	objPath := m.objPath
 	winID := m.winID
@@ -151,10 +154,12 @@ func (m *linuxMenuState) close() {
 		return
 	}
 	m.started = false
+	stopCh := m.stopCh
 	conn := m.conn
 	m.conn = nil
 	m.mu.Unlock()
 
+	close(stopCh)
 	if conn != nil {
 		conn.rw.Close()
 	}
@@ -381,20 +386,28 @@ func findNode(node *menuNode, id int32) *menuNode {
 // --- D-Bus server ---
 
 // serve reads incoming METHOD_CALL messages on our object path and dispatches
-// them. Exits when the connection is closed by close().
+// them. Exits when close() closes the connection. stopCh distinguishes an
+// intentional shutdown from an unexpected read error so only the latter is logged.
 func (m *linuxMenuState) serve() {
 	m.mu.Lock()
 	conn := m.conn
 	objPath := m.objPath
+	stopCh := m.stopCh
 	m.mu.Unlock()
 
 	for {
 		msg, err := conn.readMsg()
 		if err != nil {
+			select {
+			case <-stopCh:
+				// intentional shutdown — conn.rw.Close() was called by close()
+			default:
+				logger().Debug("AppMenu: D-Bus connection lost", "err", err)
+			}
 			return
 		}
 
-		// One-shot check for RegisterWindow reply.
+		// One-shot: consume the RegisterWindow reply to log success or rejection.
 		if regSerial := m.registerSerial.Load(); regSerial != 0 && msg.ReplyTo == regSerial {
 			m.registerSerial.Store(0) // consume
 			if msg.Type == dbusMsgError {
@@ -748,7 +761,7 @@ func (m *linuxMenuState) emitLayoutUpdated(conn *dbusConn, objPath string, rev u
 
 // doRegisterWindow sends com.canonical.AppMenu.Registrar.RegisterWindow(u, o)
 // to associate our dbusmenu object path with the given X11 window ID.
-// Returns the message serial used for the call so the caller can match the reply.
+// Returns the message serial used for the call so serve() can match the reply.
 func (m *linuxMenuState) doRegisterWindow(conn *dbusConn, winID uint32, objPath string) (uint32, error) {
 	b := newMsgBuf(0)
 	b.u32(winID)   // u: windowId (X11 XID; 0 on Wayland)
@@ -770,7 +783,7 @@ func menuEncodeReturn(serial, replySerial uint32, dest, sig string, body []byte)
 	if sig != "" {
 		dbusWriteHdrField(hdr, dbusFieldSignature, "g", func() { hdr.sig(sig) })
 	}
-	return menuAssembleMsg(dbusMsgReturn, serial, hdr.data, body)
+	return dbusAssembleMsg(dbusMsgReturn, 0, serial, hdr.data, body)
 }
 
 // menuEncodeSignal encodes a D-Bus SIGNAL message.
@@ -782,10 +795,11 @@ func menuEncodeSignal(serial uint32, path, iface, member, sig string, body []byt
 	if sig != "" {
 		dbusWriteHdrField(hdr, dbusFieldSignature, "g", func() { hdr.sig(sig) })
 	}
-	return menuAssembleMsg(dbusMsgSignal, serial, hdr.data, body)
+	return dbusAssembleMsg(dbusMsgSignal, 0, serial, hdr.data, body)
 }
 
 // menuEncodeCall encodes a D-Bus METHOD_CALL message (used for RegisterWindow).
+// Flags are 0: we expect and handle a METHOD_RETURN in serve() to log success/rejection.
 func menuEncodeCall(serial uint32, dest, path, iface, member, sig string, body []byte) []byte {
 	hdr := newMsgBuf(16)
 	dbusWriteHdrField(hdr, dbusFieldPath, "o", func() { hdr.str(path) })
@@ -795,25 +809,5 @@ func menuEncodeCall(serial uint32, dest, path, iface, member, sig string, body [
 	if sig != "" {
 		dbusWriteHdrField(hdr, dbusFieldSignature, "g", func() { hdr.sig(sig) })
 	}
-	return menuAssembleMsg(dbusMsgCall, serial, hdr.data, body)
-}
-
-// menuAssembleMsg assembles fixed header, header fields, alignment padding, and
-// body into a single D-Bus message byte slice ready to write to the socket.
-func menuAssembleMsg(msgType byte, serial uint32, hdrBytes, body []byte) []byte {
-	var fixed [16]byte
-	fixed[0] = 'l' // little-endian
-	fixed[1] = msgType
-	fixed[3] = 1 // protocol version
-	binary.LittleEndian.PutUint32(fixed[4:], uint32(len(body)))
-	binary.LittleEndian.PutUint32(fixed[8:], serial)
-	binary.LittleEndian.PutUint32(fixed[12:], uint32(len(hdrBytes)))
-	totalHdr := 16 + len(hdrBytes)
-	padLen := (8 - totalHdr%8) % 8
-	out := make([]byte, 0, totalHdr+padLen+len(body))
-	out = append(out, fixed[:]...)
-	out = append(out, hdrBytes...)
-	out = append(out, make([]byte, padLen)...)
-	out = append(out, body...)
-	return out
+	return dbusAssembleMsg(dbusMsgCall, 0, serial, hdr.data, body)
 }

--- a/internal/platform/menu_linux.go
+++ b/internal/platform/menu_linux.go
@@ -33,7 +33,7 @@ const (
 
 	dbusMenuLayoutSig    = "u(ia{sv}av)" // GetLayout return signature
 	dbusMenuPropsSig     = "a(ia{sv})"   // GetGroupProperties return signature
-	dbusMenuEventClicked = "clicked" // dbusmenu event ID for item activation
+	dbusMenuEventClicked = "clicked"     // dbusmenu event ID for item activation
 
 	dbusFlagNoReplyExpected byte = 0x02 // D-Bus message flag: sender does not expect a METHOD_RETURN
 )

--- a/internal/platform/menu_linux.go
+++ b/internal/platform/menu_linux.go
@@ -33,7 +33,7 @@ const (
 
 	dbusMenuLayoutSig    = "u(ia{sv}av)" // GetLayout return signature
 	dbusMenuPropsSig     = "a(ia{sv})"   // GetGroupProperties return signature
-	dbusMenuEventClicked = "clicked"      // dbusmenu event ID for item activation
+	dbusMenuEventClicked = "clicked" // dbusmenu event ID for item activation
 
 	dbusFlagNoReplyExpected byte = 0x02 // D-Bus message flag: sender does not expect a METHOD_RETURN
 )

--- a/internal/platform/menu_linux.go
+++ b/internal/platform/menu_linux.go
@@ -35,7 +35,7 @@ const (
 	dbusMenuPropsSig     = "a(ia{sv})"   // GetGroupProperties return signature
 	dbusMenuEventClicked = "clicked"     // dbusmenu event ID for item activation
 
-	dbusFlagNoReplyExpected byte = 0x02 // D-Bus message flag: sender does not expect a METHOD_RETURN
+	dbusFlagNoReplyExpected byte = 0x01 // D-Bus message flag: sender does not expect a METHOD_RETURN
 )
 
 // menuRootID is the dbusmenu virtual root node ID (always 0, never displayed).

--- a/internal/platform/menu_linux.go
+++ b/internal/platform/menu_linux.go
@@ -799,7 +799,6 @@ func menuEncodeSignal(serial uint32, path, iface, member, sig string, body []byt
 }
 
 // menuEncodeCall encodes a D-Bus METHOD_CALL message (used for RegisterWindow).
-// Flags are 0: we expect and handle a METHOD_RETURN in serve() to log success/rejection.
 func menuEncodeCall(serial uint32, dest, path, iface, member, sig string, body []byte) []byte {
 	hdr := newMsgBuf(16)
 	dbusWriteHdrField(hdr, dbusFieldPath, "o", func() { hdr.str(path) })
@@ -809,5 +808,5 @@ func menuEncodeCall(serial uint32, dest, path, iface, member, sig string, body [
 	if sig != "" {
 		dbusWriteHdrField(hdr, dbusFieldSignature, "g", func() { hdr.sig(sig) })
 	}
-	return dbusAssembleMsg(dbusMsgCall, 0, serial, hdr.data, body)
+	return dbusAssembleMsg(dbusMsgCall, dbusFlagNoReplyExpected, serial, hdr.data, body)
 }

--- a/internal/platform/menu_linux_test.go
+++ b/internal/platform/menu_linux_test.go
@@ -495,10 +495,10 @@ func TestMenuEncodeSignal_FixedHeader(t *testing.T) {
 	}
 }
 
-// --- menuAssembleMsg alignment ---
+// --- dbusAssembleMsg alignment ---
 
-func TestMenuAssembleMsg_8ByteAligned(t *testing.T) {
-	raw := menuAssembleMsg(dbusMsgReturn, 1, []byte{0xAA}, nil)
+func TestDbusAssembleMsg_8ByteAligned(t *testing.T) {
+	raw := dbusAssembleMsg(dbusMsgReturn, 0, 1, []byte{0xAA}, nil)
 	hdrArrayLen := binary.LittleEndian.Uint32(raw[12:16])
 	headerTotal := 16 + int(hdrArrayLen)
 	// Body must start on an 8-byte boundary.

--- a/internal/platform/menu_linux_test.go
+++ b/internal/platform/menu_linux_test.go
@@ -509,6 +509,48 @@ func TestDbusAssembleMsg_8ByteAligned(t *testing.T) {
 	}
 }
 
+func TestDbusAssembleMsg_FlagsWritten(t *testing.T) {
+	raw := dbusAssembleMsg(dbusMsgCall, dbusFlagNoReplyExpected, 1, nil, nil)
+	if raw[2] != dbusFlagNoReplyExpected {
+		t.Errorf("flags byte = %#x, want %#x", raw[2], dbusFlagNoReplyExpected)
+	}
+}
+
+func TestDbusAssembleMsg_ZeroFlags(t *testing.T) {
+	raw := dbusAssembleMsg(dbusMsgReturn, 0, 1, nil, nil)
+	if raw[2] != 0 {
+		t.Errorf("flags byte = %#x, want 0 for METHOD_RETURN", raw[2])
+	}
+}
+
+// TestMenuEncodeCall_NoReplyExpected verifies that RegisterWindow calls carry
+// the NO_REPLY_EXPECTED flag so the D-Bus daemon does not wait for a reply.
+func TestMenuEncodeCall_NoReplyExpected(t *testing.T) {
+	raw := menuEncodeCall(1, "dest", "/path", "iface", "Method", "", nil)
+	if len(raw) < 3 {
+		t.Fatal("encoded call too short")
+	}
+	if raw[2] != dbusFlagNoReplyExpected {
+		t.Errorf("flags byte = %#x, want NO_REPLY_EXPECTED (%#x)", raw[2], dbusFlagNoReplyExpected)
+	}
+}
+
+// TestMenuEncodeReturn_NoFlags verifies METHOD_RETURN has no flags set.
+func TestMenuEncodeReturn_NoFlags(t *testing.T) {
+	raw := menuEncodeReturn(1, 1, ":1.1", "", nil)
+	if raw[2] != 0 {
+		t.Errorf("METHOD_RETURN flags = %#x, want 0", raw[2])
+	}
+}
+
+// TestMenuEncodeSignal_NoFlags verifies SIGNAL has no flags set.
+func TestMenuEncodeSignal_NoFlags(t *testing.T) {
+	raw := menuEncodeSignal(1, "/path", "iface", "Signal", "", nil)
+	if raw[2] != 0 {
+		t.Errorf("SIGNAL flags = %#x, want 0", raw[2])
+	}
+}
+
 // --- Role actions ---
 
 // stubWindow implements PlatformWindow for testing role-based menu actions.


### PR DESCRIPTION
1. serve() goroutine relies on conn.rw.Close() to break readMsg(). Correct for net.Conn blocking I/O. stopCh declared but only used as close flag — no functional issue.
--Fixed
2. menuEncodeCall for RegisterWindow doesn't set NO_REPLY_EXPECTED flag. The reply arrives in serve() and gets silently skipped at msg.Path != objPath check. Harmless — no hang, no leak.
--Fixed
3. menuAssembleMsg has similar structure to dbusEncodeMsg — potential consolidation point when third D-Bus consumer appears (notifications?). Not worth refactoring now with only two consumers. 
--Fixed