### PR TITLE
docs: CHANGELOG + ROADMAP for v0.41.14 — HiDPI enterprise fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.14] - 2026-06-15
+
+### Fixed
+
+- **Windows HiDPI** (@lkmavi, #306, ADR-044) — unified pre-scale + verify pattern (enterprise research: Qt6, Chromium, winit, SDL3):
+  - `MonitorFromPoint` + `GetDpiForMonitor` (shcore.dll) for pre-HWND DPI query
+  - `AdjustWindowRectExForDpi` for DPI-aware window frame (fallback to `AdjustWindowRectEx` on pre-Win10 1607)
+  - Pre-scaled `CreateWindowExW` — window correct from first frame on primary monitor
+  - Post-create verify — `GetDpiForWindow` → `SetWindowPos` if different-DPI monitor
+  - `WM_GETDPISCALEDSIZE` handler for smooth multi-monitor transitions (Qt6 pattern)
+  - `PlatScaleProvider` + `SystemScaleFactor()` on Windows
+- **macOS HiDPI** (@lkmavi, #306) — physical-size tracking for Retina↔1× multi-monitor transitions:
+  - `physW`/`physH` tracking on `darwinWindow` — catches scale changes when logical size unchanged
+  - `windowDidChangeScreen:` delegate — NSNotification when window moves to different-DPI display
+  - `WakeEventLoop()` for prompt resize detection after display transition
+
 ## [0.41.13] - 2026-06-15
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.41.13
+## Current State: v0.41.14
 
 ✅ **Production-ready** with full feature set:
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.
@@ -136,10 +136,10 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 Windows DPI-aware window creation. Unified pre-scale + verify pattern (Qt6/SDL3/winit research).
 
 - [x] macOS ScaleFactor three-tier resolution (PR #313, @lkmavi)
-- [ ] Windows `AdjustWindowRectExForDpi` + `MonitorFromPoint` pre-scale (ADR-044, @lkmavi)
-- [ ] Windows `WM_GETDPISCALEDSIZE` handler for multi-monitor transitions
-- [ ] Windows `PlatScaleProvider` + `SystemScaleFactor()` (PR #313 pattern)
+- [x] Windows pre-scale + verify + WM_GETDPISCALEDSIZE + PlatScaleProvider (PR #314, @lkmavi, ADR-044)
+- [x] macOS physical-size tracking + windowDidChangeScreen delegate (PR #316, @lkmavi)
 - [ ] `Config.Width`/`Config.Height` docs: "pixels" → "logical points (DIP)"
+- [ ] @TimLai666 verification on AMD Radeon 890M, Windows 11, 200%
 
 ### v0.42.x — API Cleanup (#311)
 


### PR DESCRIPTION
CHANGELOG + ROADMAP for v0.41.14. HiDPI fixes: Windows (PR #314) + macOS (PR #316), both by @lkmavi.