### PR TITLE
feat!: GPU struct tokens + wgpu helpers — zero unsafe (v0.42.0, BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.0] - 2026-06-15
+
+### Changed
+
+- **GPU handles: struct tokens (BREAKING)** — gpucontext v0.21.0 + wgpu v0.30.1. Device/Queue/Adapter changed from interfaces to opaque struct tokens (`unsafe.Pointer`, reflect.Value pattern). Zero `unsafe` in gogpu — all via `wgpu.DeviceToHandle()`/`wgpu.AdapterToHandle()` helpers. 8 bytes, zero alloc, GC-safe, compile-time type distinct.
+- **deps:** gpucontext v0.20.0 → v0.21.0 (struct tokens), wgpu v0.29.16 → v0.30.1 (unified API + helpers)
+
 ## [0.41.15] - 2026-06-15
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.41.15
+## Current State: v0.42.0
 
 ✅ **Production-ready** with full feature set:
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.

--- a/examples/gpucontext_integration/main.go
+++ b/examples/gpucontext_integration/main.go
@@ -70,9 +70,9 @@ func main() {
 		// Print device info once
 		if !printed {
 			fmt.Println("=== gpucontext.DeviceProvider Info ===")
-			fmt.Printf("Device: %T (non-nil: %v)\n", provider.Device(), provider.Device() != nil)
-			fmt.Printf("Queue: %T (non-nil: %v)\n", provider.Queue(), provider.Queue() != nil)
-			fmt.Printf("Adapter: %T (non-nil: %v)\n", provider.Adapter(), provider.Adapter() != nil)
+			fmt.Printf("Device: %v (non-nil: %v)\n", provider.Device().Pointer(), !provider.Device().IsNil())
+			fmt.Printf("Queue: %v (non-nil: %v)\n", provider.Queue().Pointer(), !provider.Queue().IsNil())
+			fmt.Printf("Adapter: %v (non-nil: %v)\n", provider.Adapter().Pointer(), !provider.Adapter().IsNil())
 			fmt.Printf("SurfaceFormat: %v\n", provider.SurfaceFormat())
 			fmt.Println("======================================")
 			fmt.Println()

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/go-webgpu/goffi v0.5.3
-	github.com/gogpu/gpucontext v0.19.0
+	github.com/gogpu/gpucontext v0.21.0
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/wgpu v0.29.16
+	github.com/gogpu/wgpu v0.30.1
 	golang.org/x/sys v0.46.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,13 +2,13 @@ github.com/go-webgpu/goffi v0.5.3 h1:Ckc94SdHO42bIb0oEapRIcv+jKjhjGJfb9zPEvNKC7U
 github.com/go-webgpu/goffi v0.5.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
-github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
+github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
+github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.15 h1:uyy4bc8wYlvDaYOpmCBYrJ+d+e7ZqP2BN36csmRVs7o=
 github.com/gogpu/naga v0.17.15/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.29.16 h1:KHffhoveALPmFnhkIfZknJ85P3NC/hJDxOVCtwuS/Nc=
-github.com/gogpu/wgpu v0.29.16/go.mod h1:ELqMwPTkfFa8WlnxV4JuWaI718ufE2EXnJZV1WNTJbE=
+github.com/gogpu/wgpu v0.30.1 h1:dZ6FeOiKNlimaDWiiUneLExgbLqZDTu+acqajAM7gWw=
+github.com/gogpu/wgpu v0.30.1/go.mod h1:D2GQZtdBMBoPbkOUTjDm2xoO6j7dCzeTBZZOHjMhWoU=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/gpucontext_adapter.go
+++ b/gpucontext_adapter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
 )
 
 // gpuContextAdapter bridges gogpu to gpucontext.DeviceProvider interface.
@@ -23,22 +24,21 @@ type gpuContextAdapter struct {
 	app      *App
 }
 
-// Device returns the underlying *wgpu.Device as gpucontext.Device.
-// Consumers should type-assert to *wgpu.Device for full API access.
+// Device returns the underlying *wgpu.Device as gpucontext.Device opaque handle.
+// Consumers extract via wgpu.DeviceFromHandle(dev).
 func (a *gpuContextAdapter) Device() gpucontext.Device {
 	if a.renderer == nil || a.renderer.device == nil {
-		return nil
+		return gpucontext.Device{}
 	}
-	return a.renderer.device
+	return wgpu.DeviceToHandle(a.renderer.device)
 }
 
-// Queue returns the underlying *wgpu.Queue as gpucontext.Queue.
-// Consumers should type-assert to *wgpu.Queue for full API access.
+// Queue returns the underlying *wgpu.Queue as gpucontext.Queue opaque handle.
 func (a *gpuContextAdapter) Queue() gpucontext.Queue {
 	if a.renderer == nil || a.renderer.device == nil {
-		return nil
+		return gpucontext.Queue{}
 	}
-	return a.renderer.device.Queue()
+	return wgpu.QueueToHandle(a.renderer.device.Queue())
 }
 
 // SurfaceFormat returns the preferred texture format for the surface.
@@ -49,13 +49,12 @@ func (a *gpuContextAdapter) SurfaceFormat() gputypes.TextureFormat {
 	return mapTextureFormat(a.renderer.primary.format)
 }
 
-// Adapter returns the GPU adapter as gpucontext.Adapter.
-// Consumers should type-assert to *wgpu.Adapter for full API access.
+// Adapter returns the GPU adapter as gpucontext.Adapter opaque handle.
 func (a *gpuContextAdapter) Adapter() gpucontext.Adapter {
 	if a.renderer == nil || a.renderer.adapter == nil {
-		return nil
+		return gpucontext.Adapter{}
 	}
-	return a.renderer.adapter
+	return wgpu.AdapterToHandle(a.renderer.adapter)
 }
 
 // AdapterInfo returns GPU adapter metadata for render mode decisions.

--- a/gpucontext_adapter_test.go
+++ b/gpucontext_adapter_test.go
@@ -33,26 +33,23 @@ func TestGPUContextAdapterMethods(t *testing.T) {
 	adapter := &gpuContextAdapter{renderer: renderer}
 
 	t.Run("Device", func(t *testing.T) {
-		// Device returns nil when renderer.device is nil.
 		device := adapter.Device()
-		if device != nil {
-			t.Error("Device() should return nil when renderer.device is nil")
+		if !device.IsNil() {
+			t.Error("Device() should return nil handle when renderer.device is nil")
 		}
 	})
 
 	t.Run("Queue", func(t *testing.T) {
-		// Queue returns nil when renderer.device is nil.
 		queue := adapter.Queue()
-		if queue != nil {
-			t.Error("Queue() should return nil when renderer.device is nil")
+		if !queue.IsNil() {
+			t.Error("Queue() should return nil handle when renderer.device is nil")
 		}
 	})
 
 	t.Run("Adapter", func(t *testing.T) {
-		// Adapter returns nil when renderer.adapter is nil.
 		adpt := adapter.Adapter()
-		if adpt != nil {
-			t.Error("Adapter() should return nil when renderer.adapter is nil")
+		if !adpt.IsNil() {
+			t.Error("Adapter() should return nil handle when renderer.adapter is nil")
 		}
 	})
 
@@ -69,20 +66,20 @@ func TestGPUContextAdapterNilRenderer(t *testing.T) {
 	adapter := &gpuContextAdapter{renderer: nil}
 
 	t.Run("Device", func(t *testing.T) {
-		if adapter.Device() != nil {
-			t.Error("Device() should return nil with nil renderer")
+		if !adapter.Device().IsNil() {
+			t.Error("Device() should return nil handle with nil renderer")
 		}
 	})
 
 	t.Run("Queue", func(t *testing.T) {
-		if adapter.Queue() != nil {
-			t.Error("Queue() should return nil with nil renderer")
+		if !adapter.Queue().IsNil() {
+			t.Error("Queue() should return nil handle with nil renderer")
 		}
 	})
 
 	t.Run("Adapter", func(t *testing.T) {
-		if adapter.Adapter() != nil {
-			t.Error("Adapter() should return nil with nil renderer")
+		if !adapter.Adapter().IsNil() {
+			t.Error("Adapter() should return nil handle with nil renderer")
 		}
 	})
 


### PR DESCRIPTION
## Summary

gpucontext v0.21.0 + wgpu v0.30.1 integration. GPU handles (Device, Queue, Adapter) changed from broken sentinel interfaces to opaque struct tokens.

### What changed
- `gpucontext_adapter.go`: uses `wgpu.DeviceToHandle()` / `wgpu.AdapterToHandle()` — **zero `unsafe` imports in gogpu**
- Tests: `!= nil` → `.IsNil()` for struct token nil checks
- Example: updated for new API
- deps: gpucontext v0.21.0, wgpu v0.30.1

### Why
v0.20.0 sentinel methods were broken per Go spec (unexported methods can't be satisfied cross-package). Research: 3 agents, 6 patterns analyzed, reflect.Value precedent confirmed GC safety.

### Architecture (ADR-018)
- `unsafe.Pointer` isolated in wgpu helpers — consumers never touch unsafe
- 8 bytes, zero alloc, GC-safe (Go spec: unsafe.Pointer in struct fields traced by GC)
- Compile-time type distinct: Device ≠ Queue ≠ Adapter

## Test plan
- [x] Build clean: Windows, Linux, macOS
- [x] Lint 0 issues: all 3 platforms (GOWORK=off)
- [x] Tests pass
- [x] Triangle example verified visually
- [x] gpucontext_integration example: Device/Queue/Adapter non-nil, correct pointers