### PR TITLE
fix: recover surface on ErrSurfaceOutdated in present() + stop X11 resize flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Surface-outdated on present** (@samyfodil, #NNN) — `present()` now reconfigures the
+- **Surface-outdated on present** (@samyfodil, #342) — `present()` now reconfigures the
   surface on `wgpu.ErrSurfaceOutdated` (resize/DPI/monitor change) and logs at Debug,
   matching the acquire path (`recoverFromAcquireError`), instead of logging a spurious
   ERROR with no recovery. After reconfiguring, the frame is re-rendered once at the new
   size so resize no longer drops to a blank frame.
-- **X11 black flicker on resize** (@samyfodil, #NNN) — the window was created with a black
+- **X11 black flicker on resize** (@samyfodil, #342) — the window was created with a black
   `CWBackPixel`, so the X server painted newly-exposed areas black on every resize before
   the GPU repainted. Use background pixmap `None` instead (X11 default; GLFW/SDL/Chromium
   pattern) so old pixels persist until the swapchain presents the new frame.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surface on `wgpu.ErrSurfaceOutdated` (resize/DPI/monitor change) and logs at Debug,
   matching the acquire path (`recoverFromAcquireError`), instead of logging a spurious
   ERROR with no recovery. After reconfiguring, the frame is re-rendered once at the new
-  size so resize no longer flashes a dropped (black) frame.
+  size so resize no longer drops to a blank frame.
+- **X11 black flicker on resize** (@samyfodil, #NNN) — the window was created with a black
+  `CWBackPixel`, so the X server painted newly-exposed areas black on every resize before
+  the GPU repainted. Use background pixmap `None` instead (X11 default; GLFW/SDL/Chromium
+  pattern) so old pixels persist until the swapchain presents the new frame.
 
 ## [0.42.5] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.6] - 2026-06-24
+
+### Fixed
+
+- **Surface-outdated on present** (@samyfodil, #NNN) — `present()` now reconfigures the
+  surface on `wgpu.ErrSurfaceOutdated` (resize/DPI/monitor change) and logs at Debug,
+  matching the acquire path (`recoverFromAcquireError`), instead of logging a spurious
+  ERROR with no recovery. After reconfiguring, the frame is re-rendered once at the new
+  size so resize no longer flashes a dropped (black) frame.
+
 ## [0.42.5] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **X11 black flicker on resize** (@samyfodil, #342) — the window was created with a black
   `CWBackPixel`, so the X server painted newly-exposed areas black on every resize before
   the GPU repainted. Use background pixmap `None` instead (X11 default; GLFW/SDL/Chromium
-  pattern) so old pixels persist until the swapchain presents the new frame.
+  pattern) so the server no longer fills the window black; `Expose` events now request a
+  redraw so revealed regions repaint instead of staying undefined.
 
 ## [0.42.5] - 2026-06-24
 

--- a/app.go
+++ b/app.go
@@ -859,8 +859,14 @@ func (a *App) renderFrameMultiThread() {
 			frame.onDraw(ctx)
 
 			// End frame only if beginFrame was actually called (lazy acquire fired).
-			if ws.frameStarted {
-				a.renderer.endFrameForSurface(ws)
+			// If present found the surface outdated, it reconfigured the swapchain;
+			// re-render once at the new size so the frame isn't dropped to black.
+			if ws.frameStarted && a.renderer.endFrameForSurface(ws) {
+				ws.prepareLazyAcquire()
+				frame.onDraw(newContextForSurface(a.renderer, ws, frame.scale))
+				if ws.frameStarted {
+					a.renderer.endFrameForSurface(ws) // single retry; next frame handles any further churn
+				}
 			}
 			ws.resetLazyState()
 			a.renderer.currentSurface = nil

--- a/app.go
+++ b/app.go
@@ -626,6 +626,9 @@ func (a *App) classifyEvent(event *platform.Event, lastResize *platform.Event, s
 		}
 	case platform.EventClose:
 		a.windowCloseEvent(event)
+	case platform.EventExpose:
+		// No X11 background pixmap — repaint revealed regions ourselves.
+		a.RequestRedraw()
 	case platform.EventFocus:
 		a.focused = event.Focused
 		if event.Focused {
@@ -858,14 +861,15 @@ func (a *App) renderFrameMultiThread() {
 			ctx := newContextForSurface(a.renderer, ws, frame.scale)
 			frame.onDraw(ctx)
 
-			// End frame only if beginFrame was actually called (lazy acquire fired).
-			// If present found the surface outdated, it reconfigured the swapchain;
-			// re-render once at the new size so the frame isn't dropped to black.
+			// On outdated, present() reconfigured the surface; re-render once at the
+			// live scale (a DPI change is an outdated trigger, so frame.scale may be
+			// stale). One retry only — looping can livelock a live resize; if still
+			// outdated, request another frame since nothing else reschedules on-demand.
 			if ws.frameStarted && a.renderer.endFrameForSurface(ws) {
 				ws.prepareLazyAcquire()
-				frame.onDraw(newContextForSurface(a.renderer, ws, frame.scale))
-				if ws.frameStarted {
-					a.renderer.endFrameForSurface(ws) // single retry; next frame handles any further churn
+				frame.onDraw(newContextForSurface(a.renderer, ws, ws.platWindow.ScaleFactor()))
+				if ws.frameStarted && a.renderer.endFrameForSurface(ws) {
+					a.RequestRedraw()
 				}
 			}
 			ws.resetLazyState()

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -74,6 +74,7 @@ const (
 	EventPointerEnter
 	EventPointerLeave
 	EventScroll
+	EventExpose
 )
 
 // PrepareFrameResult contains per-frame surface state from the platform layer.

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -279,6 +279,8 @@ func (p *x11Platform) PollEvents() Event {
 		return Event{Type: EventPointerLeave, Pointer: event.Pointer}
 	case x11.EventTypeScroll:
 		return Event{Type: EventScroll, Scroll: event.Scroll}
+	case x11.EventTypeExpose:
+		return Event{Type: EventExpose, WindowID: p.primaryWindowID}
 	default:
 		return Event{Type: EventNone}
 	}

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -51,6 +51,7 @@ const (
 	EventTypePointerEnter
 	EventTypePointerLeave
 	EventTypeScroll
+	EventTypeExpose
 )
 
 // PlatformEvent represents a platform event.
@@ -899,8 +900,10 @@ func (p *Platform) handleEvent(event Event) PlatformEvent {
 		}
 
 	case *ExposeEvent:
-		// Could trigger redraw, but for now we just ignore
-		// The main render loop should handle this
+		// The window has no background pixmap (CWBackPixmap=None in CreateWindow),
+		// so the X server won't repaint exposed regions — we must. Request a redraw.
+		// Bursts of Expose coalesce upstream (RequestRedraw just sets a flag).
+		return PlatformEvent{Type: EventTypeExpose}
 
 	case *MapNotifyEvent:
 		w.eventMu.Lock()

--- a/internal/platform/x11/window.go
+++ b/internal/platform/x11/window.go
@@ -28,12 +28,10 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
 	// Generate window ID
 	windowID := c.GenerateID()
 
-	// Set up window attributes.
-	// Background pixmap None (not a black BackPixel): the X server must NOT clear
-	// the window to a solid color on resize. A black BackPixel makes the server
-	// paint the newly-exposed area black before the GPU repaints it, which shows
-	// up as black flicker while dragging/resizing. None leaves old pixels until
-	// the swapchain presents the new frame (GLFW/SDL/Chromium pattern).
+	// Background pixmap None, not a black BackPixel: a black BackPixel makes the X
+	// server paint newly-exposed areas black on resize before the GPU repaints
+	// (black flicker). None leaves the background untouched — we repaint on resize
+	// and Expose. GLFW/SDL/Chromium pattern.
 	valueMask := uint32(CWBackPixmap | CWEventMask)
 
 	// Event mask - listen for common events

--- a/internal/platform/x11/window.go
+++ b/internal/platform/x11/window.go
@@ -28,8 +28,13 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
 	// Generate window ID
 	windowID := c.GenerateID()
 
-	// Set up window attributes
-	valueMask := uint32(CWBackPixel | CWEventMask)
+	// Set up window attributes.
+	// Background pixmap None (not a black BackPixel): the X server must NOT clear
+	// the window to a solid color on resize. A black BackPixel makes the server
+	// paint the newly-exposed area black before the GPU repaints it, which shows
+	// up as black flicker while dragging/resizing. None leaves old pixels until
+	// the swapchain presents the new frame (GLFW/SDL/Chromium pattern).
+	valueMask := uint32(CWBackPixmap | CWEventMask)
 
 	// Event mask - listen for common events
 	eventMask := uint32(
@@ -47,8 +52,8 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
 
 	// Value list (order matters - must match bit order in valueMask)
 	valueList := []uint32{
-		screen.BlackPixel, // CWBackPixel
-		eventMask,         // CWEventMask
+		0,         // CWBackPixmap = None — no background fill on resize (anti-flicker)
+		eventMask, // CWEventMask
 	}
 
 	// Build request

--- a/renderer.go
+++ b/renderer.go
@@ -545,10 +545,13 @@ func (r *Renderer) EndFrame() {
 // endFrameForSurface flushes, presents, and releases frame resources for a
 // specific RenderTarget. Used by the multi-window frame loop. Unlike EndFrame,
 // it does NOT poll submissions -- the caller polls once after all windows.
-func (r *Renderer) endFrameForSurface(ws *RenderTarget) {
+// Returns true when present() reconfigured an outdated surface and the frame
+// should be re-rendered (see present).
+func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	ws.flushClear(r.device, r)
-	ws.present()
+	reconfigured := ws.present()
 	ws.releaseFrame()
+	return reconfigured
 }
 
 // pollSubmissions performs non-blocking submission tracking: frees GPU resources
@@ -565,16 +568,38 @@ func (r *Renderer) pollSubmissions() {
 // On Wayland, Vulkan WSI internally calls wl_surface_attach / wl_surface_commit /
 // wl_display_flush during vkQueuePresentKHR. The display lock serializes this with
 // the main thread's DispatchDefaultQueue (ADR-041 Phase 2).
-func (ws *RenderTarget) present() {
-	if ws.currentSurfaceTexture != nil {
-		lockDisplay(ws.platWindow)
-		err := ws.surface.PresentWithDamage(ws.currentSurfaceTexture, ws.damageRects)
-		unlockDisplay(ws.platWindow)
-		if err != nil {
-			slog.Error("PRESENT ERROR", "err", err)
-		}
-		ws.damageRects = nil
+//
+// Returns true when the surface was outdated (resize/DPI/monitor change) and
+// was successfully reconfigured — the caller should re-render this frame so the
+// resized surface shows content instead of a dropped (black) frame.
+func (ws *RenderTarget) present() (reconfigured bool) {
+	if ws.currentSurfaceTexture == nil {
+		return false
 	}
+	lockDisplay(ws.platWindow)
+	err := ws.surface.PresentWithDamage(ws.currentSurfaceTexture, ws.damageRects)
+	unlockDisplay(ws.platWindow)
+	ws.damageRects = nil
+	if err == nil {
+		return false
+	}
+	// Mirror recoverFromAcquireError: outdated is an expected, recoverable
+	// event (resize/DPI/monitor change), not an error. Reconfigure and signal
+	// the caller to re-render so the new swapchain shows content immediately.
+	if errors.Is(err, wgpu.ErrSurfaceOutdated) {
+		slog.Debug("gogpu: surface outdated on present, reconfiguring", "width", ws.width, "height", ws.height)
+		if ws.width > 0 && ws.height > 0 {
+			if cfgErr := ws.configure(ws.renderer.device, ws.renderer.adapter); cfgErr != nil {
+				slog.Error("gogpu: reconfigure after outdated failed", "err", cfgErr)
+				ws.state = SurfaceLost
+				return false
+			}
+			return true
+		}
+		return false
+	}
+	slog.Error("PRESENT ERROR", "err", err)
+	return false
 }
 
 // prepareLazyAcquire resets per-frame state for deferred beginFrame.

--- a/renderer.go
+++ b/renderer.go
@@ -538,6 +538,8 @@ func (r *Renderer) EndFrame() {
 		r.pollSubmissions()
 		return
 	}
+	// Outdated-reconfigure recovery is left to the next BeginFrame/EndFrame —
+	// this manual path has no retained draw callback to replay.
 	r.endFrameForSurface(r.primary)
 	r.pollSubmissions()
 }
@@ -545,8 +547,7 @@ func (r *Renderer) EndFrame() {
 // endFrameForSurface flushes, presents, and releases frame resources for a
 // specific RenderTarget. Used by the multi-window frame loop. Unlike EndFrame,
 // it does NOT poll submissions -- the caller polls once after all windows.
-// Returns true when present() reconfigured an outdated surface and the frame
-// should be re-rendered (see present).
+// Returns true if present() reconfigured an outdated surface (see present).
 func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	ws.flushClear(r.device, r)
 	reconfigured := ws.present()
@@ -569,9 +570,7 @@ func (r *Renderer) pollSubmissions() {
 // wl_display_flush during vkQueuePresentKHR. The display lock serializes this with
 // the main thread's DispatchDefaultQueue (ADR-041 Phase 2).
 //
-// Returns true when the surface was outdated (resize/DPI/monitor change) and
-// was successfully reconfigured — the caller should re-render this frame so the
-// resized surface shows content instead of a dropped (black) frame.
+// Returns true if the surface was outdated and reconfigured — caller re-renders.
 func (ws *RenderTarget) present() (reconfigured bool) {
 	if ws.currentSurfaceTexture == nil {
 		return false
@@ -583,9 +582,8 @@ func (ws *RenderTarget) present() (reconfigured bool) {
 	if err == nil {
 		return false
 	}
-	// Mirror recoverFromAcquireError: outdated is an expected, recoverable
-	// event (resize/DPI/monitor change), not an error. Reconfigure and signal
-	// the caller to re-render so the new swapchain shows content immediately.
+	// Mirror recoverFromAcquireError: outdated is expected (resize/DPI/monitor),
+	// not an error — reconfigure and signal the caller to re-render.
 	if errors.Is(err, wgpu.ErrSurfaceOutdated) {
 		slog.Debug("gogpu: surface outdated on present, reconfiguring", "width", ws.width, "height", ws.height)
 		if ws.width > 0 && ws.height > 0 {


### PR DESCRIPTION
## Summary

Two related fixes for window resize / DPI / monitor changes on the surface-present path.

### 1. Present path didn't recover from `ErrSurfaceOutdated`

The acquire and present paths handled the **identical** `wgpu.ErrSurfaceOutdated` differently:

- **Acquire** (`recoverFromAcquireError`): reconfigures the surface and logs at `Debug` — correct. Outdated is an expected, recoverable event on resize/DPI/monitor change.
- **Present** (`(*RenderTarget).present()`): just did `slog.Error("PRESENT ERROR", ...)` and **nothing else** — no reconfigure. It happened to self-heal on the next frame's acquire, but it logged a scary ERROR for a routine event and dropped the current frame.

`present()` now mirrors the acquire path: on `ErrSurfaceOutdated` it reconfigures the swapchain and logs at `Debug` (marking `SurfaceLost` only if reconfigure fails), reserving `ERROR` for genuinely unexpected present errors. It then signals the frame loop to re-render the frame once at the new size so it isn't dropped to a blank frame.

### 2. X11 black flicker on resize

The X11 window was created with `CWBackPixel = BlackPixel`, so the X server filled newly-exposed regions with black on every resize before the GPU backend repainted them — visible as black flicker while dragging/resizing. Switched to background pixmap `None` (the X11 default, and what GLFW/SDL/Chromium use): the server leaves existing pixels untouched on resize, so old content persists until the swapchain presents the next frame.

The two are complementary — the renderer reconfigures and repaints, while the X server no longer blanks the window in the gap.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Manually verified on X11 + NVIDIA (pure-Go Vulkan backend, `CGO_ENABLED=0`): dragging and resizing the window between monitors no longer logs `PRESENT ERROR ... surface outdated` (now `Debug`), no longer flashes black, and rendering recovers cleanly.

## Trade-off

With background pixmap `None`, the window shows undefined pixels for the brief moment between first map and first frame instead of black. In practice the first frame paints immediately so this is invisible, but it's the documented consequence of the standard anti-flicker setup.
