### PR TITLE
fix: CSD GNOME artifact + macOS layer-hosting + deps (v0.41.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.12] - 2026-06-15
+
+### Fixed
+
+- **Wayland CSD GNOME artifact** (@lkmavi, #300) — null-attach instead of surface destroy for atomic hide/show via parent commit (fixes one-frame artifact on GNOME)
+- **macOS invisible title bar** (@lkmavi) — `setLayer:` before `setWantsLayer:YES` for layer-hosting mode (macOS 15+ compositing fix)
+- **KDE SSD detection** (@lkmavi) — `zxdg_toplevel_decoration_v1.configure` listener for compositor decoration mode response
+- **CSD state transitions at same resolution** (@lkmavi, #300) — forced `csdPendingResize` on maximize↔fullscreen at same screen size
+- **CSD focused state sync** (@lkmavi) — title bar repaint on focus change
+
+### Changed
+
+- **deps:** golang.org/x/sys v0.45.0 → v0.46.0
+- **lint:** removed unused nolint directive in darwin/objc.go
+
 ## [0.41.11] - 2026-06-14
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.41.11
+## Current State: v0.41.12
 
 ✅ **Production-ready** with full feature set:
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gogpu/gpucontext v0.19.0
 	github.com/gogpu/gputypes v0.5.0
 	github.com/gogpu/wgpu v0.29.14
-	golang.org/x/sys v0.45.0
+	golang.org/x/sys v0.46.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,5 @@ github.com/gogpu/naga v0.17.14 h1:/xUBCkCHSaSi991SSOeYADS9jjlAQivea4brYduI/So=
 github.com/gogpu/naga v0.17.14/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 github.com/gogpu/wgpu v0.29.14 h1:Ewd1Ifn/EOlcLaJYni3e13svF8rTTnNTh/14nFBVSdo=
 github.com/gogpu/wgpu v0.29.14/go.mod h1:bADGRXNCRDoItZMBd3t61v2L18jB7PJVC3N/0R0wZoA=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/platform/darwin/objc.go
+++ b/internal/platform/darwin/objc.go
@@ -1357,7 +1357,6 @@ func SetAssociatedObject(object ID, key unsafe.Pointer, value unsafe.Pointer, po
 
 // GetAssociatedObject retrieves the associated object for the given key.
 //
-//nolint:govet // intentional use of unsafe.Pointer
 func GetAssociatedObject(object ID, key unsafe.Pointer) unsafe.Pointer {
 	if object == 0 {
 		return nil

--- a/internal/platform/darwin/objc.go
+++ b/internal/platform/darwin/objc.go
@@ -1356,7 +1356,6 @@ func SetAssociatedObject(object ID, key unsafe.Pointer, value unsafe.Pointer, po
 }
 
 // GetAssociatedObject retrieves the associated object for the given key.
-//
 func GetAssociatedObject(object ID, key unsafe.Pointer) unsafe.Pointer {
 	if object == 0 {
 		return nil


### PR DESCRIPTION
## Summary

- **docs:** CHANGELOG + ROADMAP for v0.41.12 (@lkmavi CSD fixes from PR #309)
- **deps:** golang.org/x/sys v0.45.0 → v0.46.0
- **lint:** removed unused nolint directive in darwin/objc.go

## Test plan

- [x] Build clean: Windows, Linux, macOS
- [x] Lint 0 issues: all 3 platforms
- [x] go fmt clean