### PR TITLE
docs: enterprise README/CONTRIBUTING/ROADMAP/SECURITY update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,19 +193,21 @@ type(scope): description
 ```
 gogpu/
 ├── gpu/                    # GPU abstraction layer
-│   ├── backend.go          # Backend interface
-│   ├── types/              # WebGPU types
+│   ├── types/              # BackendType, GraphicsAPI enums
 │   └── backend/
-│       ├── rust/           # Rust backend (wgpu-native)
-│       └── native/         # Pure Go backend (gogpu/wgpu)
-├── internal/platform/      # Platform-specific code
-│   ├── windows/            # Win32
-│   ├── darwin/             # macOS Cocoa
-│   ├── wayland/            # Linux Wayland
-│   └── x11/                # Linux X11
-├── gmath/                  # Math primitives
+│       └── native/         # HAL backend creation (Vulkan/Metal/DX12/GLES/Software)
+├── internal/platform/      # Platform-specific windowing
+│   ├── platform_windows.go # Win32
+│   ├── platform_darwin.go  # macOS Cocoa
+│   ├── platform_linux.go   # X11 + Wayland
+│   ├── platform_browser.go # Browser/WASM
+│   ├── darwin/             # Objective-C runtime via goffi
+│   ├── wayland/            # libwayland-client FFI, CSD, xdg-shell, input
+│   └── x11/               # Pure Go X11 wire protocol
+├── gmath/                  # Vec2, Vec3, Vec4, Mat4, Color
 ├── window/                 # Window configuration
-├── input/                  # Input types
+├── input/                  # Keyboard and mouse input
+├── sound/                  # Platform system sounds
 ├── examples/               # Example applications
 └── scripts/                # Build/release scripts
 ```
@@ -214,12 +216,13 @@ gogpu/
 
 ## Platform Support
 
-| Platform | Windowing | Pure Go Backend | Status |
-|----------|-----------|-----------------|--------|
-| Windows | Win32 | Vulkan | Production |
-| Linux X11 | X11 | Vulkan | Community Testing |
-| Linux Wayland | Wayland | Vulkan | Community Testing |
-| macOS | Cocoa | Metal | Community Testing |
+| Platform | Windowing | GPU Backends | Status |
+|----------|-----------|-------------|--------|
+| Windows | Win32 | Vulkan, DX12, GLES, Software | Production |
+| Linux X11 | X11 (Pure Go wire protocol) | Vulkan, GLES, Software | Production |
+| Linux Wayland | Wayland (libwayland FFI) | Vulkan, GLES, Software | Production |
+| macOS | Cocoa (goffi ObjC runtime) | Metal, Software | Production |
+| Browser | WASM (syscall/js) | WebGPU | Production |
 
 ---
 
@@ -234,7 +237,7 @@ go test ./...
 ### Run Specific Package
 
 ```bash
-go test -v ./gpu/backend/gpu/...
+go test -v ./internal/platform/...
 ```
 
 ### Run with Race Detector
@@ -253,10 +256,12 @@ bash scripts/pre-release-check.sh
 
 ## Areas Where We Need Help
 
-- **Platform Testing** — Test on Linux X11, Wayland, macOS
-- **DX12 Backend** — Windows DirectX 12 implementation
+- **Platform Testing** — Test on Linux Wayland (GNOME, KDE, sway), macOS, Windows DX12/GLES
+- **GLES Testing** — Different GPU vendors (AMD, NVIDIA, Intel) and driver versions
 - **Documentation** — Examples, tutorials, API docs
-- **Performance** — Profiling, optimization
+- **Cursor Fallback** — `wl_pointer.set_cursor` with libwayland-cursor for compositors without `wp_cursor_shape_v1` (ADR-043)
+- **CSD Geometry** — Maximize/fullscreen decoration handling (#300)
+- **Performance** — Profiling, benchmarks, optimization
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@
 
 ## Overview
 
-**GoGPU** is a GPU computing framework for Go that provides a high-level API for graphics and compute operations. Built on [gogpu/wgpu](https://github.com/gogpu/wgpu) — the unified Go WebGPU package with three backends: Pure Go (default), Rust FFI (`-tags rust`), and Browser WASM.
+**GoGPU** is a Pure Go GPU application framework — windowing, input, lifecycle management, and platform abstraction for GPU-accelerated applications. Part of the [GoGPU ecosystem](https://github.com/gogpu) (1.1M+ LOC across 15 repositories).
+
+Built on [gogpu/wgpu](https://github.com/gogpu/wgpu) — the unified Go WebGPU package with three backends: Pure Go (default), Rust FFI (`-tags rust`), and Browser WASM.
 
 ### Key Features
 
@@ -134,7 +136,7 @@ app := gogpu.NewApp(gogpu.DefaultConfig().
     WithGraphicsAPI(gogpu.GraphicsAPIGLES))
 
 // Software backend — no GPU required, always available
-// Windows: renders to screen via GDI. Linux/macOS: headless.
+// Renders to screen (GDI, X11, Wayland SHM, macOS) or headless (CI/testing)
 app := gogpu.NewApp(gogpu.DefaultConfig().
     WithGraphicsAPI(gogpu.GraphicsAPISoftware))
 ```
@@ -557,11 +559,12 @@ User Application
        │
        ├─────────────────┐
        ▼                 ▼
-┌─────────────┐  ┌─────────────┐
-│  gogpu/wgpu │  │  Platform   │
-│ (Pure Go    │  │  Windowing  │
-│  WebGPU)    │  │ Win32/Cocoa │
-└──────┬──────┘  └─────────────┘
+┌─────────────┐  ┌──────────────────┐
+│  gogpu/wgpu │  │     Platform     │
+│ (Pure Go    │  │    Windowing     │
+│  WebGPU)    │  │ Win32/Cocoa/X11  │
+└──────┬──────┘  │ Wayland/Browser  │
+       │         └──────────────────┘
        │
  ┌─────┴─────┬─────┬─────┬─────────┐
  ▼           ▼     ▼     ▼         ▼
@@ -575,14 +578,15 @@ Vulkan     DX12  Metal  GLES   Software
 | `gogpu` (root) | App, Config, Context, Renderer, Texture |
 | `gpu/` | Backend selection (HAL-based) |
 | `gpu/types/` | BackendType, GraphicsAPI enums |
-| `gpu/backend/rust/` | Rust backend via wgpu-native FFI (opt-in, `-tags rust`) |
-| `gpu/backend/native/` | HAL backend creation (Vulkan/Metal selection) |
+| `gpu/backend/native/` | HAL backend creation (Vulkan/Metal/DX12/GLES/Software selection) |
 | `gmath/` | Vec2, Vec3, Vec4, Mat4, Color |
 | `window/` | Window configuration |
 | `input/` | Keyboard and mouse input |
 | `sound/` | Platform system sounds (Click, Alert, Error, Warning, Success) |
-| `internal/platform/` | Platform-specific windowing |
+| `internal/platform/` | Platform-specific windowing (Win32, Cocoa, X11, Wayland, Browser) |
 | `internal/thread/` | Multi-thread rendering (RenderLoop) |
+
+> **Rust backend:** Rust/wgpu-native selection lives inside [gogpu/wgpu](https://github.com/gogpu/wgpu) via build tags (ADR-038). Build with `-tags rust` and install wgpu-native: `go run github.com/go-webgpu/webgpu/cmd/setup@latest`
 
 ---
 
@@ -621,15 +625,26 @@ Native system window tabbing supported via `Config.WithTabbingMode(gogpu.Tabbing
 
 | Project | Description |
 |---------|-------------|
-| **gogpu/gogpu** | **GPU framework (this repo)** |
-| [gogpu/gpucontext](https://github.com/gogpu/gpucontext) | Shared interfaces (DeviceProvider, WindowProvider, PlatformProvider, EventSource) |
+| **gogpu/gogpu** | **Application framework — windowing, input, lifecycle (this repo)** |
+| [gogpu/wgpu](https://github.com/gogpu/wgpu) | Pure Go WebGPU implementation (Vulkan, Metal, DX12, GLES, Software) |
+| [gogpu/naga](https://github.com/gogpu/naga) | Shader compiler (WGSL → SPIR-V, MSL, GLSL, HLSL, DXIL) |
+| [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics — Skia-inspired rasterizer, GPU SDF, LCD ClearType |
+| [gogpu/ui](https://github.com/gogpu/ui) | GUI toolkit — 22+ widgets, 4 themes ([awesome-go](https://github.com/avelino/awesome-go)) |
+| [gogpu/g3d](https://github.com/gogpu/g3d) | 3D rendering engine — PBR, scene graph, GLTF |
+| [gogpu/compose](https://github.com/gogpu/compose) | Multi-process composition (Unix socket, LZ4, hot-plug) |
+| [gogpu/audio](https://github.com/gogpu/audio) | Pure Go audio engine — WASAPI, WAV, Mixer |
+| [gogpu/systray](https://github.com/gogpu/systray) | System tray — Windows, macOS, Linux, dark mode |
+| [gogpu/gpucontext](https://github.com/gogpu/gpucontext) | Shared interfaces (DeviceProvider, WindowProvider, EventSource) |
 | [gogpu/gputypes](https://github.com/gogpu/gputypes) | Shared WebGPU types (TextureFormat, BufferUsage, Limits) |
-| [gogpu/wgpu](https://github.com/gogpu/wgpu) | Pure Go WebGPU implementation |
-| [gogpu/naga](https://github.com/gogpu/naga) | Shader compiler (WGSL to SPIR-V, MSL, GLSL) |
-| [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics library |
-| [gogpu/ui](https://github.com/gogpu/ui) | GUI toolkit (planned) |
-| [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) | wgpu-native FFI bindings |
-| [go-webgpu/goffi](https://github.com/go-webgpu/goffi) | Pure Go FFI library |
+| [go-webgpu/goffi](https://github.com/go-webgpu/goffi) | Pure Go FFI library (no CGO) |
+| [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) | wgpu-native FFI bindings (Rust backend) |
+
+### Used By
+
+| Project | Description |
+|---------|-------------|
+| [born-ml/born](https://github.com/born-ml/born) | Pure Go ML framework — GPU-accelerated training and inference |
+| [ironwail-go](https://github.com/darkliquid/ironwail-go) | Quake 1 engine running on GoGPU Vulkan |
 
 ---
 
@@ -680,7 +695,7 @@ go test ./...
 | Contributor | Contributions |
 |-------------|---------------|
 | [@ppoage](https://github.com/ppoage) | macOS ARM64 (Apple Silicon) support — 3 merged PRs across gogpu, wgpu, and naga with ~3,500 lines of code. Made Metal backend work on M1/M4 |
-| [@lkmavi](https://github.com/lkmavi) | macOS native window tabbing (`NSWindow.tabbingMode`) — Config API, selectors, multi-window propagation, example |
+| [@lkmavi](https://github.com/lkmavi) | Star contributor — GLES Linux FFI fix (30+ GL calls), 4-phase renderer init, KDE Plasma AppMenu protocol, CSD cursor/hit-test, multiwindow Wayland fix, macOS native tabbing, native file dialogs + menus (all platforms). 10+ PRs across wgpu + gogpu |
 | [@sverrehu](https://github.com/sverrehu) | X11 remote display auth fix — found `.Xauthority` binary address mismatch ([#203](https://github.com/gogpu/gogpu/issues/203)), confirmed fix. macOS key event fix ([#194](https://github.com/gogpu/gogpu/issues/194)) |
 | [@JanGordon](https://github.com/JanGordon) | Documentation fix (wgpu) |
 
@@ -696,6 +711,8 @@ go test ./...
 | [@cyberbeast](https://github.com/cyberbeast) · Sandesh Gade | macOS Tahoe debugger — thorough Metal backend debugging on Apple M2 Max with detailed diagnostics |
 | [@crsolver](https://github.com/crsolver) | UI architecture advisor — significant input on the UI toolkit RFC with 8+ discussion comments |
 | [@neurlang](https://github.com/neurlang) | Wayland expert — author of [neurlang/wayland](https://github.com/neurlang/wayland), provided expert consultation on Wayland protocol issues |
+| [@z46-dev](https://github.com/z46-dev) · Evan Parker | Wayland champion — AMD Radeon RADV tester, filed [#292](https://github.com/gogpu/gogpu/issues/292) (Wayland SIGSEGV) and [#300](https://github.com/gogpu/gogpu/issues/300) (CSD geometry). Confirmed Software + Vulkan + GLES on native Linux |
+| [@omer316](https://github.com/omer316) | Pop!_OS tester — detailed Wayland traces for [#292](https://github.com/gogpu/gogpu/issues/292), confirmed fixes across all backends. First to ask about [sponsorship](https://opencollective.com/gogpu) |
 
 ### Early Adopters
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,12 +20,12 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 1. **Pure Go** — No CGO, easy cross-compilation, single binary deployment
 2. **WebGPU-First** — Follow W3C WebGPU specification
-3. **Dual Backend** — Rust (wgpu-native) or Pure Go (gogpu/wgpu)
+3. **Triple Backend** — Pure Go (default), Rust FFI (`-tags rust`), Browser WASM (ADR-038)
 4. **Enterprise-Ready** — Production-grade error handling and patterns
 
 ---
 
-## Current State: v0.41.7
+## Current State: v0.41.9
 
 ✅ **Production-ready** with full feature set:
 - **Hidden-then-show window creation** — GLFW/Ebiten/SDL3/Flutter pattern: window created hidden, shown after GPU init. Eliminates black flash and WM_SETFOCUS race on all platforms.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## Supported Versions
 
-GoGPU is currently in early development (v0.x.x).
+GoGPU follows semantic versioning. Security fixes are applied to the latest release.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2.x   | :white_check_mark: |
-| < 0.2.0 | :x:                |
+| 0.41.x  | :white_check_mark: |
+| < 0.41  | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -35,11 +35,12 @@ Instead, please report security issues via:
 
 ## Security Considerations
 
-GoGPU uses native GPU libraries via FFI. Users should be aware of:
+GoGPU uses platform libraries via FFI (goffi). Users should be aware of:
 
-1. **Native Library Loading** - Rust backend loads wgpu-native DLL/so/dylib
-2. **GPU Memory** - Ensure proper resource cleanup to avoid GPU memory leaks
-3. **Shader Code** - WGSL shaders are compiled by wgpu-native
+1. **Native Library Loading** — Pure Go backend loads platform libraries at runtime via `dlopen`: `libwayland-client.so` (Linux), `libvulkan.so`, `libEGL.so`, `user32.dll` (Windows), Cocoa frameworks (macOS). Rust backend (optional, `-tags rust`) loads `wgpu-native` shared library
+2. **GPU Memory** — Ensure proper resource cleanup (`Destroy()` or `TrackResource()`) to avoid GPU memory leaks
+3. **Shader Code** — WGSL shaders are compiled by naga (Pure Go) or wgpu-native (Rust backend)
+4. **Clipboard** — `ClipboardRead`/`ClipboardWrite` access system clipboard (X11 selection, Win32, Wayland `wl_data_device`)
 
 ## Security Contact
 


### PR DESCRIPTION
## Summary

Comprehensive documentation update to enterprise level across 4 files.

### README.md
- Overview: app framework (windowing, input, lifecycle), not generic "GPU computing framework"
- Ecosystem table: all 15 repos + "Used By" (Born ML, Ironwail-go)
- Architecture diagram: all 5 platforms (Win32/Cocoa/X11/Wayland/Browser)
- Software backend: screen presentation + headless (not "headless only")
- Package Structure: rust/ removed (ADR-038), Rust note with build instructions
- @lkmavi: updated to star contributor (10+ PRs)
- @z46-dev + @omer316: added to Community Champions

### CONTRIBUTING.md
- Project structure: accurate paths, no rust/, + sound/
- Platform Support: 5 platforms × all GPU backends
- Areas Where We Need Help: current priorities (cursor fallback, CSD, GLES testing)
- Fixed incorrect test path

### ROADMAP.md
- "Dual Backend" → "Triple Backend" (ADR-038)
- v0.41.7 → v0.41.9

### SECURITY.md
- Supported version: 0.2.x → 0.41.x
- Security considerations: Pure Go FFI (goffi), naga shader compilation, clipboard

## Test plan
- [x] `go build ./...` — pass
- [x] `golangci-lint run` — 0 issues
- [ ] CI green