### PR TITLE
fix: CSD maximize/fullscreen geometry — enterprise pattern (#300, v0.41.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.11] - 2026-06-14
+
+### Fixed
+
+- **Wayland CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed based on enterprise research (GTK4, winit/SCTK, SDL3/libdecor, GLFW consensus):
+  - Title bar at `(0, -tbH)` on maximize instead of `(0, 0)` — no longer covers Vulkan content (winit AdwaitaFrame pattern)
+  - Fullscreen state parsed from `xdg_toplevel` states (value 2) — was missing entirely
+  - ALL decorations destroyed on fullscreen, recreated on restore (unanimous enterprise pattern)
+  - `set_window_geometry` uses negative offset on maximize: `(0, -tbH, W, H+tbH)` (winit/libdecor pattern)
+  - `ResizeCSD` triggers on state change even without size change (fullscreen↔maximize at same resolution)
+
 ## [0.41.10] - 2026-06-14
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,9 +25,10 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.41.10
+## Current State: v0.41.11
 
 ✅ **Production-ready** with full feature set:
+- **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.
 - **Hidden-then-show window creation** — GLFW/Ebiten/SDL3/Flutter pattern: window created hidden, shown after GPU init. Eliminates black flash and WM_SETFOCUS race on all platforms.
 - **Universal App Lifecycle** — RenderTarget, QuitOnLastWindowClosed, AppLifecycle enum (5 states), surface/lifecycle callbacks (ADR-026, Phases 1-3)
 - **macOS system menu** — `SetMenu()`, `SetCustomMenu()`, `MenuRole`, native menu bar (ADR-022, @lkmavi)

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -1448,13 +1448,14 @@ func (p *waylandPlatform) setupInputCallbacks() {
 				newWidth := int(width)
 				newHeight := int(height)
 
-				// Geometry = content area (0, 0, contentW, contentH).
-				// Configure matches geometry → content size directly.
-				// On maximize: compositor sends full screen size, but we need room
-				// for the title bar inside the screen. Subtract only tbH.
+				// Content size from configure dimensions (winit/GTK4 enterprise pattern):
+				//   Normal:     configure = content size (geometry at 0,0)
+				//   Maximize:   configure = geometry size, subtract tbH for content
+				//   Fullscreen: configure = full screen, no subtraction (all CSD hidden)
 				vulkanW := newWidth
 				vulkanH := newHeight
-				if isMaximized && p.libwl != nil && p.libwl.CSDActive() {
+				isFullscreen := p.libwl != nil && p.libwl.CSDActive() && p.libwl.IsFullscreen()
+				if !isFullscreen && isMaximized && p.libwl != nil && p.libwl.CSDActive() {
 					tbH, _ := p.libwl.CSDBorders()
 					vulkanH = newHeight - tbH
 					if vulkanH < 1 {

--- a/internal/platform/wayland/csd_painter.go
+++ b/internal/platform/wayland/csd_painter.go
@@ -39,12 +39,13 @@ type CSDButtonState struct {
 
 // CSDState holds the current decoration state for painting.
 type CSDState struct {
-	Title     string
-	Focused   bool
-	Maximized bool
-	Close     CSDButtonState
-	Maximize  CSDButtonState
-	Minimize  CSDButtonState
+	Title      string
+	Focused    bool
+	Maximized  bool
+	Fullscreen bool
+	Close      CSDButtonState
+	Maximize   CSDButtonState
+	Minimize   CSDButtonState
 }
 
 // CSDPainter renders CSD decoration pixels into ARGB8888 buffers.

--- a/internal/platform/wayland/libwayland_csd.go
+++ b/internal/platform/wayland/libwayland_csd.go
@@ -192,6 +192,11 @@ func (h *LibwaylandHandle) IsMaximized() bool {
 	return h.csdState.Maximized
 }
 
+// IsFullscreen returns true if the window is currently fullscreen.
+func (h *LibwaylandHandle) IsFullscreen() bool {
+	return h.csdState.Fullscreen
+}
+
 // CSDBorders returns the CSD border dimensions: titleBarHeight, borderWidth.
 // Used to subtract CSD borders from configure dimensions (GLFW pattern).
 func (h *LibwaylandHandle) CSDBorders() (titleBarH, borderW int) {
@@ -508,11 +513,12 @@ func (h *LibwaylandHandle) repaintCSDTitleBar() {
 //
 // Called from xdgSurfaceConfigureCb after ack_configure and before the parent
 // surface commit. Subsurfaces in sync mode cache their commits until parent commit.
-func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit // CSD resize with maximize/restore transitions
+func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit // CSD resize with maximize/restore/fullscreen transitions
 	if !h.csdActive || h.csdPainter == nil {
 		return
 	}
-	if contentW == h.csdContentW && contentH == h.csdContentH {
+	sizeChanged := contentW != h.csdContentW || contentH != h.csdContentH
+	if !sizeChanged && !h.csdPendingRepaint {
 		return
 	}
 
@@ -523,10 +529,11 @@ func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit
 	bW := h.csdPainter.BorderWidth()
 	totalW := contentW + bW*2
 
-	// Dimensions and positions for each subsurface.
-	// On maximize: title bar at (0,0) inside window, borders resize to screen edges.
-	// Content starts below title bar. All decorations visible (GLFW pattern).
-	// On normal: title bar above content at (-bW, -tbH), borders around content.
+	// Subsurface layout per window state (winit/SCTK + GTK4 enterprise pattern):
+	//   Normal:     title bar at (-bW, -tbH), all 4 borders visible
+	//   Maximize:   title bar at (0, -tbH), side/bottom borders destroyed
+	//   Fullscreen: ALL decorations destroyed (title bar + borders)
+	fullscreen := h.csdState.Fullscreen
 	maximized := h.csdState.Maximized
 	specs := [4]struct {
 		w, h int
@@ -537,34 +544,29 @@ func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit
 		{bW, contentH, int32(contentW), 0},        // right border
 		{totalW, bW, -int32(bW), int32(contentH)}, // bottom border
 	}
-	if maximized {
-		// Title bar at (0,0) inside window, full content width.
-		// Borders at screen edges around content area.
+	if maximized && !fullscreen {
+		// Title bar at (0, -tbH) — above content, no side borders.
+		// Content starts at (0,0). Geometry includes title bar via negative offset.
 		specs[0] = struct {
 			w, h int
 			x, y int32
-		}{contentW, tbH, 0, 0}
-		specs[1] = struct {
-			w, h int
-			x, y int32
-		}{bW, contentH, -int32(bW), int32(tbH)}
-		specs[2] = struct {
-			w, h int
-			x, y int32
-		}{bW, contentH, int32(contentW), int32(tbH)}
-		specs[3] = struct {
-			w, h int
-			x, y int32
-		}{contentW, bW, 0, int32(tbH + contentH)}
+		}{contentW, tbH, 0, -int32(tbH)}
 	}
 
 	state := h.csdState
 
+	// Determine which decorations should be destroyed.
+	// Fullscreen: destroy ALL (including title bar) — enterprise consensus.
+	// Maximize: destroy borders only, keep title bar — winit/GTK4 pattern.
+	shouldDestroy := func(i int) bool {
+		if fullscreen {
+			return true
+		}
+		return maximized && i != csdTop
+	}
+
 	for i, spec := range specs {
-		// For borders (not title bar) on maximize: destroy surface+subsurface
-		// to clear ghost pixels on WSLg. Recreate on restore.
-		// Title bar (i==csdTop) is NEVER destroyed — pointer state preserved for buttons.
-		if maximized && i != csdTop && h.csdSurfaces[i] != 0 {
+		if shouldDestroy(i) && h.csdSurfaces[i] != 0 {
 			if h.csdBuffers[i] != 0 {
 				h.marshalVoid(h.csdBuffers[i], 0)
 				h.csdBuffers[i] = 0
@@ -589,8 +591,8 @@ func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit
 			continue
 		}
 
-		// Recreate border surface+subsurface after maximize→restore.
-		if !maximized && i != csdTop && h.csdSurfaces[i] == 0 {
+		// Recreate surface+subsurface after maximize→restore or fullscreen→restore.
+		if !shouldDestroy(i) && h.csdSurfaces[i] == 0 {
 			surf, err := h.marshalConstructor(h.compositor, 0, h.surfaceInterface)
 			if err != nil {
 				slog.Warn("CSD restore: create surface failed", "edge", i, "err", err)

--- a/internal/platform/wayland/libwayland_input.go
+++ b/internal/platform/wayland/libwayland_input.go
@@ -575,15 +575,20 @@ func inputToplevelConfigureCb(data, toplevel, width, height, states uintptr) {
 		return
 	}
 
-	// Parse states array for maximized (1) and activated (4) states.
+	// Parse states array for maximized (1), fullscreen (2), and activated (4).
 	// wl_array layout on 64-bit: { uint64 size, uint64 alloc, uintptr data }
 	var activated bool
 	if states != 0 {
 		activated = wlArrayContainsUint32(states, 4) // xdg_toplevel_state::activated
 		if h.csdActive {
-			maximized := wlArrayContainsUint32(states, 1) // xdg_toplevel_state::maximized
+			maximized := wlArrayContainsUint32(states, 1)  // xdg_toplevel_state::maximized
+			fullscreen := wlArrayContainsUint32(states, 2) // xdg_toplevel_state::fullscreen
 			if h.csdState.Maximized != maximized {
 				h.csdState.Maximized = maximized
+				h.csdPendingRepaint = true
+			}
+			if h.csdState.Fullscreen != fullscreen {
+				h.csdState.Fullscreen = fullscreen
 				h.csdPendingRepaint = true
 			}
 		}

--- a/internal/platform/wayland/libwayland_xdg.go
+++ b/internal/platform/wayland/libwayland_xdg.go
@@ -233,22 +233,26 @@ func xdgSurfaceConfigureCb(data, xdgSurface, serial uintptr) {
 		h.ResizeCSD(h.csdPendingResizeW, h.csdPendingResizeH)
 	}
 
-	// Set window geometry = content area (0, 0, contentW, contentH).
-	// CSD subsurfaces are OUTSIDE geometry (title bar at negative offset, borders at edges).
-	// Configure events match geometry → content size directly, NO border subtraction.
-	// Negative origin (-bW, -tbH) causes resize jump on WSLg — avoid it.
+	// Window geometry per state (winit/libdecor enterprise pattern):
+	//   Normal:     (0, 0, contentW, contentH) — title bar outside geometry
+	//   Maximize:   (0, -tbH, contentW, contentH+tbH) — title bar inside geometry via negative offset
+	//   Fullscreen: (0, 0, configW, configH) — no decorations, full area
 	if h.csdActive && h.csdContentW > 0 {
+		geoX := int32(0)
 		geoY := int32(0)
+		geoW := h.csdContentW
 		geoH := h.csdContentH
-		if h.csdState.Maximized {
-			// On maximize: title bar at (0,0) inside window. Geometry must include
-			// title bar area so compositor positions window with title bar visible.
+		if h.csdState.Fullscreen {
+			geoW = h.configuredW
+			geoH = h.configuredH
+		} else if h.csdState.Maximized {
 			tbH := h.csdPainter.TitleBarHeight()
+			geoY = -int32(tbH)
 			geoH = h.csdContentH + tbH
 		}
-		slog.Debug("set_window_geometry CSD", "x", 0, "y", geoY, "w", h.csdContentW, "h", geoH)
-		h.marshalVoid(h.xdgSurface, 3, 0, uintptr(uint32(geoY)),
-			uintptr(uint32(h.csdContentW)), uintptr(uint32(geoH)))
+		slog.Debug("set_window_geometry CSD", "x", geoX, "y", geoY, "w", geoW, "h", geoH)
+		h.marshalVoid(h.xdgSurface, 3, uintptr(uint32(geoX)), uintptr(uint32(geoY)),
+			uintptr(uint32(geoW)), uintptr(uint32(geoH)))
 	} else if h.configuredW > 0 && h.configuredH > 0 {
 		slog.Debug("set_window_geometry non-CSD", "w", h.configuredW, "h", h.configuredH)
 		h.marshalVoid(h.xdgSurface, 3, 0, 0,


### PR DESCRIPTION
## Summary

Fixes 5 CSD (Client-Side Decorations) geometry bugs on Wayland maximize/fullscreen, reported in #300 by @z46-dev.

Based on deep enterprise research of GTK4, winit/SCTK, SDL3/libdecor, and GLFW source code — all four frameworks agree on the patterns implemented here.

### Bugs Fixed

1. **Title bar covers content on maximize** — positioned at `(0, 0)` instead of `(0, -tbH)`. Now uses winit/SCTK negative offset model: title bar above content origin.
2. **Fullscreen state not parsed** — `xdg_toplevel_state::fullscreen` (value 2) was never read from configure states array. Added alongside existing maximized (1) and activated (4) parsing.
3. **Decorations visible on fullscreen** — no fullscreen handling existed. Now destroys ALL decoration subsurfaces on fullscreen (GTK4/winit/GLFW unanimous pattern), recreates on restore.
4. **`set_window_geometry` wrong on maximize** — was `(0, 0, W, H+tbH)`, now `(0, -tbH, W, H+tbH)` (winit/libdecor pattern). Fullscreen: `(0, 0, configW, configH)`.
5. **State change without size change skipped** — `ResizeCSD` now triggers on `csdPendingRepaint` even when dimensions unchanged (e.g., fullscreen↔maximize transition at same resolution).

### Files Changed

- `internal/platform/wayland/csd_painter.go` — `Fullscreen` field added to `CSDState`
- `internal/platform/wayland/libwayland_input.go` — parse fullscreen state (2) in configure callback
- `internal/platform/wayland/libwayland_csd.go` — `IsFullscreen()`, title bar at `(0,-tbH)` on maximize, destroy ALL on fullscreen
- `internal/platform/wayland/libwayland_xdg.go` — negative offset geometry model
- `internal/platform/platform_linux.go` — fullscreen: no border subtraction from configure size

## Test plan

- [x] Build clean: Linux, Windows, macOS
- [x] Lint 0 issues: `GOOS=linux golangci-lint run`
- [x] WSL2 triangle: launches, renders, exit 0
- [ ] @z46-dev: maximize fills screen, no border artifacts (Sway, AMD Radeon)
- [ ] @z46-dev: fullscreen has no visible decorations
- [ ] @z46-dev: restore from maximize/fullscreen restores CSD correctly
- [ ] @lkmavi: verify on additional compositor
