### PR TITLE
fix(app): close X11 Display before releasing Vulkan instance (X11/NVIDIA shutdown SIGSEGV)

### DIFF
--- a/app.go
+++ b/app.go
@@ -255,24 +255,30 @@ func (a *App) Run() error {
 	if err != nil {
 		return err
 	}
-	defer a.manager.Destroy()
-	defer platWindow.Destroy()
-
 	a.renderLoop = thread.NewRenderLoop()
-	defer a.renderLoop.Stop()
 
 	if err := a.initRenderer(platWindow); err != nil {
+		a.renderLoop.Stop()
+		a.manager.Destroy()
 		return err
 	}
 
 	platWindow.Show()
 
-	// Shutdown sequence (all on render thread for GPU safety):
-	// 1. WaitIdle — ensure all GPU work completes
-	// 2. DrainDeferredDestroys — release GC-enqueued resources
-	// 3. tracker.CloseAll() — auto-tracked resources (LIFO)
-	// 4. onClose callback — manual cleanup (legacy pattern)
-	// 5. Renderer.Destroy() — release GPU device
+	// Shutdown sequence — order matters on X11/NVIDIA (see step 4 below).
+	// All GPU steps run on the render thread for thread safety.
+	// 1. WaitForGPU / DrainDeferredDestroys / tracker.CloseAll / onClose
+	// 2. Renderer.Destroy()     — release GPU surface/device/adapter (NOT instance)
+	// 3. platWindow + manager   — close the OS window and the X11 Display
+	// 4. Renderer.ReleaseInstance() — unload the Vulkan driver (ICD) LAST
+	// 5. renderLoop.Stop()      — stop the render thread last of all
+	//
+	// Step 3 must precede step 4: the X11 close path is manager.Destroy()
+	// (x11PlatformWindow.Destroy is a no-op — teardown is on the platform).
+	// XCloseDisplay invokes the NVIDIA driver's XESetCloseDisplay hook; if the
+	// Vulkan instance — and thus the ICD — was already released, that hook
+	// points into unloaded code and SIGSEGVs. Close the display while the ICD
+	// is still loaded, release the instance afterwards.
 	defer func() {
 		a.renderLoop.RunOnRenderThreadVoid(func() {
 			a.renderer.WaitForGPU()
@@ -287,6 +293,12 @@ func (a *App) Run() error {
 		a.renderLoop.RunOnRenderThreadVoid(func() {
 			a.renderer.Destroy()
 		})
+		platWindow.Destroy()
+		a.manager.Destroy()
+		a.renderLoop.RunOnRenderThreadVoid(func() {
+			a.renderer.ReleaseInstance()
+		})
+		a.renderLoop.Stop()
 	}()
 
 	a.registerPrimaryWindow(platWindow)

--- a/renderer.go
+++ b/renderer.go
@@ -1208,6 +1208,16 @@ func (r *Renderer) Destroy() {
 		r.adapter.Release()
 		r.adapter = nil
 	}
+	// NOTE: the Vulkan instance is released separately via ReleaseInstance so
+	// the X11 Display* can be closed while the driver (ICD) is still loaded.
+	// On X11/NVIDIA, releasing the instance unloads the ICD; XCloseDisplay then
+	// jumps into the driver's freed XESetCloseDisplay hook and SIGSEGVs.
+}
+
+// ReleaseInstance releases the Vulkan instance. Split from Destroy so callers
+// can close platform display handles (X11 XCloseDisplay) before the instance —
+// and thus the driver ICD — is unloaded. Safe to call after Destroy; idempotent.
+func (r *Renderer) ReleaseInstance() {
 	if r.instance != nil {
 		r.instance.Release()
 		r.instance = nil


### PR DESCRIPTION
## Problem

On X11 / NVIDIA (pure-Go Vulkan backend, `CGO_ENABLED=0`), every clean shutdown
SIGSEGVs. The app runs fine; `App.Run()` returns, then the process dies instead
of exiting 0:

```
SIGSEGV: segmentation violation   (PC == fault addr — jumped to freed code)
github.com/go-webgpu/goffi/...CallFunction
github.com/gogpu/gogpu/internal/platform/x11.(*xlibHandle).close   platform.go:276  // XCloseDisplay
github.com/gogpu/gogpu/internal/platform/x11.(*Platform).Destroy   platform.go:1500
github.com/gogpu/gogpu/internal/platform.(*x11Platform).Destroy    platform_linux.go:349
github.com/gogpu/gogpu.(*App).Run.deferwrap1                       app.go
```

## Root cause

`App.Run`'s teardown released the **Vulkan instance** (`Renderer.Destroy()` →
`instance.Release()`, which unloads the driver ICD) **before** the X11 `Display*`
was closed. The display close happens in `manager.Destroy()` →
`x11Platform.Destroy()` → `Platform.Destroy()` → `xlibHandle.close()` →
`XCloseDisplay` — note `x11PlatformWindow.Destroy()` is a no-op, so this is the
*only* close path.

The NVIDIA Vulkan ICD registers a per-`Display` `XESetCloseDisplay` close-hook;
Xlib invokes that hook from *inside* `XCloseDisplay`. By then the ICD code is
unloaded, so the hook is a jump into freed memory — `PC == fault address`,
exactly the observed signature.

## Fix

Reorder teardown so the X11 `Display*` is closed while the Vulkan instance (and
thus the driver) is still loaded:

- Split `Renderer.ReleaseInstance()` out of `Renderer.Destroy()`.
- Orchestrate the shutdown defer: GPU drain/wait → `Renderer.Destroy()`
  (releases surface/device/adapter) → `platWindow.Destroy()` + `manager.Destroy()`
  (**XCloseDisplay**, main thread) → `Renderer.ReleaseInstance()` (unload ICD) →
  `renderLoop.Stop()`.

The surface (the only GPU object bound to `Display*`) is released inside
`Destroy()` before the display is closed; `XCloseDisplay` stays on the main
thread while GPU ops stay on the render thread — no thread-affinity change. The
renderer-init error path cleans up `renderLoop`/`manager` explicitly.

## Verification

Reproduced and fixed on real hardware — **X11 + NVIDIA GeForce RTX 3050 Ti
(driver 550.163.01), pure-Go Vulkan backend, `CGO_ENABLED=0`, Go 1.26**:

- Before: SIGSEGV in `XCloseDisplay` on every shutdown (stack above).
- After: clean `exit 0`.

Repro drives a few frames then calls `app.Quit()` to trigger the same deferred
teardown a window-close would, then asserts the process exits 0.

Also green: `go build ./...`, `go build -tags rust ./...`, `gofmt`, `go vet`,
`go test ./...`, and `scripts/pre-release-check.sh` (race-detector run).
