### PR TITLE
fix(wayland): add wl_surface.frame callback gating for animation (v0.42.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.9] - 2026-06-28
+
+### Fixed
+
+- **Wayland frame callback gating** (ui#152, BUG-WL-006) — add `wl_surface.frame` callback to gate animation frames on Wayland. Without this, the render loop outran the compositor's presentation rate, causing visible CSD desync during animation (visible on camera, not in screen recordings). Implements winit 3-state machine (None/Requested/Received) via C libwayland FFI. `GOGPU_WAYLAND_FRAME_CALLBACK=0` env var to disable for debugging. Enterprise refs: winit `state.rs:273`, SDL3 `SDL_waylandwindow.c:2968`, Gio `os_wayland.go:1779`.
+
 ## [0.42.8] - 2026-06-25
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.42.1
+## Current State: v0.42.9
 
 ✅ **Production-ready** with full feature set:
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.
@@ -79,6 +79,14 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.42.9** | 2026-06-28 | **Wayland frame callback gating** (ui#152, BUG-WL-006) — `wl_surface.frame` 3-state machine (winit pattern) via C libwayland FFI. Fixes CSD desync during animation. ADR-049. |
+| **v0.42.8** | 2026-06-25 | **deps:** wgpu v0.30.5 — Software backend text rendering fix (@samyfodil) |
+| **v0.42.7** | 2026-06-25 | **deps:** wgpu v0.30.4 — Metal stencil state translation fix |
+| **v0.42.6** | 2026-06-25 | **Surface-outdated on present** (@samyfodil, #342) — present() recovery + X11 resize flicker fix (CWBackPixmap=None). **fc-match** fallback for subpixel detection. **ErrSurfaceLost** symmetric handling. |
+| **v0.42.5** | 2026-06-24 | **wl_output.subpixel wired** (#338) — bind wl_output via Pure Go registry, read compositor EDID data |
+| **v0.42.4** | 2026-06-24 | **Subpixel default None** (#338) — changed from RGB to None on Wayland+X11. `GOGPU_SUBPIXEL_LAYOUT` env var. ADR-047. |
+| **v0.42.3** | 2026-06-24 | **macOS live resize** + **API polish** (@lkmavi, #335 #336) — contentsGravity, SetTitle (3 platforms), OnFocus/HasFocus, SetMinSize/SetMaxSize (4 platforms), WithResizable, NewSeparator, error sentinels |
+| **v0.42.2** | 2026-06-23 | **X11/NVIDIA SIGSEGV** (@samyfodil, #332) — reorder teardown: XCloseDisplay before vkDestroyInstance. Split ReleaseInstance from Destroy. |
 | **v0.39.3** | 2026-05-26 | **Linux clipboard** (PLAT-009, ADR-037) — X11 ICCCM selection + Wayland data_device. ClipboardRead/Write work on all Linux platforms. deps: wgpu v0.28.8. |
 | **v0.39.2** | 2026-05-25 | **Wayland cursor shapes** (wp_cursor_shape_manager_v1, 12 shapes + CSD resize cursors) + **platform fixes** — damage_buffer (#272), Activated→EventFocus (#273), DPI MouseLeave (#271), X11 HitTest (#270), dispatchFocus (BUG-FOCUS-001) |
 | **v0.39.1** | 2026-05-22 | **AppLifecycle enum + callbacks** (ADR-026 Phase 3 complete) — AppLifecycle (5 states), OnSurfaceAvailable/Destroyed, OnResumed/Suspended/MemoryWarning |

--- a/app.go
+++ b/app.go
@@ -422,8 +422,9 @@ func (a *App) Run() error {
 		// OnDraw: CONTINUOUS = every VSync (games), otherwise only when dirty.
 		// ANIMATING mode: onUpdate runs every tick, OnDraw only on RequestRedraw.
 		// Lazy acquire inside: if OnDraw doesn't draw, no swapchain acquire.
-		if continuousRender || invalidated {
+		if (continuousRender || invalidated) && a.frameCallbackReady() {
 			a.renderFrameMultiThread()
+			a.platWindow.SyncFrame()
 		}
 	}
 
@@ -945,6 +946,18 @@ func (a *App) SetAppName(name string) {
 // The main loop will exit after completing the current frame.
 func (a *App) Quit() {
 	a.running = false
+}
+
+// frameCallbackReady checks if the platform allows rendering this frame.
+// On Wayland, the compositor controls presentation timing via wl_surface.frame
+// callbacks — if the compositor hasn't acked the previous frame, rendering is
+// skipped to prevent outrunning the compositor's presentation rate (FRAME-001).
+// On all other platforms, this always returns true.
+func (a *App) frameCallbackReady() bool {
+	if fg, ok := a.platWindow.(platform.FrameGater); ok {
+		return fg.FrameCallbackReady()
+	}
+	return true
 }
 
 // RequestRedraw requests a frame redraw.

--- a/app.go
+++ b/app.go
@@ -424,7 +424,6 @@ func (a *App) Run() error {
 		// Lazy acquire inside: if OnDraw doesn't draw, no swapchain acquire.
 		if (continuousRender || invalidated) && a.frameCallbackReady() {
 			a.renderFrameMultiThread()
-			a.platWindow.SyncFrame()
 		}
 	}
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -172,6 +172,8 @@ All Config options can be overridden via environment variables:
 | `GOGPU_POWER_PREFERENCE` | `low`, `high` | none | GPU selection |
 | `GOGPU_RENDER_MODE` | `auto`, `cpu`, `gpu` | auto | 2D render path (ADR-020) |
 | `GOGPU_DEBUG_DAMAGE` | `1` | off | Damage region overlay (ADR-021) |
+| `GOGPU_SUBPIXEL_LAYOUT` | `rgb`, `bgr`, `vrgb`, `vbgr`, `none` | auto-detect | LCD subpixel override (ADR-047) |
+| `GOGPU_WAYLAND_FRAME_CALLBACK` | `0` | enabled | Disable Wayland frame callback gating (ADR-049) |
 
 ### AdapterInfo
 
@@ -256,6 +258,8 @@ naga (shader)              wgpu              go-webgpu/webgpu
 | `EventSource` | Input events (keyboard, mouse, scroll, IME) | gogpu.App |
 | `WindowProvider` | Window size, scale factor | gogpu.App |
 | `WindowChrome` | Frameless windows, fullscreen | gogpu.App |
+| `FrameGater` | Wayland frame callback gating (ADR-049) | waylandPlatformWindow |
+| `DisplayLocker` | Wayland display mutex for thread safety (ADR-041) | waylandPlatformWindow |
 
 ## Package Structure
 

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -285,6 +285,24 @@ type DisplayLocker interface {
 	DisplayUnlock()
 }
 
+// FrameGater is an optional interface for platforms that implement compositor
+// frame callback gating. On Wayland, the compositor controls presentation
+// timing via wl_surface.frame callbacks. Without gating, the render loop can
+// submit frames faster than the compositor can composite them, causing visible
+// tearing with CSD subsurfaces (BUG-WL-006).
+//
+// Platforms that don't need frame gating (X11, Win32, macOS, browser) simply
+// don't implement this interface — callers use type assertion.
+//
+// FRAME-001: Wayland frame callback gating (winit 3-state pattern).
+type FrameGater interface {
+	// FrameCallbackReady reports whether the compositor has acknowledged the
+	// previous frame and the render loop may submit a new one. Returns true
+	// when no frame callback is pending (initial state) or when the compositor
+	// has fired the done event. Returns false while waiting for the compositor.
+	FrameCallbackReady() bool
+}
+
 type MenuRole int
 
 const (

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -546,7 +546,15 @@ func (w *waylandPlatformWindow) CursorMode() int {
 	return w.platform.CursorMode()
 }
 
-func (w *waylandPlatformWindow) SyncFrame() {}
+// SyncFrame on Wayland requests the next frame callback from the compositor.
+// Called after present on the render thread. The frame callback gates the
+// next render: FrameCallbackReady() returns false until the compositor fires
+// the done event (FRAME-001 / BUG-WL-006, winit pattern).
+func (w *waylandPlatformWindow) SyncFrame() {
+	if w.platform.libwl != nil && wayland.FrameCallbackEnabled() {
+		w.platform.libwl.RequestFrameCallback()
+	}
+}
 
 func (w *waylandPlatformWindow) SetFrameless(frameless bool) {
 	w.platform.SetFrameless(frameless)
@@ -592,6 +600,17 @@ func (w *waylandPlatformWindow) DisplayUnlock() {
 	if w.platform.libwl != nil {
 		w.platform.libwl.DisplayUnlock()
 	}
+}
+
+// FrameCallbackReady implements FrameGater for Wayland frame callback gating.
+// Returns true when the compositor has acknowledged the previous frame (or no
+// callback is pending). Returns false while waiting for the compositor's done
+// event (FRAME-001 / BUG-WL-006, winit 3-state pattern).
+func (w *waylandPlatformWindow) FrameCallbackReady() bool {
+	if w.platform.libwl == nil || !wayland.FrameCallbackEnabled() {
+		return true // Not initialized or gating disabled
+	}
+	return w.platform.libwl.FrameCallbackReady()
 }
 
 func (w *waylandPlatformWindow) Destroy() {
@@ -2484,6 +2503,14 @@ func (p *waylandPlatform) PollEvents() Event {
 			if err := p.libwl.DispatchCSDEvents(); err != nil {
 				logger().Error("CSD dispatch error", "error", err)
 			}
+		}
+
+		// FRAME-001: Check if the compositor acked our frame callback.
+		// If so, queue an expose event to trigger a redraw. This ensures
+		// the render loop does not skip the next frame when in IDLE mode
+		// (where WaitEvents blocks until an event arrives).
+		if wayland.FrameCallbackEnabled() && p.libwl.ConsumeFrameCallbackReady() {
+			w.queueEvent(Event{Type: EventExpose, WindowID: p.primaryWindowID})
 		}
 	}
 

--- a/internal/platform/wayland/libwayland.go
+++ b/internal/platform/wayland/libwayland.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/go-webgpu/goffi/ffi"
@@ -88,6 +89,14 @@ type LibwaylandHandle struct {
 	// 0=unset (never received), 1=CLIENT_SIDE (app must draw CSD), 2=SERVER_SIDE.
 	// KDE Plasma may respond CLIENT_SIDE even after we request SERVER_SIDE.
 	decorMode uint32
+
+	// Frame callback gating (FRAME-001 / BUG-WL-006, winit 3-state pattern).
+	// Prevents render loop from outrunning the compositor's presentation rate.
+	// 0=None, 1=Requested, 2=Received. Atomic — no mutex needed for reads.
+	frameCallbackState int32
+	// frameCallbackReady is set to true when the compositor fires done.
+	// Consumed by ConsumeFrameCallbackReady to trigger RequestRedraw.
+	frameCallbackReady atomic.Bool
 
 	// App event queue — ALL our Wayland objects (registry, compositor, surface,
 	// xdg, seat, pointer, keyboard, etc.) live on this queue. The default queue

--- a/internal/platform/wayland/libwayland_frame.go
+++ b/internal/platform/wayland/libwayland_frame.go
@@ -177,11 +177,19 @@ func (h *LibwaylandHandle) RequestFrameCallback() {
 		return
 	}
 
-	// Commit the surface so the compositor processes the frame request.
-	// wl_surface.commit = opcode 6.
-	h.marshalVoid(h.surface, 6)
+	// wl_surface.frame is double-buffered (Wayland spec: "The frame request
+	// will take effect on the next wl_surface.commit"). Since RequestFrameCallback
+	// is called AFTER Vulkan present (which already committed the surface),
+	// we need an explicit commit to activate the pending frame callback.
+	// Without it, the callback never fires — the next present is gated by
+	// this very callback (chicken-and-egg).
+	// Note: winit/SDL3/Gio avoid this by calling frame() BEFORE present.
+	h.marshalVoid(h.surface, 6) // wl_surface.commit = opcode 6
 
-	// Flush to ensure the request reaches the compositor immediately.
+	// Flush so the frame request + commit reach the compositor without waiting
+	// for the next event loop iteration. Without this, requests sit in the
+	// client buffer until the next wl_display_flush, delaying the callback
+	// by up to one vsync cycle.
 	if err := h.flush(); err != nil {
 		slog.Warn("wayland: flush after frame request failed", "err", err)
 	}

--- a/internal/platform/wayland/libwayland_frame.go
+++ b/internal/platform/wayland/libwayland_frame.go
@@ -178,21 +178,15 @@ func (h *LibwaylandHandle) RequestFrameCallback() {
 	}
 
 	// wl_surface.frame is double-buffered (Wayland spec: "The frame request
-	// will take effect on the next wl_surface.commit"). Since RequestFrameCallback
-	// is called AFTER Vulkan present (which already committed the surface),
-	// we need an explicit commit to activate the pending frame callback.
-	// Without it, the callback never fires — the next present is gated by
-	// this very callback (chicken-and-egg).
-	// Note: winit/SDL3/Gio avoid this by calling frame() BEFORE present.
-	h.marshalVoid(h.surface, 6) // wl_surface.commit = opcode 6
-
-	// Flush so the frame request + commit reach the compositor without waiting
-	// for the next event loop iteration. Without this, requests sit in the
-	// client buffer until the next wl_display_flush, delaying the callback
-	// by up to one vsync cycle.
-	if err := h.flush(); err != nil {
-		slog.Warn("wayland: flush after frame request failed", "err", err)
-	}
+	// will take effect on the next wl_surface.commit"). RequestFrameCallback
+	// is called BEFORE Vulkan present (winit pre_present_notify pattern), so
+	// the present's internal wl_surface.commit activates the frame callback
+	// atomically with the buffer swap. No explicit commit or flush needed.
+	//
+	// Enterprise refs: winit calls frame() in pre_present_notify BEFORE
+	// swap_buffers; SDL3 calls wl_surface_frame in surface_frame_done
+	// BEFORE the next eglSwapBuffers; Gio calls wl_surface_frame BEFORE
+	// the frame event that triggers rendering + present.
 
 	// Transition: None|Received → Requested
 	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackRequested)

--- a/internal/platform/wayland/libwayland_frame.go
+++ b/internal/platform/wayland/libwayland_frame.go
@@ -1,0 +1,220 @@
+//go:build linux
+
+package wayland
+
+// libwayland_frame.go — wl_surface.frame callback gating (BUG-WL-006 / FRAME-001).
+//
+// Implements a 3-state machine (winit pattern: None → Requested → Received) that
+// gates the render loop from submitting frames faster than the Wayland compositor
+// can composite them with CSD subsurfaces. Without this, the render loop can
+// outrun the compositor's presentation rate, causing visible tearing/flicker
+// during animation that is only visible on camera (NOT in screen recordings).
+//
+// Enterprise references:
+//   - winit (Rust): state.rs:273-289, event_loop/mod.rs:460
+//     3-state machine: None|Requested|Received. frame() only if None|Received.
+//   - SDL3: SDL_waylandwindow.c:833-834,2966-2969
+//     Perpetual chain: wl_callback_destroy + wl_surface_frame in done handler.
+//   - Gio (Go): os_wayland.go:1779-1786
+//     lastFrameCallback == nil gate before drawing.
+//
+// Implementation uses C libwayland FFI (goffi) path because our C wl_surface
+// lives on the C display connection. A Pure Go WlCallback would never receive
+// the compositor's done event dispatched by C libwayland.
+
+import (
+	"log/slog"
+	"os"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/go-webgpu/goffi/ffi"
+)
+
+// FrameCallbackState represents the 3-state machine for frame callback gating.
+// Follows the winit pattern (state.rs).
+const (
+	// FrameCallbackNone means no frame callback is in flight.
+	// Rendering is allowed. Next RequestFrameCallback transitions to Requested.
+	FrameCallbackNone int32 = 0
+
+	// FrameCallbackRequested means a frame callback has been sent to the compositor
+	// and we are waiting for the done event. Rendering MUST be skipped.
+	FrameCallbackRequested int32 = 1
+
+	// FrameCallbackReceived means the compositor fired the done event.
+	// Rendering is allowed. Next RequestFrameCallback transitions to Requested.
+	FrameCallbackReceived int32 = 2
+)
+
+// wl_callback interface descriptor — constructed for addListener on the frame callback proxy.
+// wl_callback has 0 methods and 1 event (done: opcode 0, signature "u").
+var frameCallbackIface struct {
+	once     sync.Once
+	iface    cWlInterface
+	events   [1]cWlMessage
+	listener [1]uintptr // done callback
+}
+
+// initFrameCallbackIface constructs the wl_callback interface descriptor
+// and creates the goffi listener once.
+func initFrameCallbackIface() {
+	frameCallbackIface.once.Do(func() {
+		nt := uintptr(unsafe.Pointer(&xdg.nullTypes[0]))
+		// Ensure xdg nullTypes are initialized (shared zero-filled array).
+		initXdgInterfaces()
+
+		// wl_callback has 0 methods and 1 event: done(callback_data: uint)
+		frameCallbackIface.events[0] = cWlMessage{
+			Name:      cstr("done\x00"),
+			Signature: cstr("u\x00"),
+			Types:     nt,
+		}
+
+		frameCallbackIface.iface = cWlInterface{
+			Name:        cstr("wl_callback\x00"),
+			Version:     1,
+			MethodCount: 0,
+			Methods:     0,
+			EventCount:  1,
+			Events:      uintptr(unsafe.Pointer(&frameCallbackIface.events[0])),
+		}
+
+		// Create goffi callback for the done handler.
+		frameCallbackIface.listener[0] = ffi.NewCallback(frameCallbackDoneCb)
+	})
+}
+
+// --- Per-proxy callback routing ---
+// Frame callbacks are ephemeral (one-shot), so we use a map keyed by
+// the wl_callback proxy pointer to route the done event to the correct
+// LibwaylandHandle. The entry is inserted in RequestFrameCallback and
+// removed in the done handler.
+
+var (
+	frameCallbackHandlesMu sync.Mutex
+	frameCallbackHandles   = make(map[uintptr]*LibwaylandHandle)
+)
+
+// frameCallbackDoneCb is the C-callable handler for wl_callback.done.
+// Signature: void(data, wl_callback, callback_data).
+//
+// Called during DispatchDefaultQueue (which holds displayMu). The callback
+// is always dispatched on the main thread — same context as all other
+// Wayland event handlers in this codebase.
+func frameCallbackDoneCb(data, callback, callbackData uintptr) {
+	frameCallbackHandlesMu.Lock()
+	h := frameCallbackHandles[callback]
+	delete(frameCallbackHandles, callback)
+	frameCallbackHandlesMu.Unlock()
+
+	if h == nil {
+		return
+	}
+
+	slog.Debug("wl_surface.frame done", "callback_data", uint32(callbackData))
+
+	// Destroy the callback proxy (SDL3 pattern: destroy before re-register).
+	h.proxyDestroy(callback)
+
+	// Transition: Requested → Received
+	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackReceived)
+
+	// Signal that a new frame can be drawn. The main loop will call
+	// RequestRedraw on the next iteration if animation is active.
+	h.frameCallbackReady.Store(true)
+}
+
+// RequestFrameCallback sends a wl_surface.frame request to the compositor.
+// Idempotent: if state is already Requested, this is a no-op.
+//
+// Must be called from the render thread (after present) or main thread.
+// The C libwayland calls require displayMu, which is acquired internally.
+//
+// Follows the winit pattern (state.rs:273-282): only send frame() if
+// current state is None or Received (never double-request).
+func (h *LibwaylandHandle) RequestFrameCallback() {
+	// Fast path: already requested — no-op (idempotent, winit pattern).
+	state := atomic.LoadInt32(&h.frameCallbackState)
+	if state == FrameCallbackRequested {
+		return
+	}
+
+	initFrameCallbackIface()
+
+	h.displayMu.Lock()
+	defer h.displayMu.Unlock()
+
+	// Double-check under lock (another thread may have raced).
+	state = atomic.LoadInt32(&h.frameCallbackState)
+	if state == FrameCallbackRequested {
+		return
+	}
+
+	// wl_surface.frame (opcode 3) creates a new wl_callback.
+	// Use marshalConstructor with the wl_callback interface.
+	callback, err := h.marshalConstructor(h.surface, 3, unsafe.Pointer(&frameCallbackIface.iface))
+	if err != nil {
+		slog.Warn("wayland: wl_surface.frame failed", "err", err)
+		return
+	}
+
+	// Register callback → handle mapping for the done handler.
+	frameCallbackHandlesMu.Lock()
+	frameCallbackHandles[callback] = h
+	frameCallbackHandlesMu.Unlock()
+
+	// Add listener so the compositor's done event reaches our handler.
+	if err := h.addListener(callback, uintptr(unsafe.Pointer(&frameCallbackIface.listener[0]))); err != nil {
+		slog.Warn("wayland: frame callback listener failed", "err", err)
+		// Clean up on failure.
+		frameCallbackHandlesMu.Lock()
+		delete(frameCallbackHandles, callback)
+		frameCallbackHandlesMu.Unlock()
+		h.proxyDestroy(callback)
+		return
+	}
+
+	// Commit the surface so the compositor processes the frame request.
+	// wl_surface.commit = opcode 6.
+	h.marshalVoid(h.surface, 6)
+
+	// Flush to ensure the request reaches the compositor immediately.
+	if err := h.flush(); err != nil {
+		slog.Warn("wayland: flush after frame request failed", "err", err)
+	}
+
+	// Transition: None|Received → Requested
+	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackRequested)
+	h.frameCallbackReady.Store(false)
+
+	// Prevent GC of the listener array while the callback is in flight.
+	runtime.KeepAlive(&frameCallbackIface.listener)
+
+	slog.Debug("wl_surface.frame requested")
+}
+
+// FrameCallbackReady reports whether the render loop may submit a frame.
+// Returns true when state is None (initial) or Received (compositor said go).
+// Returns false when state is Requested (waiting for compositor).
+//
+// Safe to call from any goroutine (atomic load).
+func (h *LibwaylandHandle) FrameCallbackReady() bool {
+	return atomic.LoadInt32(&h.frameCallbackState) != FrameCallbackRequested
+}
+
+// ConsumeFrameCallbackReady atomically checks and clears the ready flag.
+// Returns true if the frame callback was received since the last consume.
+// Used by the platform layer to trigger RequestRedraw after compositor ack.
+func (h *LibwaylandHandle) ConsumeFrameCallbackReady() bool {
+	return h.frameCallbackReady.CompareAndSwap(true, false)
+}
+
+// FrameCallbackEnabled reports whether frame callback gating is active.
+// Disabled by setting GOGPU_WAYLAND_FRAME_CALLBACK=0.
+func FrameCallbackEnabled() bool {
+	v := os.Getenv("GOGPU_WAYLAND_FRAME_CALLBACK")
+	return v != "0"
+}

--- a/internal/platform/wayland/libwayland_frame_test.go
+++ b/internal/platform/wayland/libwayland_frame_test.go
@@ -1,0 +1,197 @@
+//go:build linux
+
+package wayland
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+)
+
+// TestFrameCallbackStateMachine verifies the 3-state machine transitions
+// (None → Requested → Received → None cycle) used for compositor frame gating.
+// Reference: winit state.rs:273-289.
+func TestFrameCallbackStateMachine(t *testing.T) {
+	tests := []struct {
+		name      string
+		initial   int32
+		operation string // "request" or "receive"
+		wantState int32
+		wantReady bool
+	}{
+		{
+			name:      "initial state is None",
+			initial:   FrameCallbackNone,
+			wantState: FrameCallbackNone,
+			wantReady: true,
+		},
+		{
+			name:      "Received state allows rendering",
+			initial:   FrameCallbackReceived,
+			wantState: FrameCallbackReceived,
+			wantReady: true,
+		},
+		{
+			name:      "Requested state blocks rendering",
+			initial:   FrameCallbackRequested,
+			wantState: FrameCallbackRequested,
+			wantReady: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &LibwaylandHandle{}
+			atomic.StoreInt32(&h.frameCallbackState, tt.initial)
+
+			if got := h.FrameCallbackReady(); got != tt.wantReady {
+				t.Errorf("FrameCallbackReady() = %v, want %v (state=%d)", got, tt.wantReady, tt.initial)
+			}
+
+			gotState := atomic.LoadInt32(&h.frameCallbackState)
+			if gotState != tt.wantState {
+				t.Errorf("state = %d, want %d", gotState, tt.wantState)
+			}
+		})
+	}
+}
+
+// TestFrameCallbackEnvVar verifies that GOGPU_WAYLAND_FRAME_CALLBACK=0
+// disables frame callback gating.
+func TestFrameCallbackEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     bool
+	}{
+		{"enabled by default (empty)", "", true},
+		{"enabled with 1", "1", true},
+		{"disabled with 0", "0", false},
+		{"enabled with arbitrary value", "yes", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue == "" {
+				os.Unsetenv("GOGPU_WAYLAND_FRAME_CALLBACK")
+			} else {
+				t.Setenv("GOGPU_WAYLAND_FRAME_CALLBACK", tt.envValue)
+			}
+
+			got := FrameCallbackEnabled()
+			if got != tt.want {
+				t.Errorf("FrameCallbackEnabled() = %v, want %v (env=%q)", got, tt.want, tt.envValue)
+			}
+		})
+	}
+}
+
+// TestFrameCallbackReadyConsume verifies the atomic consume pattern:
+// ConsumeFrameCallbackReady returns true only once, then false until
+// the next done event.
+func TestFrameCallbackReadyConsume(t *testing.T) {
+	h := &LibwaylandHandle{}
+
+	// Initially, ready flag is false (no callback has fired yet).
+	if h.ConsumeFrameCallbackReady() {
+		t.Error("ConsumeFrameCallbackReady() should be false initially")
+	}
+
+	// Simulate compositor firing done: set ready flag.
+	h.frameCallbackReady.Store(true)
+
+	// First consume should return true.
+	if !h.ConsumeFrameCallbackReady() {
+		t.Error("ConsumeFrameCallbackReady() should be true after done")
+	}
+
+	// Second consume should return false (already consumed).
+	if h.ConsumeFrameCallbackReady() {
+		t.Error("ConsumeFrameCallbackReady() should be false after second consume")
+	}
+}
+
+// TestFrameCallbackStateConstants verifies the state constants match the
+// expected values from the winit 3-state pattern.
+func TestFrameCallbackStateConstants(t *testing.T) {
+	if FrameCallbackNone != 0 {
+		t.Errorf("FrameCallbackNone = %d, want 0", FrameCallbackNone)
+	}
+	if FrameCallbackRequested != 1 {
+		t.Errorf("FrameCallbackRequested = %d, want 1", FrameCallbackRequested)
+	}
+	if FrameCallbackReceived != 2 {
+		t.Errorf("FrameCallbackReceived = %d, want 2", FrameCallbackReceived)
+	}
+}
+
+// TestFrameCallbackReadyStateTransitions verifies FrameCallbackReady
+// returns correct values for each state.
+func TestFrameCallbackReadyStateTransitions(t *testing.T) {
+	h := &LibwaylandHandle{}
+
+	// None → ready
+	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackNone)
+	if !h.FrameCallbackReady() {
+		t.Error("FrameCallbackReady() should be true in None state")
+	}
+
+	// Requested → not ready
+	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackRequested)
+	if h.FrameCallbackReady() {
+		t.Error("FrameCallbackReady() should be false in Requested state")
+	}
+
+	// Received → ready
+	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackReceived)
+	if !h.FrameCallbackReady() {
+		t.Error("FrameCallbackReady() should be true in Received state")
+	}
+}
+
+// TestFrameCallbackDoneCbRouting verifies that the done callback correctly
+// routes to the LibwaylandHandle via the per-proxy map.
+func TestFrameCallbackDoneCbRouting(t *testing.T) {
+	h := &LibwaylandHandle{}
+	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackRequested)
+
+	// Simulate a callback proxy pointer.
+	fakeProxy := uintptr(0xDEAD_BEEF)
+
+	// Register the handle.
+	frameCallbackHandlesMu.Lock()
+	frameCallbackHandles[fakeProxy] = h
+	frameCallbackHandlesMu.Unlock()
+
+	// The done callback cannot be called directly here because it calls
+	// proxyDestroy which requires a real C connection. Instead, verify
+	// the map routing works.
+	frameCallbackHandlesMu.Lock()
+	got := frameCallbackHandles[fakeProxy]
+	frameCallbackHandlesMu.Unlock()
+
+	if got != h {
+		t.Error("frame callback handle not found in map")
+	}
+
+	// Clean up.
+	frameCallbackHandlesMu.Lock()
+	delete(frameCallbackHandles, fakeProxy)
+	frameCallbackHandlesMu.Unlock()
+}
+
+// TestFrameCallbackDoneCbMissingHandle verifies that the done callback
+// handles a missing handle gracefully (no panic).
+func TestFrameCallbackDoneCbMissingHandle(t *testing.T) {
+	// Call with a proxy that has no registered handle.
+	// Should not panic — just return silently.
+	// Note: We can't call frameCallbackDoneCb directly because it calls
+	// proxyDestroy. Test that the map lookup handles missing entries.
+	frameCallbackHandlesMu.Lock()
+	h := frameCallbackHandles[uintptr(0xBAD_F00D)]
+	frameCallbackHandlesMu.Unlock()
+
+	if h != nil {
+		t.Error("expected nil handle for unregistered proxy")
+	}
+}

--- a/renderer.go
+++ b/renderer.go
@@ -553,7 +553,9 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	// Request frame callback BEFORE present (winit pre_present_notify pattern).
 	// Wayland spec: "The frame request will take effect on the next commit."
 	// The present's internal wl_surface.commit activates it atomically.
-	ws.platWindow.SyncFrame()
+	if ws.platWindow != nil {
+		ws.platWindow.SyncFrame()
+	}
 	reconfigured := ws.present()
 	ws.releaseFrame()
 	return reconfigured

--- a/renderer.go
+++ b/renderer.go
@@ -550,6 +550,10 @@ func (r *Renderer) EndFrame() {
 // Returns true if present() reconfigured an outdated surface (see present).
 func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	ws.flushClear(r.device, r)
+	// Request frame callback BEFORE present (winit pre_present_notify pattern).
+	// Wayland spec: "The frame request will take effect on the next commit."
+	// The present's internal wl_surface.commit activates it atomically.
+	ws.platWindow.SyncFrame()
 	reconfigured := ws.present()
 	ws.releaseFrame()
 	return reconfigured


### PR DESCRIPTION
## Summary

Wayland `wl_surface.frame` callback gating to fix animation visual glitch (ui#152, BUG-WL-006).

Without frame callback gating, the render loop outran the Wayland compositor's presentation rate, causing CSD subsurface desync during animation — visible on camera but not in screen recordings.

## Architecture (ADR-049)

- **winit 3-state machine** (None/Requested/Received) via C libwayland FFI (goffi)
- Frame callback requested BEFORE present (winit `pre_present_notify` pattern) — present's internal `wl_surface.commit` activates callback atomically
- `FrameGater` optional interface (type assertion, like existing `DisplayLocker`)
- Atomic state transitions: lock-free reads, `displayMu` only for C calls
- Per-proxy callback routing map for multi-window support
- `GOGPU_WAYLAND_FRAME_CALLBACK=0` env var to disable for debugging

## Enterprise references (verified against local code)

- winit `state.rs:273-282` — 3-state machine, gates RedrawRequested
- SDL3 `SDL_waylandwindow.c:2968` — `wl_surface_frame` for ALL windows (including Vulkan)
- Gio `os_wayland.go:1779` — `lastFrameCallback == nil` gate
- Wayland spec: "The frame request will take effect on the next wl_surface.commit"

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./...` — passes (7 new frame callback tests + existing tests)
- [x] `golangci-lint run` — 0 issues (Windows, Linux, macOS)
- [ ] Visual: WSL2 Wayland test with collapsible animation
- [ ] @porjo verification on Intel Iris Plus ICL GT2 / Fedora 44
