### PR TITLE
fix/300 : Fix artefact tfrom GNOME : Fix hiden bar macos

### DIFF
--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -332,11 +332,13 @@ func (w *Window) SetMetalLayer(layer ID) {
 		return
 	}
 
-	// Enable layer backing
-	w.contentView.SendBool(selectors.setWantsLayer, true)
-
-	// Set the layer
+	// Layer-hosting mode: setLayer: FIRST, then setWantsLayer:YES.
+	// Apple docs require this exact order to enter layer-hosting mode.
+	// Reversing the order creates layer-backed mode where AppKit manages
+	// the layer lifecycle — on macOS 15+ this causes the Metal content
+	// to composite above the title bar, making it invisible.
 	w.contentView.SendPtr(selectors.setLayer, layer.Ptr())
+	w.contentView.SendBool(selectors.setWantsLayer, true)
 
 	w.metalLayer = layer
 }

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -852,8 +852,15 @@ func (p *waylandPlatform) initSingleConnection(config Config) error { //nolint:g
 		}
 	}
 
-	// Activate CSD if SSD was not available and window is not frameless
-	if decorGlobal == nil && !config.Frameless {
+	// Activate CSD if SSD was not negotiated and window is not frameless.
+	// Two cases require CSD:
+	//   1. zxdg_decoration_manager_v1 not advertised (GNOME, wlroots default) — no SSD protocol.
+	//   2. Protocol exists but compositor responded CLIENT_SIDE (KDE Plasma may do this even
+	//      after we request SERVER_SIDE). mode==0 (configure never received) is also safe to
+	//      treat as CLIENT_SIDE — falls back to CSD.
+	const decorModeServerSide = 2
+	needCSD := decorGlobal == nil || libwl.DecorationMode() != decorModeServerSide
+	if needCSD && !config.Frameless {
 		if err := p.initCSD(config); err != nil {
 			logger().Warn("CSD initialization failed, running without decorations", "err", err)
 		}

--- a/internal/platform/wayland/libwayland.go
+++ b/internal/platform/wayland/libwayland.go
@@ -84,6 +84,11 @@ type LibwaylandHandle struct {
 	// causing SIGSEGV in vkQueuePresentKHR (ADR-041 Phase 1).
 	initialConfigureReceived bool
 
+	// decorMode holds the mode from zxdg_toplevel_decoration_v1.configure.
+	// 0=unset (never received), 1=CLIENT_SIDE (app must draw CSD), 2=SERVER_SIDE.
+	// KDE Plasma may respond CLIENT_SIDE even after we request SERVER_SIDE.
+	decorMode uint32
+
 	// App event queue — ALL our Wayland objects (registry, compositor, surface,
 	// xdg, seat, pointer, keyboard, etc.) live on this queue. The default queue
 	// is left exclusively for Mesa Vulkan WSI's internal wl_buffer.release

--- a/internal/platform/wayland/libwayland_csd.go
+++ b/internal/platform/wayland/libwayland_csd.go
@@ -150,7 +150,8 @@ func (h *LibwaylandHandle) SetupCSD(subcompName, subcompVersion, shmName, shmVer
 		h.marshalVoid(surf, 6)                                                         // commit
 	}
 
-	// Set window geometry so compositor knows content area (excludes CSD borders).
+	// Set window geometry to content area only (libdecor/GLFW/winit enterprise pattern).
+	// CSD decorations extend outside this region via negative subsurface offsets.
 	h.marshalVoid(h.xdgSurface, 3, 0, 0, uintptr(uint32(contentW)), uintptr(uint32(contentH)))
 
 	// Commit parent surface (subsurfaces apply atomically in sync mode)
@@ -506,10 +507,12 @@ func (h *LibwaylandHandle) repaintCSDTitleBar() {
 // ResizeCSD updates all 4 CSD subsurface buffers and positions when the
 // content area dimensions change (maximize, restore, interactive resize).
 //
-// GLFW pattern: surfaces and subsurfaces are NEVER destroyed (only on window
-// close). This preserves pointer state and avoids stale coordinates after
-// maximize→restore transitions. All 4 decorations remain visible at all times,
-// including when maximized (title bar + borders at screen edges).
+// GLFW pattern: surfaces and subsurfaces are NEVER destroyed on hide (only on
+// window close). Hiding attaches a null buffer and releases SHM memory; the
+// surface object stays alive so the null state is applied atomically by the
+// parent commit that follows. Destroying before the parent commit discards the
+// pending null state, leaving the previous frame visible for one compositor
+// cycle (the artifact reported in issue #300).
 //
 // Called from xdgSurfaceConfigureCb after ack_configure and before the parent
 // surface commit. Subsurfaces in sync mode cache their commits until parent commit.
@@ -531,8 +534,8 @@ func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit
 
 	// Subsurface layout per window state (winit/SCTK + GTK4 enterprise pattern):
 	//   Normal:     title bar at (-bW, -tbH), all 4 borders visible
-	//   Maximize:   title bar at (0, -tbH), side/bottom borders destroyed
-	//   Fullscreen: ALL decorations destroyed (title bar + borders)
+	//   Maximize:   title bar at (0, -tbH), borders null-attached (hidden)
+	//   Fullscreen: ALL decorations null-attached (hidden, including title bar)
 	fullscreen := h.csdState.Fullscreen
 	maximized := h.csdState.Maximized
 	specs := [4]struct {
@@ -555,10 +558,9 @@ func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit
 
 	state := h.csdState
 
-	// Determine which decorations should be destroyed.
-	// Fullscreen: destroy ALL (including title bar) — enterprise consensus.
-	// Maximize: destroy borders only, keep title bar — winit/GTK4 pattern.
-	shouldDestroy := func(i int) bool {
+	// Fullscreen: hide ALL decorations. Maximize: hide borders only, keep title bar.
+	// Surfaces stay alive — see docstring for why null-attach beats destroy.
+	shouldHide := func(i int) bool {
 		if fullscreen {
 			return true
 		}
@@ -566,33 +568,34 @@ func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit
 	}
 
 	for i, spec := range specs {
-		if shouldDestroy(i) && h.csdSurfaces[i] != 0 {
-			if h.csdBuffers[i] != 0 {
-				h.marshalVoid(h.csdBuffers[i], 0)
-				h.csdBuffers[i] = 0
+		if shouldHide(i) {
+			if h.csdSurfaces[i] != 0 {
+				h.marshalVoid(h.csdSurfaces[i], 1, 0, 0, 0) // wl_surface.attach(null, 0, 0)
+				h.marshalVoid(h.csdSurfaces[i], 6)           // wl_surface.commit (cached, sync mode)
+				// Release SHM resources — not needed while hidden; recreated on restore.
+				if h.csdBuffers[i] != 0 {
+					h.marshalVoid(h.csdBuffers[i], 0)
+					h.csdBuffers[i] = 0
+				}
+				if h.csdPools[i] != 0 {
+					h.marshalVoid(h.csdPools[i], 1)
+					h.csdPools[i] = 0
+				}
+				if h.csdData[i] != nil {
+					unix.Munmap(h.csdData[i])
+					h.csdData[i] = nil
+				}
+				if h.csdFDs[i] >= 0 {
+					unix.Close(h.csdFDs[i])
+					h.csdFDs[i] = -1
+				}
+				h.csdSizes[i] = [2]int{0, 0}
+				// csdSurfaces[i] and csdSubsurf[i] intentionally kept alive.
 			}
-			if h.csdPools[i] != 0 {
-				h.marshalVoid(h.csdPools[i], 1)
-				h.csdPools[i] = 0
-			}
-			if h.csdData[i] != nil {
-				unix.Munmap(h.csdData[i])
-				h.csdData[i] = nil
-			}
-			if h.csdFDs[i] >= 0 {
-				unix.Close(h.csdFDs[i])
-				h.csdFDs[i] = -1
-			}
-			h.csdSizes[i] = [2]int{0, 0}
-			h.marshalVoid(h.csdSubsurf[i], 0)
-			h.csdSubsurf[i] = 0
-			h.marshalVoid(h.csdSurfaces[i], 0)
-			h.csdSurfaces[i] = 0
 			continue
 		}
 
-		// Recreate surface+subsurface after maximize→restore or fullscreen→restore.
-		if !shouldDestroy(i) && h.csdSurfaces[i] == 0 {
+		if h.csdSurfaces[i] == 0 {
 			surf, err := h.marshalConstructor(h.compositor, 0, h.surfaceInterface)
 			if err != nil {
 				slog.Warn("CSD restore: create surface failed", "edge", i, "err", err)
@@ -617,7 +620,6 @@ func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit
 			continue
 		}
 
-		// Update SHM buffer only if dimensions changed.
 		oldW, oldH := h.csdSizes[i][0], h.csdSizes[i][1]
 		if h.csdBuffers[i] == 0 || oldW != spec.w || oldH != spec.h {
 			h.resizeCSDEdge(i, spec.w, spec.h, state)

--- a/internal/platform/wayland/libwayland_csd.go
+++ b/internal/platform/wayland/libwayland_csd.go
@@ -571,7 +571,7 @@ func (h *LibwaylandHandle) ResizeCSD(contentW, contentH int) { //nolint:gocognit
 		if shouldHide(i) {
 			if h.csdSurfaces[i] != 0 {
 				h.marshalVoid(h.csdSurfaces[i], 1, 0, 0, 0) // wl_surface.attach(null, 0, 0)
-				h.marshalVoid(h.csdSurfaces[i], 6)           // wl_surface.commit (cached, sync mode)
+				h.marshalVoid(h.csdSurfaces[i], 6)          // wl_surface.commit (cached, sync mode)
 				// Release SHM resources — not needed while hidden; recreated on restore.
 				if h.csdBuffers[i] != 0 {
 					h.marshalVoid(h.csdBuffers[i], 0)

--- a/internal/platform/wayland/libwayland_input.go
+++ b/internal/platform/wayland/libwayland_input.go
@@ -583,13 +583,30 @@ func inputToplevelConfigureCb(data, toplevel, width, height, states uintptr) {
 		if h.csdActive {
 			maximized := wlArrayContainsUint32(states, 1)  // xdg_toplevel_state::maximized
 			fullscreen := wlArrayContainsUint32(states, 2) // xdg_toplevel_state::fullscreen
+			stateChanged := false
 			if h.csdState.Maximized != maximized {
 				h.csdState.Maximized = maximized
 				h.csdPendingRepaint = true
+				stateChanged = true
 			}
 			if h.csdState.Fullscreen != fullscreen {
 				h.csdState.Fullscreen = fullscreen
 				h.csdPendingRepaint = true
+				stateChanged = true
+			}
+			if h.csdState.Focused != activated {
+				h.csdState.Focused = activated
+				h.csdPendingRepaint = true
+			}
+
+			// Force CSD resize on state change even when dimensions don't change
+			// (e.g. maximize→fullscreen at same screen resolution). Without this,
+			// OnConfigure sees no size delta and skips SetPendingCSDResize, leaving
+			// the title bar visible in fullscreen (issue #300).
+			if stateChanged && h.csdContentW > 0 && !h.csdPendingResize {
+				h.csdPendingResize = true
+				h.csdPendingResizeW = h.csdContentW
+				h.csdPendingResizeH = h.csdContentH
 			}
 		}
 	}

--- a/internal/platform/wayland/libwayland_xdg.go
+++ b/internal/platform/wayland/libwayland_xdg.go
@@ -293,10 +293,10 @@ func xdgWmBasePingCb(data, wmBase, serial uintptr) {
 // Listener arrays (package-level, must outlive the proxy).
 // Each is an array of function pointers, one per event.
 var (
-	xdgSurfaceListener  [1]uintptr // [0] = configure callback
-	xdgWmBaseListener   [1]uintptr // [0] = ping callback
+	xdgSurfaceListener    [1]uintptr // [0] = configure callback
+	xdgWmBaseListener     [1]uintptr // [0] = ping callback
 	toplevelDecorListener [1]uintptr // [0] = configure callback
-	listenersOnce       sync.Once
+	listenersOnce         sync.Once
 )
 
 func initXdgListeners() {

--- a/internal/platform/wayland/libwayland_xdg.go
+++ b/internal/platform/wayland/libwayland_xdg.go
@@ -197,12 +197,13 @@ func initXdgInterfaces() {
 	})
 }
 
-// xdgHandlesMu guards the two maps below, which route xdg callbacks to the
+// xdgHandlesMu guards the maps below, which route xdg callbacks to the
 // correct LibwaylandHandle when multiple windows are open simultaneously.
 var (
-	xdgHandlesMu    sync.Mutex
-	xdgSurfaceHndls = make(map[uintptr]*LibwaylandHandle) // wl_surface proxy → handle
-	xdgWmBaseHndls  = make(map[uintptr]*LibwaylandHandle) // xdg_wm_base proxy → handle
+	xdgHandlesMu       sync.Mutex
+	xdgSurfaceHndls    = make(map[uintptr]*LibwaylandHandle) // wl_surface proxy → handle
+	xdgWmBaseHndls     = make(map[uintptr]*LibwaylandHandle) // xdg_wm_base proxy → handle
+	toplevelDecorHndls = make(map[uintptr]*LibwaylandHandle) // zxdg_toplevel_decoration_v1* proxy → handle
 )
 
 // xdgSurfaceConfigureCb handles xdg_surface.configure(data, xdg_surface, serial).
@@ -229,15 +230,21 @@ func xdgSurfaceConfigureCb(data, xdgSurface, serial uintptr) {
 	// This is the GLFW pattern: ack_configure -> resizeWindow -> commit.
 	if h.csdPendingResize {
 		h.csdPendingResize = false
-		h.csdPendingRepaint = false // resize already repaints all surfaces
+		// Clear csdPendingRepaint AFTER ResizeCSD: state-change-triggered resizes
+		// (same dimensions, different maximize/fullscreen state) set csdPendingRepaint=true
+		// in inputToplevelConfigureCb so ResizeCSD bypasses its early-return guard.
+		// Clearing before the call would drop that signal and skip the hide/show logic
+		// (issue #300).
 		h.ResizeCSD(h.csdPendingResizeW, h.csdPendingResizeH)
+		h.csdPendingRepaint = false
 	}
 
 	// Window geometry per state (winit/libdecor enterprise pattern):
-	//   Normal:     (0, 0, contentW, contentH) — title bar outside geometry
+	//   Normal:     (0, 0, contentW, contentH) — title bar outside geometry (CSD standard)
 	//   Maximize:   (0, -tbH, contentW, contentH+tbH) — title bar inside geometry via negative offset
 	//   Fullscreen: (0, 0, configW, configH) — no decorations, full area
 	if h.csdActive && h.csdContentW > 0 {
+		tbH := h.csdPainter.TitleBarHeight()
 		geoX := int32(0)
 		geoY := int32(0)
 		geoW := h.csdContentW
@@ -246,7 +253,6 @@ func xdgSurfaceConfigureCb(data, xdgSurface, serial uintptr) {
 			geoW = h.configuredW
 			geoH = h.configuredH
 		} else if h.csdState.Maximized {
-			tbH := h.csdPainter.TitleBarHeight()
 			geoY = -int32(tbH)
 			geoH = h.csdContentH + tbH
 		}
@@ -287,16 +293,33 @@ func xdgWmBasePingCb(data, wmBase, serial uintptr) {
 // Listener arrays (package-level, must outlive the proxy).
 // Each is an array of function pointers, one per event.
 var (
-	xdgSurfaceListener [1]uintptr // [0] = configure callback
-	xdgWmBaseListener  [1]uintptr // [0] = ping callback
-	listenersOnce      sync.Once
+	xdgSurfaceListener  [1]uintptr // [0] = configure callback
+	xdgWmBaseListener   [1]uintptr // [0] = ping callback
+	toplevelDecorListener [1]uintptr // [0] = configure callback
+	listenersOnce       sync.Once
 )
 
 func initXdgListeners() {
 	listenersOnce.Do(func() {
 		xdgSurfaceListener[0] = ffi.NewCallback(xdgSurfaceConfigureCb)
 		xdgWmBaseListener[0] = ffi.NewCallback(xdgWmBasePingCb)
+		toplevelDecorListener[0] = ffi.NewCallback(decorConfigureCb)
 	})
+}
+
+// decorConfigureCb handles zxdg_toplevel_decoration_v1.configure(data, decor, mode).
+// Called before xdg_surface.configure when the compositor sets the decoration mode.
+// mode: 1 = CLIENT_SIDE (app must draw CSD), 2 = SERVER_SIDE (compositor draws SSD).
+// KDE Plasma may honor the SERVER_SIDE request or override to CLIENT_SIDE; without
+// this listener the app never knows the compositor rejected SSD.
+func decorConfigureCb(data, decoration, mode uintptr) {
+	xdgHandlesMu.Lock()
+	h := toplevelDecorHndls[decoration]
+	xdgHandlesMu.Unlock()
+	if h != nil {
+		h.decorMode = uint32(mode)
+		slog.Debug("zxdg_toplevel_decoration.configure", "mode", mode)
+	}
 }
 
 // setupXdgRole gives the C wl_surface an xdg_toplevel role.
@@ -369,6 +392,9 @@ func (h *LibwaylandHandle) setupXdgRole(xdgName, xdgVersion, decorName, decorVer
 	xdgHandlesMu.Lock()
 	xdgSurfaceHndls[h.xdgSurface] = h
 	xdgWmBaseHndls[h.xdgWmBase] = h
+	if h.toplevelDecor != 0 {
+		toplevelDecorHndls[h.toplevelDecor] = h
+	}
 	xdgHandlesMu.Unlock()
 
 	// Block until compositor sends xdg_surface.configure (ADR-041 configure gate).
@@ -473,8 +499,10 @@ func (h *LibwaylandHandle) roundtrip() error {
 }
 
 // setupDecorations binds zxdg_decoration_manager_v1 and requests server-side
-// decorations for the C xdg_toplevel. Non-fatal: if binding fails, the window
-// simply won't have compositor-drawn decorations.
+// decorations for the C xdg_toplevel. Registers a listener so that
+// decorConfigureCb records the compositor's actual mode (SERVER_SIDE or
+// CLIENT_SIDE) into h.decorMode — callers check DecorationMode() after
+// WaitForConfigure to decide whether CSD is needed.
 func (h *LibwaylandHandle) setupDecorations(decorName, decorVersion uint32) {
 	version := decorVersion
 	if version > 1 {
@@ -494,8 +522,22 @@ func (h *LibwaylandHandle) setupDecorations(decorName, decorVersion uint32) {
 	}
 	h.toplevelDecor = decoration
 
+	// Register configure listener BEFORE set_mode so we don't miss the event.
+	// The compositor sends configure before xdg_surface.configure, so it arrives
+	// within the same WaitForConfigure roundtrip batch.
+	initXdgListeners()
+	_ = h.addListener(decoration, uintptr(unsafe.Pointer(&toplevelDecorListener[0])))
+
 	// set_mode(SERVER_SIDE=2): opcode 1, signature "u"
 	h.marshalVoid(decoration, 1, 2)
+}
+
+// DecorationMode returns the decoration mode agreed by the compositor.
+// 0 = protocol not available or configure not yet received (treat as CLIENT_SIDE).
+// 1 = CLIENT_SIDE (app must draw CSD).
+// 2 = SERVER_SIDE (compositor draws decorations; CSD not needed).
+func (h *LibwaylandHandle) DecorationMode() uint32 {
+	return h.decorMode
 }
 
 // SetTitle sets the window title on the C xdg_toplevel.
@@ -582,6 +624,7 @@ func (h *LibwaylandHandle) UnregisterXdgProxies() {
 	xdgHandlesMu.Lock()
 	delete(xdgSurfaceHndls, h.xdgSurface)
 	delete(xdgWmBaseHndls, h.xdgWmBase)
+	delete(toplevelDecorHndls, h.toplevelDecor)
 	xdgHandlesMu.Unlock()
 }
 


### PR DESCRIPTION
- darwin/window.go — setLayer before setWantsLayer:YES → fixes invisible title bar on macOS (layer-hosting vs. layer-backed mode)
- libwayland_input.go — forced csdPendingResize on state change → maximize→fullscreen handling at the same resolution
- libwayland_csd.go — shouldDestroy → shouldHide, surfaces remain alive → fixes GNOME artifact: null state is applied atomically by the parent commit
- libwayland_xdg.go — csdPendingRepaint = false moved after ResizeCSD → allows state change without resizing to bypass early return