### PR TITLE
fix/306-macos : Fix ScaleFactor() macos

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -185,6 +185,7 @@ linters:
           - gocyclo
           - cyclop
           - gocognit
+          - nestif
           - godot
           - revive
           - gosec

--- a/app.go
+++ b/app.go
@@ -912,11 +912,23 @@ func (a *App) PhysicalSize() (width, height int) {
 // ScaleFactor returns the DPI scale factor.
 // 1.0 = standard (96 DPI on Windows, 72 on macOS), 2.0 = Retina/HiDPI.
 // Implements gpucontext.WindowProvider.
+//
+// Three-tier resolution (Flutter/GLFW pattern):
+//  1. platWindow — most accurate, reflects the window's actual screen.
+//  2. manager (PlatScaleProvider) — available after Run() starts, before
+//     the first window is shown.
+//  3. platform.SystemScaleFactor() — available before Run() on supported
+//     platforms (macOS: [NSScreen mainScreen].backingScaleFactor).
 func (a *App) ScaleFactor() float64 {
 	if a.platWindow != nil {
 		return a.platWindow.ScaleFactor()
 	}
-	return 1.0
+	if a.manager != nil {
+		if sp, ok := a.manager.(platform.PlatScaleProvider); ok {
+			return sp.ScaleFactor()
+		}
+	}
+	return platform.SystemScaleFactor()
 }
 
 // ClipboardRead reads text content from the system clipboard.

--- a/examples/hidpi/main.go
+++ b/examples/hidpi/main.go
@@ -38,7 +38,8 @@ func main() {
 		scale := dc.ScaleFactor()
 		pw, ph := dc.FramebufferSize()
 
-		if pw > 0 && ph > 0 && (pw != lastPW || ph != lastPH) {
+		sizeChanged := pw > 0 && ph > 0 && (pw != lastPW || ph != lastPH)
+		if sizeChanged {
 			if texLow != nil {
 				texLow.Destroy()
 			}

--- a/examples/hidpi/main.go
+++ b/examples/hidpi/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"log"
+	"time"
+
+	"github.com/gogpu/gogpu"
+)
+
+func main() {
+	app := gogpu.NewApp(gogpu.DefaultConfig().
+		WithTitle("HiDPI — logical res → physical res (cycles every 2s)").
+		WithSize(800, 600).
+		WithContinuousRender(false))
+
+	fmt.Printf("ScaleFactor before Run: %.1f\n", app.ScaleFactor())
+
+	go func() {
+		for range time.Tick(2 * time.Second) {
+			app.RequestRedraw()
+		}
+	}()
+
+	var (
+		texLow  *gogpu.Texture
+		texHigh *gogpu.Texture
+		lastPW  int
+		lastPH  int
+		lw, lh  int
+		start   = time.Now()
+		phase   = -1
+	)
+
+	app.OnDraw(func(dc *gogpu.Context) {
+		scale := dc.ScaleFactor()
+		pw, ph := dc.FramebufferSize()
+
+		if pw > 0 && ph > 0 && (pw != lastPW || ph != lastPH) {
+			if texLow != nil {
+				texLow.Destroy()
+			}
+			if texHigh != nil {
+				texHigh.Destroy()
+			}
+
+			lw = int(float64(pw) / scale)
+			lh = int(float64(ph) / scale)
+
+			var err error
+			texLow, err = dc.Renderer().NewTextureFromImage(buildCheckerImage(lw, lh, 4))
+			if err != nil {
+				log.Printf("texLow: %v", err)
+			}
+			texHigh, err = dc.Renderer().NewTextureFromImage(buildCheckerImage(pw, ph, 4))
+			if err != nil {
+				log.Printf("texHigh: %v", err)
+			}
+
+			lastPW, lastPH = pw, ph
+			phase = -1
+
+			fmt.Printf("scale=%.1f  logical=%dx%d  physical=%dx%d\n", scale, lw, lh, pw, ph)
+		}
+
+		cur := int(time.Since(start).Seconds()/2) % 2
+		dc.Clear(0.06, 0.06, 0.08, 1.0)
+
+		if cur == 0 && texLow != nil {
+			_ = dc.DrawTextureScaled(texLow, 0, 0, float32(pw), float32(ph))
+			if cur != phase {
+				fmt.Printf("[logical]   texture %dx%d upscaled to %dx%d\n", lw, lh, pw, ph)
+			}
+		} else if cur == 1 && texHigh != nil {
+			_ = dc.DrawTextureScaled(texHigh, 0, 0, float32(pw), float32(ph))
+			if cur != phase {
+				fmt.Printf("[physical]  texture %dx%d pixel-perfect\n", pw, ph)
+			}
+		}
+		phase = cur
+	})
+
+	app.OnClose(func() {
+		if texLow != nil {
+			texLow.Destroy()
+		}
+		if texHigh != nil {
+			texHigh.Destroy()
+		}
+	})
+
+	if err := app.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func buildCheckerImage(w, h, cellPx int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	dark := color.RGBA{40, 40, 40, 255}
+	light := color.RGBA{220, 220, 220, 255}
+	grid := color.RGBA{100, 180, 255, 255}
+
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			if x%cellPx == 0 || y%cellPx == 0 {
+				img.SetRGBA(x, y, grid)
+				continue
+			}
+			if ((x/cellPx)+(y/cellPx))%2 == 0 {
+				img.SetRGBA(x, y, light)
+			} else {
+				img.SetRGBA(x, y, dark)
+			}
+		}
+	}
+	return img
+}

--- a/internal/platform/darwin/application.go
+++ b/internal/platform/darwin/application.go
@@ -89,6 +89,27 @@ func (a *Application) Init() error {
 	return nil
 }
 
+// MainScreenScaleFactor returns the backing scale factor of the primary display.
+// Queries [NSScreen mainScreen].backingScaleFactor directly, bypassing
+// NSApplication and window lifecycle — safe to call at any point in the
+// process lifetime, including before Init(). This mirrors the approach used
+// by Flutter (FlutterViewController) and GLFW (cocoa_monitor.m).
+//
+// Returns 2.0 on Retina displays, 1.0 on standard density displays.
+func MainScreenScaleFactor() float64 {
+	initSelectors()
+	initClasses()
+	screen := classes.NSScreen.Send(selectors.mainScreen)
+	if screen.IsNil() {
+		return 1.0
+	}
+	scale := screen.GetDouble(selectors.backingScaleFactor)
+	if scale <= 0 {
+		return 1.0
+	}
+	return scale
+}
+
 // SetAppName sets the name of the application that will
 // be displayed in the About, Quit and other menus.
 func (a *Application) SetAppName(name string) {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -290,6 +290,16 @@ const (
 	MenuRoleBringAllToFront
 )
 
+// PlatScaleProvider is an optional interface for platforms that can report the
+// primary display DPI scale factor before a window is created. Callers use a
+// type assertion: if sp, ok := manager.(PlatScaleProvider); ok { ... }
+//
+// On macOS this is implemented via [NSScreen mainScreen].backingScaleFactor,
+// which is available before NSApplication initialization (Flutter/GLFW pattern).
+type PlatScaleProvider interface {
+	ScaleFactor() float64
+}
+
 // PlatMenuManager is an optional interface for platforms that support
 // native application menus (macOS). Platforms that don't support menus
 // simply don't implement this interface.

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -70,6 +70,21 @@ func newPlatformManager() PlatformManager {
 	return &darwinPlatform{}
 }
 
+// ScaleFactor implements PlatScaleProvider.
+// Returns the primary window's backing scale factor when a window exists;
+// otherwise queries [NSScreen mainScreen].backingScaleFactor directly.
+// This mirrors the Flutter/GLFW pattern: the main screen DPI is available
+// from process start, before NSApplication or any window is created.
+func (p *darwinPlatform) ScaleFactor() float64 {
+	p.mu.RLock()
+	pw := p.primary
+	p.mu.RUnlock()
+	if pw != nil && pw.window != nil {
+		return pw.window.BackingScaleFactor()
+	}
+	return darwin.MainScreenScaleFactor()
+}
+
 // --- PlatformManager implementation on darwinPlatform ---
 
 // Init initializes the macOS platform subsystem (process-level, no window).

--- a/internal/platform/scale.go
+++ b/internal/platform/scale.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package platform
+
+// SystemScaleFactor returns the primary display DPI scale factor.
+// Returns 1.0 on platforms where the scale cannot be determined before
+// platform manager initialization.
+func SystemScaleFactor() float64 { return 1.0 }

--- a/internal/platform/scale_darwin.go
+++ b/internal/platform/scale_darwin.go
@@ -1,0 +1,12 @@
+//go:build darwin
+
+package platform
+
+import "github.com/gogpu/gogpu/internal/platform/darwin"
+
+// SystemScaleFactor returns the primary display DPI scale factor.
+// On macOS this queries [NSScreen mainScreen].backingScaleFactor and is safe
+// to call before NSApplication initialization or window creation.
+func SystemScaleFactor() float64 {
+	return darwin.MainScreenScaleFactor()
+}

--- a/platform_provider_test.go
+++ b/platform_provider_test.go
@@ -132,9 +132,16 @@ func TestWindowProviderNilPlatform(t *testing.T) {
 	})
 
 	t.Run("ScaleFactor", func(t *testing.T) {
+		// Before Run(), ScaleFactor() resolves via platform.SystemScaleFactor()
+		// which queries [NSScreen mainScreen].backingScaleFactor on macOS.
+		// The result must be a valid positive scale, not a hardcoded 1.0.
 		sf := app.ScaleFactor()
-		if sf != 1.0 {
-			t.Errorf("ScaleFactor() = %f, want 1.0", sf)
+		want := platform.SystemScaleFactor()
+		if sf != want {
+			t.Errorf("ScaleFactor() = %f, want SystemScaleFactor()=%f", sf, want)
+		}
+		if sf <= 0 {
+			t.Errorf("ScaleFactor() = %f, want > 0", sf)
 		}
 	})
 

--- a/platform_provider_test.go
+++ b/platform_provider_test.go
@@ -68,6 +68,14 @@ func (m *mockWindow) IsFullscreen() bool   { return m.fullscreen }
 func (m *mockWindow) Close()               { m.closed = true }
 func (m *mockWindow) Show()                {}
 
+// mockScaleManager wraps mockManager and implements platform.PlatScaleProvider.
+type mockScaleManager struct {
+	mockManager
+	scaleFactor float64
+}
+
+func (m *mockScaleManager) ScaleFactor() float64 { return m.scaleFactor }
+
 // mockManager implements platform.PlatformManager for testing.
 type mockManager struct {
 	clipboardText  string
@@ -201,6 +209,25 @@ func TestPlatformProviderNilPlatform(t *testing.T) {
 		sl := app.SubpixelLayout()
 		if sl != gpucontext.SubpixelNone {
 			t.Errorf("SubpixelLayout() = %v, want SubpixelNone", sl)
+		}
+	})
+}
+
+// TestScaleFactorResolution verifies three-tier ScaleFactor resolution:
+// platWindow → PlatScaleProvider → SystemScaleFactor.
+func TestScaleFactorResolution(t *testing.T) {
+	t.Run("manager implements PlatScaleProvider", func(t *testing.T) {
+		app := &App{manager: &mockScaleManager{scaleFactor: 1.5}}
+		if sf := app.ScaleFactor(); sf != 1.5 {
+			t.Errorf("ScaleFactor() = %f, want 1.5", sf)
+		}
+	})
+
+	t.Run("manager without PlatScaleProvider falls back to SystemScaleFactor", func(t *testing.T) {
+		app := &App{manager: &mockManager{}}
+		want := platform.SystemScaleFactor()
+		if sf := app.ScaleFactor(); sf != want {
+			t.Errorf("ScaleFactor() = %f, want SystemScaleFactor()=%f", sf, want)
 		}
 	})
 }


### PR DESCRIPTION
# CHANGES
- app.ScaleFactor() — three-tier resolution (Flutter/GLFW pattern): platWindow → PlatScaleProvider → platform.SystemScaleFactor(). Previously returned 1.0 when called before Run().
- Added PlatScaleProvider optional interface to platform.go for managers that can report DPI scale before a window is created.
- darwinPlatform implements PlatScaleProvider via [NSWindow backingScaleFactor] falling back to [NSScreen mainScreen].backingScaleFactor.
- Added darwin.MainScreenScaleFactor() — queries [NSScreen mainScreen].backingScaleFactor directly, safe to call before NSApplication init (mirrors Flutter/GLFW approach).
- Added platform.SystemScaleFactor() with darwin and non-darwin (1.0) build variants.
- Added examples/hidpi/main.go — demo showing logical vs physical texture resolution on Retina.
