### PR TITLE
fix(platform): subpixel layout detection defaults to None on unknown displays (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.4] - 2026-06-24
+
+### Fixed
+
+- **Subpixel layout detection defaults to RGB on unknown displays** (#338) — changed default from SubpixelRGB to SubpixelNone (grayscale AA) on both Wayland and X11. Prevents color fringing on BGR/unknown monitors. Added `GOGPU_SUBPIXEL_LAYOUT` env var override (values: `rgb`, `bgr`, `vrgb`, `vbgr`, `none`). Wayland `wl_output.geometry` subpixel field now parsed and stored (wiring to detection chain in follow-up). X11: fixed nil fallback and all "no data" defaults to SubpixelNone.
+
 ## [0.42.3] - 2026-06-24
 
 ### Fixed

--- a/internal/platform/desktop_linux.go
+++ b/internal/platform/desktop_linux.go
@@ -17,6 +17,16 @@ const (
 	envQTScaleFactor = "QT_SCALE_FACTOR"
 )
 
+// Subpixel layout string identifiers shared by env var parser, fontconfig parser,
+// and X11 Xft.rgba parser.
+const (
+	subpixelValueRGB  = "rgb"
+	subpixelValueBGR  = "bgr"
+	subpixelValueVRGB = "vrgb"
+	subpixelValueVBGR = "vbgr"
+	subpixelValueNone = "none"
+)
+
 // detectDarkMode checks environment variables and desktop settings to determine
 // if dark mode is active. Works for GNOME, KDE, and other freedesktop desktops.
 //
@@ -91,29 +101,49 @@ func detectReduceMotion() bool {
 // variables and fontconfig settings. Used as a fallback for Wayland
 // (which cannot read X resources) and when X11 RESOURCE_MANAGER is unavailable.
 //
-// Detection order:
-//  1. GDK_SCALE / QT_SCALE_FACTOR >= 2 → SubpixelNone (HiDPI, subpixels too small)
-//  2. Fontconfig config files (~/.config/fontconfig/fonts.conf or /etc/fonts/local.conf)
-//     <match><edit name="rgba"><const>rgb</const></edit></match>
-//  3. Default to SubpixelRGB (most common LCD arrangement)
+// Detection order (ADR-047):
+//  1. GOGPU_SUBPIXEL_LAYOUT env var override
+//  2. GDK_SCALE / QT_SCALE_FACTOR >= 2 → SubpixelNone (HiDPI, subpixels too small)
+//  3. Fontconfig config files (~/.config/fontconfig/fonts.conf or /etc/fonts/local.conf)
+//  4. Default to SubpixelNone (safe — grayscale AA on unknown displays)
 func detectSubpixelLayout() gpucontext.SubpixelLayout {
-	// HiDPI displays should use grayscale AA — subpixels are too small to matter.
+	if layout, ok := parseSubpixelEnvVar(); ok {
+		return layout
+	}
+
 	if isHiDPI() {
 		return gpucontext.SubpixelNone
 	}
 
-	// Check fontconfig user config (~/.config/fontconfig/fonts.conf)
 	if layout, ok := parseFontconfigRGBA(userFontconfigPath()); ok {
 		return layout
 	}
 
-	// Check fontconfig system config
 	if layout, ok := parseFontconfigRGBA("/etc/fonts/local.conf"); ok {
 		return layout
 	}
 
-	// Default: RGB is the most common subpixel arrangement for LCDs.
-	return gpucontext.SubpixelRGB
+	return gpucontext.SubpixelNone
+}
+
+// parseSubpixelEnvVar reads GOGPU_SUBPIXEL_LAYOUT env var.
+// Valid values: rgb, bgr, vrgb, vbgr, none.
+func parseSubpixelEnvVar() (gpucontext.SubpixelLayout, bool) {
+	v := strings.ToLower(os.Getenv("GOGPU_SUBPIXEL_LAYOUT"))
+	switch v {
+	case subpixelValueRGB:
+		return gpucontext.SubpixelRGB, true
+	case subpixelValueBGR:
+		return gpucontext.SubpixelBGR, true
+	case subpixelValueVRGB:
+		return gpucontext.SubpixelVRGB, true
+	case subpixelValueVBGR:
+		return gpucontext.SubpixelVBGR, true
+	case subpixelValueNone:
+		return gpucontext.SubpixelNone, true
+	default:
+		return gpucontext.SubpixelNone, false
+	}
 }
 
 // isHiDPI returns true if environment variables indicate HiDPI (scale >= 2.0).
@@ -177,15 +207,15 @@ func parseFontconfigRGBA(path string) (gpucontext.SubpixelLayout, bool) {
 
 	value := strings.TrimSpace(rest[:constEnd])
 	switch strings.ToLower(value) {
-	case "rgb":
+	case subpixelValueRGB:
 		return gpucontext.SubpixelRGB, true
-	case "bgr":
+	case subpixelValueBGR:
 		return gpucontext.SubpixelBGR, true
-	case "vrgb":
+	case subpixelValueVRGB:
 		return gpucontext.SubpixelVRGB, true
-	case "vbgr":
+	case subpixelValueVBGR:
 		return gpucontext.SubpixelVBGR, true
-	case "none":
+	case subpixelValueNone:
 		return gpucontext.SubpixelNone, true
 	default:
 		return gpucontext.SubpixelNone, false

--- a/internal/platform/desktop_linux_test.go
+++ b/internal/platform/desktop_linux_test.go
@@ -416,11 +416,11 @@ func TestDetectSubpixelLayout(t *testing.T) {
 		t.Errorf("detectSubpixelLayout() with fontconfig bgr = %v, want SubpixelBGR", got)
 	}
 
-	// Test 3: No fontconfig, no HiDPI → default RGB
+	// Test 3: No fontconfig, no HiDPI → default None (ADR-047: safe for unknown displays)
 	os.Setenv("XDG_CONFIG_HOME", "/nonexistent")
 	os.Setenv("HOME", "/nonexistent")
 	got = detectSubpixelLayout()
-	if got != gpucontext.SubpixelRGB {
-		t.Errorf("detectSubpixelLayout() default = %v, want SubpixelRGB", got)
+	if got != gpucontext.SubpixelNone {
+		t.Errorf("detectSubpixelLayout() default = %v, want SubpixelNone", got)
 	}
 }

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -327,10 +327,13 @@ func (p *x11Platform) ClipboardWrite(text string) error {
 // SubpixelLayout returns the display's subpixel arrangement for LCD text rendering.
 // Delegates to the X11 platform which reads Xft.rgba from RESOURCE_MANAGER.
 func (p *x11Platform) SubpixelLayout() gpucontext.SubpixelLayout {
+	if layout, ok := parseSubpixelEnvVar(); ok {
+		return layout
+	}
 	if p.inner != nil {
 		return p.inner.SubpixelLayout()
 	}
-	return gpucontext.SubpixelRGB
+	return gpucontext.SubpixelNone
 }
 
 // DarkMode returns true if the system dark mode is active.
@@ -2517,7 +2520,8 @@ func (p *waylandPlatform) ClipboardWrite(text string) error {
 }
 
 // SubpixelLayout returns the display's subpixel arrangement for LCD text rendering.
-// Wayland does not expose X resources, so this falls back to fontconfig detection.
+// Detection order (ADR-047): env var → fontconfig → None.
+// TODO: read wl_output.geometry subpixel field when output binding is wired (ADR-047 Phase 2).
 func (p *waylandPlatform) SubpixelLayout() gpucontext.SubpixelLayout {
 	return detectSubpixelLayout()
 }

--- a/internal/platform/wayland/compositor.go
+++ b/internal/platform/wayland/compositor.go
@@ -310,8 +310,9 @@ type WlOutput struct {
 	display *Display
 	id      ObjectID
 
-	mu    sync.Mutex
-	scale int32
+	mu       sync.Mutex
+	scale    int32
+	subpixel int32 // wl_output_subpixel enum from geometry event (0=unknown,1=none,2=h_rgb,3=h_bgr,4=v_rgb,5=v_bgr)
 
 	// Event handlers
 	onScale func(scale int32)
@@ -352,17 +353,53 @@ func (o *WlOutput) SetScaleHandler(handler func(scale int32)) {
 	o.onScale = handler
 }
 
+// Subpixel returns the subpixel arrangement reported by the compositor.
+// Values: 0=unknown, 1=none, 2=horizontal_rgb, 3=horizontal_bgr, 4=vertical_rgb, 5=vertical_bgr.
+func (o *WlOutput) Subpixel() int32 {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.subpixel
+}
+
 // dispatch handles wl_output events.
 func (o *WlOutput) dispatch(msg *Message) error {
 	switch msg.Opcode {
 	case outputEventScale:
 		return o.handleScale(msg)
-	case outputEventGeometry, outputEventMode, outputEventDone:
-		// Ignore other events for now
+	case outputEventGeometry:
+		return o.handleGeometry(msg)
+	case outputEventMode, outputEventDone:
 		return nil
 	default:
 		return nil
 	}
+}
+
+// handleGeometry extracts the subpixel field from the geometry event.
+// Wire format: x(int) y(int) phys_w(int) phys_h(int) subpixel(int) make(string) model(string) transform(int)
+func (o *WlOutput) handleGeometry(msg *Message) error {
+	decoder := NewDecoder(msg.Args)
+	if _, err := decoder.Int32(); err != nil { // x
+		return err
+	}
+	if _, err := decoder.Int32(); err != nil { // y
+		return err
+	}
+	if _, err := decoder.Int32(); err != nil { // physical_width
+		return err
+	}
+	if _, err := decoder.Int32(); err != nil { // physical_height
+		return err
+	}
+	subpixel, err := decoder.Int32()
+	if err != nil {
+		return err
+	}
+
+	o.mu.Lock()
+	o.subpixel = subpixel
+	o.mu.Unlock()
+	return nil
 }
 
 func (o *WlOutput) handleScale(msg *Message) error {

--- a/internal/platform/x11/dpi_test.go
+++ b/internal/platform/x11/dpi_test.go
@@ -135,12 +135,12 @@ func TestParseXftRGBA(t *testing.T) {
 		{
 			name:      "no Xft.rgba present",
 			resources: "Xft.antialias:\t1\nXft.hinting:\t1\n",
-			want:      gpucontext.SubpixelRGB, // default
+			want:      gpucontext.SubpixelNone, // safe default (ADR-047)
 		},
 		{
 			name:      "empty string",
 			resources: "",
-			want:      gpucontext.SubpixelRGB, // default
+			want:      gpucontext.SubpixelNone, // safe default (ADR-047)
 		},
 		{
 			name:      "uppercase RGB",
@@ -153,9 +153,9 @@ func TestParseXftRGBA(t *testing.T) {
 			want:      gpucontext.SubpixelBGR,
 		},
 		{
-			name:      "unknown value defaults to RGB",
+			name:      "unknown value defaults to None",
 			resources: "Xft.rgba:\tunknown\n",
-			want:      gpucontext.SubpixelRGB,
+			want:      gpucontext.SubpixelNone,
 		},
 		{
 			name:      "no trailing newline",

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -613,12 +613,12 @@ func (p *Platform) SubpixelLayout() gpucontext.SubpixelLayout {
 
 	rootWindow := p.conn.RootWindow()
 	if rootWindow == 0 {
-		return gpucontext.SubpixelRGB
+		return gpucontext.SubpixelNone
 	}
 
 	data, _, _, err := p.conn.GetProperty(rootWindow, AtomResourceManager, Atom(0), 0, 8192, false)
 	if err != nil || len(data) == 0 {
-		return gpucontext.SubpixelRGB
+		return gpucontext.SubpixelNone
 	}
 
 	return parseXftRGBA(string(data))
@@ -627,7 +627,7 @@ func (p *Platform) SubpixelLayout() gpucontext.SubpixelLayout {
 // parseXftRGBA parses the Xft.rgba value from an X RESOURCE_MANAGER string.
 // The string contains lines like "Xft.rgba:\trgb" or "Xft.rgba: bgr".
 // Valid values: "rgb", "bgr", "vrgb", "vbgr", "none".
-// Returns SubpixelRGB if Xft.rgba is not found (most common LCD default).
+// Returns SubpixelNone if Xft.rgba is not found (safe default for unknown displays, ADR-047).
 func parseXftRGBA(resources string) gpucontext.SubpixelLayout {
 	for _, line := range strings.Split(resources, "\n") {
 		line = strings.TrimSpace(line)
@@ -648,11 +648,11 @@ func parseXftRGBA(resources string) gpucontext.SubpixelLayout {
 		case "none":
 			return gpucontext.SubpixelNone
 		default:
-			return gpucontext.SubpixelRGB
+			return gpucontext.SubpixelNone
 		}
 	}
-	// Xft.rgba not set — default to RGB (most common LCD layout).
-	return gpucontext.SubpixelRGB
+	// Xft.rgba not set — safe default for unknown displays (ADR-047).
+	return gpucontext.SubpixelNone
 }
 
 // initXkbcommon loads libxkbcommon and creates a keymap.


### PR DESCRIPTION
## Summary

- Change subpixel layout default from `SubpixelRGB` to `SubpixelNone` on Wayland and X11 (#338)
- Add `GOGPU_SUBPIXEL_LAYOUT` env var override (`rgb`, `bgr`, `vrgb`, `vbgr`, `none`)
- Parse `wl_output.geometry` subpixel field (stored on WlOutput, wiring to detection chain in follow-up)
- X11: fix nil inner fallback + all "no data" defaults → SubpixelNone
- Extract shared subpixel string constants (goconst lint compliance)
- Windows/macOS/Browser unaffected (already correct per audit)

Fixes #338. ADR-047.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./...` — passes (updated 4 test expectations: default → None)
- [x] `golangci-lint run` — 0 issues (Windows, Linux, macOS)
- [ ] Manual: Wayland with `GOGPU_SUBPIXEL_LAYOUT=none` — grayscale AA, no fringing
- [ ] Manual: Wayland with `GOGPU_SUBPIXEL_LAYOUT=rgb` — LCD RGB rendering
