### PR TITLE
fix: Wayland app event queue + CSD mutex + deps (ADR-041, #292, v0.41.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.4] - 2026-06-05
+
+### Fixed
+
+- **Wayland Vulkan: app event queue separation** (ADR-041 Phase 4, #292) — moved all app Wayland objects (compositor, surface, xdg_*, input) to a custom `wl_event_queue`. Default queue left for Mesa Vulkan WSI. `DispatchDefaultQueue` now uses `wl_display_prepare_read_queue` + `wl_display_dispatch_queue_pending` on the app queue only. Prevents our dispatch from firing Mesa's internal `wl_buffer.release` callbacks. Enterprise pattern from GLFW/SDL3.
+- **Wayland CSD thread safety** — `DispatchCSDEvents()` now holds `displayMu` to serialize CSD `wl_display_flush` with render thread Vulkan WSI calls.
+
+### Changed
+
+- **deps:** wgpu v0.29.1 → v0.29.4 (Wayland GLES wl_egl_window + Software wl_shm present + VK_ERROR_SURFACE_LOST handling), goffi v0.5.2 → v0.5.3
+
 ## [0.41.3] - 2026-06-05
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.39.3
+## Current State: v0.41.4
 
 ✅ **Production-ready** with full feature set:
 - **Universal App Lifecycle** — RenderTarget, QuitOnLastWindowClosed, AppLifecycle enum (5 states), surface/lifecycle callbacks (ADR-026, Phases 1-3)
@@ -43,7 +43,10 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 - **Runtime fullscreen** — `App.SetFullscreen(bool)`, `App.ToggleFullscreen()` on all platforms (ADR-018)
 - **Multi-window** — `App.NewWindow()` creates additional windows with shared GPU device (ADR-010)
 - **Damage-aware presentation** — `Context.SetDamageRects()` passes dirty regions to compositor (ADR-013)
-- Dual backend (Rust/Pure Go) — cross-platform (Windows, macOS, Linux, **Browser/WASM**)
+- **Triple-backend WebGPU** — Pure Go / Rust FFI / Browser WASM via build tags (ADR-038)
+- **Native file dialogs** — macOS NSPanel, Windows COM, Linux D-Bus + zenity/kdialog (ADR-036, @lkmavi)
+- **Native menus** — macOS NSMenu, Windows HMENU, Linux D-Bus AppMenu (ADR-040, @lkmavi)
+- **Wayland thread safety** — app event queue separation, CSD displayMu, configure gate (ADR-041, #292)
 - **PlatformManager / PlatformWindow** — clean process-level / per-window split (Qt6 pattern)
 - Multi-thread architecture (Ebiten/Gio pattern)
 - Event-driven rendering with three-state model (0% CPU when idle)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -392,6 +392,10 @@ selection protocol), Wayland (wl_data_device). Wayland cursor shapes (12 shapes 
 wp_cursor_shape_manager_v1) shipped in v0.39.2. Wayland BlitPixels remains TODO.
 See `docs/dev/research/PLATFORM-IMPLEMENTATION-MATRIX.md` for full matrix.
 
+### Wayland Thread Safety (ADR-041)
+
+All app Wayland objects live on a custom `wl_event_queue` (separated from Mesa Vulkan WSI's default queue). `DispatchDefaultQueue` uses queue-specific `prepare_read_queue` + `dispatch_queue_pending`. CSD operations hold `displayMu`. Render thread present is covered by `DisplayLocker` interface. Enterprise pattern from GLFW/SDL3.
+
 ### Thread Safety
 
 Surface reconfiguration happens exclusively on the render thread.

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/gogpu/gogpu
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.5.2
+	github.com/go-webgpu/goffi v0.5.3
 	github.com/gogpu/gpucontext v0.19.0
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/wgpu v0.29.1
+	github.com/gogpu/wgpu v0.29.4
 	golang.org/x/sys v0.45.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.5.2 h1:Kq2llPlA6IhkkmAffkM5CtsgaXuBQC4mBI0BOREwV04=
-github.com/go-webgpu/goffi v0.5.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.5.3 h1:Ckc94SdHO42bIb0oEapRIcv+jKjhjGJfb9zPEvNKC7U=
+github.com/go-webgpu/goffi v0.5.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
@@ -8,7 +8,7 @@ github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.13 h1:VlponVgD1fEfNotx0874M4n7tnfum8YlMEB3pBdd2Ps=
 github.com/gogpu/naga v0.17.13/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.29.1 h1:pSLOpg/VlhnkyZ2ffmnqkGUVAiuCbPnnduxlWgPHZwI=
-github.com/gogpu/wgpu v0.29.1/go.mod h1:aZVNcEK4tf8fmSha+W7vwxxfJBBRWvUMjT+17bWHSYY=
+github.com/gogpu/wgpu v0.29.4 h1:Ah/RYHzLWmgvVuphY2urD453GTdFMvlNZ12fW2SNUrc=
+github.com/gogpu/wgpu v0.29.4/go.mod h1:QNkSyEeUPVjq8hDuScyki0+wJ5I7WCEvMyP9K9Z2aEw=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/platform/wayland/libwayland.go
+++ b/internal/platform/wayland/libwayland.go
@@ -49,23 +49,28 @@ type LibwaylandHandle struct {
 	toplevelDecor uintptr // zxdg_toplevel_decoration_v1* proxy
 
 	// Function symbols
-	fnDisplayConnect unsafe.Pointer
-	fnDisplayDisconn unsafe.Pointer
-	fnDisplayFlush   unsafe.Pointer
-	fnProxyMarshal   unsafe.Pointer // wl_proxy_marshal_array_constructor
-	fnProxyMarshalV  unsafe.Pointer // wl_proxy_marshal_array_constructor_versioned
-	fnProxyDestroy   unsafe.Pointer
-	fnAddListener    unsafe.Pointer // wl_proxy_add_listener
-	fnRoundtrip      unsafe.Pointer // wl_display_roundtrip
-	fnDispatchPend   unsafe.Pointer // wl_display_dispatch_pending
-	fnPrepareRead    unsafe.Pointer // wl_display_prepare_read
-	fnReadEvents     unsafe.Pointer // wl_display_read_events
-	fnCancelRead     unsafe.Pointer // wl_display_cancel_read
-	fnGetFD          unsafe.Pointer // wl_display_get_fd
-	fnCreateQueue    unsafe.Pointer // wl_display_create_queue
-	fnDispatchQueueP unsafe.Pointer // wl_display_dispatch_queue_pending
-	fnProxySetQueue  unsafe.Pointer // wl_proxy_set_queue
-	fnMarshalArray   unsafe.Pointer // wl_proxy_marshal_array (no new_id)
+	fnDisplayConnect   unsafe.Pointer
+	fnDisplayDisconn   unsafe.Pointer
+	fnDisplayFlush     unsafe.Pointer
+	fnProxyMarshal     unsafe.Pointer // wl_proxy_marshal_array_constructor
+	fnProxyMarshalV    unsafe.Pointer // wl_proxy_marshal_array_constructor_versioned
+	fnProxyDestroy     unsafe.Pointer
+	fnAddListener      unsafe.Pointer // wl_proxy_add_listener
+	fnRoundtrip        unsafe.Pointer // wl_display_roundtrip
+	fnDispatchPend     unsafe.Pointer // wl_display_dispatch_pending
+	fnPrepareRead      unsafe.Pointer // wl_display_prepare_read
+	fnReadEvents       unsafe.Pointer // wl_display_read_events
+	fnCancelRead       unsafe.Pointer // wl_display_cancel_read
+	fnGetFD            unsafe.Pointer // wl_display_get_fd
+	fnCreateQueue      unsafe.Pointer // wl_display_create_queue
+	fnDispatchQueueP   unsafe.Pointer // wl_display_dispatch_queue_pending
+	fnProxySetQueue    unsafe.Pointer // wl_proxy_set_queue
+	fnMarshalArray     unsafe.Pointer // wl_proxy_marshal_array (no new_id)
+	fnCreateWrapper    unsafe.Pointer // wl_proxy_create_wrapper
+	fnWrapperDestroy   unsafe.Pointer // wl_proxy_wrapper_destroy
+	fnPrepareReadQueue unsafe.Pointer // wl_display_prepare_read_queue
+	fnDestroyQueue     unsafe.Pointer // wl_event_queue_destroy
+	fnRoundtripQueue   unsafe.Pointer // wl_display_roundtrip_queue
 
 	// displayMu serializes wl_display access between the main thread (event dispatch)
 	// and the render thread (Vulkan WSI present/acquire). libwayland docs state that
@@ -78,6 +83,13 @@ type LibwaylandHandle struct {
 	// Without this, Vulkan present can race ahead of the compositor mapping the surface,
 	// causing SIGSEGV in vkQueuePresentKHR (ADR-041 Phase 1).
 	initialConfigureReceived bool
+
+	// App event queue — ALL our Wayland objects (registry, compositor, surface,
+	// xdg, seat, pointer, keyboard, etc.) live on this queue. The default queue
+	// is left exclusively for Mesa Vulkan WSI's internal wl_buffer.release
+	// callbacks. This separation prevents our dispatch from firing Mesa's
+	// callbacks outside Mesa's expected context (ADR-041 Phase 4).
+	appQueue uintptr // wl_event_queue* for all our objects
 
 	// CSD objects (subsurfaces for client-side decorations)
 	subcompositor uintptr    // wl_subcompositor* proxy
@@ -163,21 +175,26 @@ type LibwaylandHandle struct {
 	touchInterface         unsafe.Pointer // &wl_touch_interface
 
 	// Call interfaces (goffi call descriptors, prepared once)
-	cifConnect     types.CallInterface
-	cifDisconn     types.CallInterface
-	cifFlush       types.CallInterface
-	cifMarshal     types.CallInterface
-	cifMarshalV    types.CallInterface
-	cifDestroy     types.CallInterface
-	cifAddListener types.CallInterface
-	cifRoundtrip   types.CallInterface
-	cifDispatchP   types.CallInterface // wl_display_dispatch_pending(display) -> int
-	cifPrepareRead types.CallInterface // wl_display_prepare_read(display) -> int
-	cifReadEvents  types.CallInterface // wl_display_read_events(display) -> int
-	cifCreateQueue types.CallInterface // wl_display_create_queue(display) -> queue*
-	cifDispatchQP  types.CallInterface // wl_display_dispatch_queue_pending(display, queue) -> int
-	cifSetQueue    types.CallInterface // wl_proxy_set_queue(proxy, queue) -> void
-	cifMarshalArr  types.CallInterface // wl_proxy_marshal_array(proxy, opcode, args) -> void
+	cifConnect        types.CallInterface
+	cifDisconn        types.CallInterface
+	cifFlush          types.CallInterface
+	cifMarshal        types.CallInterface
+	cifMarshalV       types.CallInterface
+	cifDestroy        types.CallInterface
+	cifAddListener    types.CallInterface
+	cifRoundtrip      types.CallInterface
+	cifDispatchP      types.CallInterface // wl_display_dispatch_pending(display) -> int
+	cifPrepareRead    types.CallInterface // wl_display_prepare_read(display) -> int
+	cifReadEvents     types.CallInterface // wl_display_read_events(display) -> int
+	cifCreateQueue    types.CallInterface // wl_display_create_queue(display) -> queue*
+	cifDispatchQP     types.CallInterface // wl_display_dispatch_queue_pending(display, queue) -> int
+	cifSetQueue       types.CallInterface // wl_proxy_set_queue(proxy, queue) -> void
+	cifMarshalArr     types.CallInterface // wl_proxy_marshal_array(proxy, opcode, args) -> void
+	cifCreateWrapper  types.CallInterface // wl_proxy_create_wrapper(proxy) -> proxy*
+	cifWrapperDestroy types.CallInterface // wl_proxy_wrapper_destroy(wrapper) -> void
+	cifPrepareReadQ   types.CallInterface // wl_display_prepare_read_queue(display, queue) -> int
+	cifDestroyQueue   types.CallInterface // wl_event_queue_destroy(queue) -> void
+	cifRoundtripQueue types.CallInterface // wl_display_roundtrip_queue(display, queue) -> int
 }
 
 // Display returns the wl_display* C pointer for Vulkan surface creation.
@@ -231,10 +248,47 @@ func OpenLibwayland(compositorName, compositorVersion, xdgWmBaseName, xdgWmBaseV
 	}
 	h.display = display
 
-	// Step 5: Get registry — wl_proxy_marshal_array_constructor(display, 1, [NULL], &wl_registry_interface)
-	// Opcode 1 = wl_display::get_registry. Arg: one new_id (NULL placeholder, constructor fills it).
-	registry, err := h.marshalConstructor(display, 1, h.registryInterface)
+	// Step 4b: Create app event queue — ALL our objects live here.
+	// The default queue is left exclusively for Mesa Vulkan WSI's internal
+	// wl_buffer.release callbacks. This prevents our dispatch from firing
+	// Mesa's callbacks outside Mesa's expected context (GLFW/SDL3 pattern,
+	// ADR-041 Phase 4).
+	var appQueue uintptr
+	queueArgs := [1]unsafe.Pointer{unsafe.Pointer(&h.display)}
+	ffi.CallFunction(&h.cifCreateQueue, h.fnCreateQueue, unsafe.Pointer(&appQueue), queueArgs[:])
+	if appQueue == 0 {
+		h.disconnectDisplay()
+		return nil, fmt.Errorf("wayland: wl_display_create_queue returned NULL")
+	}
+	h.appQueue = appQueue
+
+	// Step 4c: Create ephemeral display wrapper assigned to appQueue.
+	// wl_proxy_create_wrapper creates a lightweight proxy that inherits
+	// the wrapper's queue to all child objects created through it.
+	// This is the GLFW pattern: wrapper → get_registry → registry on appQueue
+	// → all registry.bind results on appQueue → all child objects on appQueue.
+	var displayWrapper uintptr
+	wrapperArgs := [1]unsafe.Pointer{unsafe.Pointer(&h.display)}
+	ffi.CallFunction(&h.cifCreateWrapper, h.fnCreateWrapper, unsafe.Pointer(&displayWrapper), wrapperArgs[:])
+	if displayWrapper == 0 {
+		h.destroyAppQueue()
+		h.disconnectDisplay()
+		return nil, fmt.Errorf("wayland: wl_proxy_create_wrapper returned NULL")
+	}
+	// Assign the wrapper to our app queue — children inherit this queue.
+	setQArgs := [2]unsafe.Pointer{unsafe.Pointer(&displayWrapper), unsafe.Pointer(&appQueue)}
+	ffi.CallFunction(&h.cifSetQueue, h.fnProxySetQueue, nil, setQArgs[:])
+
+	// Step 5: Get registry THROUGH the wrapper so it inherits appQueue.
+	// Opcode 1 = wl_display::get_registry. Arg: one new_id (NULL placeholder).
+	registry, err := h.marshalConstructor(displayWrapper, 1, h.registryInterface)
+
+	// Destroy the wrapper — child objects (registry) retain the queue assignment.
+	destroyWrapperArgs := [1]unsafe.Pointer{unsafe.Pointer(&displayWrapper)}
+	ffi.CallFunction(&h.cifWrapperDestroy, h.fnWrapperDestroy, nil, destroyWrapperArgs[:])
+
 	if err != nil {
+		h.destroyAppQueue()
 		h.disconnectDisplay()
 		return nil, fmt.Errorf("wayland: failed to get registry: %w", err)
 	}
@@ -375,6 +429,9 @@ func (h *LibwaylandHandle) Close() {
 	_ = h.flush()
 	h.Roundtrip()
 
+	// Destroy app event queue after all objects are gone (ADR-041 Phase 4).
+	h.destroyAppQueue()
+
 	h.disconnectDisplay()
 }
 
@@ -401,6 +458,11 @@ func (h *LibwaylandHandle) resolveSymbols() error {
 		{"wl_display_dispatch_queue_pending", &h.fnDispatchQueueP},
 		{"wl_proxy_set_queue", &h.fnProxySetQueue},
 		{"wl_proxy_marshal_array", &h.fnMarshalArray},
+		{"wl_proxy_create_wrapper", &h.fnCreateWrapper},
+		{"wl_proxy_wrapper_destroy", &h.fnWrapperDestroy},
+		{"wl_display_prepare_read_queue", &h.fnPrepareReadQueue},
+		{"wl_event_queue_destroy", &h.fnDestroyQueue},
+		{"wl_display_roundtrip_queue", &h.fnRoundtripQueue},
 	}
 
 	for _, s := range syms {
@@ -488,6 +550,16 @@ func (h *LibwaylandHandle) prepareCIFs() error {
 		{"set_queue", &h.cifSetQueue, types.VoidTypeDescriptor, []*types.TypeDescriptor{ptr, ptr}},
 		// void wl_proxy_marshal_array(wl_proxy*, uint32_t opcode, union wl_argument*)
 		{"marshal_array", &h.cifMarshalArr, types.VoidTypeDescriptor, []*types.TypeDescriptor{ptr, types.UInt32TypeDescriptor, ptr}},
+		// wl_proxy* wl_proxy_create_wrapper(void* proxy)
+		{"create_wrapper", &h.cifCreateWrapper, ptr, []*types.TypeDescriptor{ptr}},
+		// void wl_proxy_wrapper_destroy(void* wrapper)
+		{"wrapper_destroy", &h.cifWrapperDestroy, types.VoidTypeDescriptor, []*types.TypeDescriptor{ptr}},
+		// int wl_display_prepare_read_queue(wl_display*, wl_event_queue*)
+		{"prepare_read_queue", &h.cifPrepareReadQ, i32, []*types.TypeDescriptor{ptr, ptr}},
+		// void wl_event_queue_destroy(wl_event_queue*)
+		{"destroy_queue", &h.cifDestroyQueue, types.VoidTypeDescriptor, []*types.TypeDescriptor{ptr}},
+		// int wl_display_roundtrip_queue(wl_display*, wl_event_queue*)
+		{"roundtrip_queue", &h.cifRoundtripQueue, i32, []*types.TypeDescriptor{ptr, ptr}},
 	}
 
 	for _, d := range cifDefs {
@@ -580,6 +652,16 @@ func (h *LibwaylandHandle) proxyDestroy(proxy uintptr) {
 	}
 	args := [1]unsafe.Pointer{unsafe.Pointer(&proxy)}
 	_ = ffi.CallFunction(&h.cifDestroy, h.fnProxyDestroy, nil, args[:])
+}
+
+// destroyAppQueue destroys the app event queue.
+func (h *LibwaylandHandle) destroyAppQueue() {
+	if h.appQueue == 0 || h.fnDestroyQueue == nil {
+		return
+	}
+	args := [1]unsafe.Pointer{unsafe.Pointer(&h.appQueue)}
+	ffi.CallFunction(&h.cifDestroyQueue, h.fnDestroyQueue, nil, args[:])
+	h.appQueue = 0
 }
 
 // disconnectDisplay calls wl_display_disconnect.

--- a/internal/platform/wayland/libwayland_csd.go
+++ b/internal/platform/wayland/libwayland_csd.go
@@ -219,6 +219,11 @@ func (h *LibwaylandHandle) DispatchCSDEvents() error {
 	if !h.csdActive {
 		return nil
 	}
+	// Hold displayMu to serialize CSD wl_display operations (flush, dispatch_queue_pending)
+	// with the render thread's Vulkan/GLES/Software WSI calls. Without this lock, CSD flush()
+	// races with any backend's internal wl_display_flush — causing SIGSEGV (ADR-041, #292).
+	h.displayMu.Lock()
+	defer h.displayMu.Unlock()
 	if err := h.flush(); err != nil {
 		return fmt.Errorf("csd dispatch: flush failed: %w", err)
 	}

--- a/internal/platform/wayland/libwayland_input.go
+++ b/internal/platform/wayland/libwayland_input.go
@@ -158,8 +158,12 @@ func (h *LibwaylandHandle) SetupToplevelListeners() error {
 	return h.addListener(h.xdgToplevel, uintptr(unsafe.Pointer(&inputToplevelListener[0])))
 }
 
-// DispatchDefaultQueue dispatches pending events on the default queue (non-blocking).
-// This handles xdg events, pointer, keyboard, touch — everything on the main display.
+// DispatchDefaultQueue dispatches pending events on our app queue (non-blocking).
+// Despite the legacy name, this dispatches the app queue (appQueue), NOT the
+// Wayland default queue. All our objects (registry, compositor, surface, xdg,
+// seat, pointer, keyboard) live on appQueue. The default queue is left
+// exclusively for Mesa Vulkan WSI's internal wl_buffer.release callbacks
+// (ADR-041 Phase 4, GLFW/SDL3 pattern).
 //
 // Holds displayMu for the duration of all wl_display operations to prevent races
 // with the render thread's Vulkan WSI calls (ADR-041 Phase 2).
@@ -171,11 +175,20 @@ func (h *LibwaylandHandle) DispatchDefaultQueue() error {
 		return err
 	}
 
-	// Non-blocking dispatch: prepare_read → read if data available → dispatch_pending.
+	// Non-blocking dispatch: prepare_read_queue → read if data available → dispatch_queue_pending.
+	// Using queue-specific variants ensures we never fire Mesa Vulkan WSI's
+	// internal callbacks (wl_buffer.release) which live on the default queue.
 	dispArgs := [1]unsafe.Pointer{unsafe.Pointer(&h.display)}
 
 	var prepResult int32
-	ffi.CallFunction(&h.cifPrepareRead, h.fnPrepareRead, unsafe.Pointer(&prepResult), dispArgs[:])
+	if h.appQueue != 0 {
+		// Queue-specific prepare_read: only locks for our app queue.
+		prepArgs := [2]unsafe.Pointer{unsafe.Pointer(&h.display), unsafe.Pointer(&h.appQueue)}
+		ffi.CallFunction(&h.cifPrepareReadQ, h.fnPrepareReadQueue, unsafe.Pointer(&prepResult), prepArgs[:])
+	} else {
+		// Fallback: no app queue (should not happen in normal operation).
+		ffi.CallFunction(&h.cifPrepareRead, h.fnPrepareRead, unsafe.Pointer(&prepResult), dispArgs[:])
+	}
 
 	if prepResult == 0 {
 		// Successfully locked for reading — check if data available
@@ -184,14 +197,20 @@ func (h *LibwaylandHandle) DispatchDefaultQueue() error {
 			var readResult int32
 			ffi.CallFunction(&h.cifReadEvents, h.fnReadEvents, unsafe.Pointer(&readResult), dispArgs[:])
 		} else {
-			// No data — cancel read lock
+			// No data — cancel read lock.
+			// wl_display_cancel_read is NOT queue-specific (cancels the global read lock).
 			ffi.CallFunction(&h.cifPrepareRead, h.fnCancelRead, nil, dispArgs[:])
 		}
 	}
 
-	// Dispatch any events that were read (or already queued)
+	// Dispatch events on our app queue only (never touches default queue).
 	var dispResult int32
-	ffi.CallFunction(&h.cifDispatchP, h.fnDispatchPend, unsafe.Pointer(&dispResult), dispArgs[:])
+	if h.appQueue != 0 {
+		queueArgs := [2]unsafe.Pointer{unsafe.Pointer(&h.display), unsafe.Pointer(&h.appQueue)}
+		ffi.CallFunction(&h.cifDispatchQP, h.fnDispatchQueueP, unsafe.Pointer(&dispResult), queueArgs[:])
+	} else {
+		ffi.CallFunction(&h.cifDispatchP, h.fnDispatchPend, unsafe.Pointer(&dispResult), dispArgs[:])
+	}
 
 	return nil
 }

--- a/internal/platform/wayland/libwayland_xdg.go
+++ b/internal/platform/wayland/libwayland_xdg.go
@@ -436,14 +436,24 @@ func (h *LibwaylandHandle) addListener(proxy uintptr, listener uintptr) error {
 	return nil
 }
 
-// roundtrip calls wl_display_roundtrip(display).
-// This flushes, reads events, and dispatches them (including our configure callback).
+// roundtrip calls wl_display_roundtrip_queue(display, appQueue) if the app queue
+// is active, otherwise falls back to wl_display_roundtrip(display).
+// Using the queue-specific variant ensures roundtrip only dispatches our objects'
+// events, never Mesa Vulkan WSI's internal callbacks (ADR-041 Phase 4).
 func (h *LibwaylandHandle) roundtrip() error {
 	var result int32
-	args := [1]unsafe.Pointer{unsafe.Pointer(&h.display)}
-	_ = ffi.CallFunction(&h.cifRoundtrip, h.fnRoundtrip, unsafe.Pointer(&result), args[:])
-	if result < 0 {
-		return fmt.Errorf("wl_display_roundtrip failed: %d", result)
+	if h.appQueue != 0 {
+		args := [2]unsafe.Pointer{unsafe.Pointer(&h.display), unsafe.Pointer(&h.appQueue)}
+		_ = ffi.CallFunction(&h.cifRoundtripQueue, h.fnRoundtripQueue, unsafe.Pointer(&result), args[:])
+		if result < 0 {
+			return fmt.Errorf("wl_display_roundtrip_queue failed: %d", result)
+		}
+	} else {
+		args := [1]unsafe.Pointer{unsafe.Pointer(&h.display)}
+		_ = ffi.CallFunction(&h.cifRoundtrip, h.fnRoundtrip, unsafe.Pointer(&result), args[:])
+		if result < 0 {
+			return fmt.Errorf("wl_display_roundtrip failed: %d", result)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Wayland Vulkan SIGSEGV fix: app event queue separation + CSD displayMu + wgpu v0.29.4. Enterprise pattern from GLFW/SDL3. All backends verified on Windows.