### PR TITLE
fix(app): add platWindow.Destroy in initRenderer error path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.2] - 2026-06-23
+
+### Fixed
+
+- **X11/NVIDIA shutdown SIGSEGV** (@samyfodil, #332) — reorder teardown so X11 `XCloseDisplay` runs before Vulkan instance release. NVIDIA ICD registers `XESetCloseDisplay` hook; releasing the instance first unloads the hook code, causing SIGSEGV on every shutdown. Split `Renderer.ReleaseInstance()` from `Destroy()` for correct ordering.
+- **initRenderer error path** — ensure `platWindow.Destroy()` is called on renderer init failure (prevents window handle leak on Windows)
+
 ## [0.42.1] - 2026-06-21
 
 ### Changed

--- a/app.go
+++ b/app.go
@@ -259,6 +259,7 @@ func (a *App) Run() error {
 
 	if err := a.initRenderer(platWindow); err != nil {
 		a.renderLoop.Stop()
+		platWindow.Destroy()
 		a.manager.Destroy()
 		return err
 	}


### PR DESCRIPTION
## Summary

- Follow-up to #332: add `platWindow.Destroy()` in `initRenderer` error path
- On Windows, `win32Window.Destroy()` calls `DestroyWindow(hwnd)` — skipping it leaks the window handle until process exit
- On X11/macOS `Destroy()` is a no-op (teardown handled by `manager.Destroy()`)
- CHANGELOG updated for v0.42.2

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./...` — passes
- [x] `golangci-lint run` — 0 issues
- [x] Verified `platWindow.Destroy()` order: before `manager.Destroy()` (correct — window resources freed before platform teardown)
