### PR TITLE
fix: migrate to gputypes.BlockCopySize — RG16 bug fix (v0.42.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.10] - 2026-06-28
+
+### Fixed
+
+- **RG16 texture format size bug** (FEAT-GPUTYPES-001) — `RG16Uint/Sint/Float` returned 8 bytes instead of 4 (grouped with RGBA16 in switch). Migrated `bytesPerPixelForFormat()` to `gputypes.TextureFormat.BlockCopySize()` — canonical source of truth verified against Rust wgpu-types (87 formats). Deleted local switch table.
+
+### Changed
+
+- **deps:** gputypes v0.5.0 → v0.5.1 (BlockCopySize), wgpu v0.30.5 → v0.30.7 (format-aware copy/clear + GLES LockOSThread flaky fix)
+
 ## [0.42.9] - 2026-06-28
 
 ### Fixed

--- a/bench_test.go
+++ b/bench_test.go
@@ -54,12 +54,12 @@ func BenchmarkDefaultTextureOptions(b *testing.B) {
 }
 
 // ---------------------------------------------------------------------------
-// bytesPerPixelForFormat benchmarks
+// BlockCopySize benchmarks
 // ---------------------------------------------------------------------------
 
-// BenchmarkBytesPerPixelForFormat measures texture format lookup cost,
-// called during texture updates (UpdateData, UpdateRegion).
-func BenchmarkBytesPerPixelForFormat(b *testing.B) {
+// BenchmarkBlockCopySize measures texture format lookup cost via
+// gputypes.TextureFormat.BlockCopySize() (canonical source of truth).
+func BenchmarkBlockCopySize(b *testing.B) {
 	formats := []struct {
 		name   string
 		format gputypes.TextureFormat
@@ -74,9 +74,9 @@ func BenchmarkBytesPerPixelForFormat(b *testing.B) {
 	for _, f := range formats {
 		b.Run(f.name, func(b *testing.B) {
 			b.ReportAllocs()
-			var result int
+			var result uint32
 			for b.Loop() {
-				result = bytesPerPixelForFormat(f.format)
+				result = f.format.BlockCopySize()
 			}
 			runtime.KeepAlive(result)
 		})

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.5
 	github.com/gogpu/gpucontext v0.21.0
-	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/wgpu v0.30.5
+	github.com/gogpu/gputypes v0.5.1
+	github.com/gogpu/wgpu v0.30.7
 	golang.org/x/sys v0.46.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,11 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
-github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
-github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
+github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.15 h1:uyy4bc8wYlvDaYOpmCBYrJ+d+e7ZqP2BN36csmRVs7o=
 github.com/gogpu/naga v0.17.15/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.30.5 h1:nOrSKQCMYyn/G6GhFVi6jehbV1DNnvHaUfcczFwRij4=
-github.com/gogpu/wgpu v0.30.5/go.mod h1:Ih63YKckUGtNXnXT6LjkHcH6FUfib0TjCwDR5615gPI=
+github.com/gogpu/wgpu v0.30.7 h1:6oUDyu3fphQNaTuB/4qBFYqRUIdw11O1mPm5aF/Lx9o=
+github.com/gogpu/wgpu v0.30.7/go.mod h1:Mfd5ail+nNg8Gl/vt6cijoWMz41cpl2z+Mpx+I+ZkQ8=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/texture.go
+++ b/texture.go
@@ -121,57 +121,11 @@ func (t *Texture) Sampler() *wgpu.Sampler {
 }
 
 // BytesPerPixel returns the number of bytes per pixel for the texture format.
-// Returns 4 for RGBA8/BGRA8 formats (the most common), 0 for unknown formats.
+// Delegates to gputypes.TextureFormat.BlockCopySize() — the canonical source
+// of truth for format sizes (verified against Rust wgpu-types).
+// Returns 0 for unknown or implementation-defined formats.
 func (t *Texture) BytesPerPixel() int {
-	return bytesPerPixelForFormat(t.format)
-}
-
-// bytesPerPixelForFormat returns bytes per pixel for a given texture format.
-func bytesPerPixelForFormat(format gputypes.TextureFormat) int {
-	switch format {
-	case gputypes.TextureFormatRGBA8Unorm,
-		gputypes.TextureFormatRGBA8UnormSrgb,
-		gputypes.TextureFormatRGBA8Snorm,
-		gputypes.TextureFormatRGBA8Uint,
-		gputypes.TextureFormatRGBA8Sint,
-		gputypes.TextureFormatBGRA8Unorm,
-		gputypes.TextureFormatBGRA8UnormSrgb:
-		return 4
-	case gputypes.TextureFormatR8Unorm,
-		gputypes.TextureFormatR8Snorm,
-		gputypes.TextureFormatR8Uint,
-		gputypes.TextureFormatR8Sint:
-		return 1
-	case gputypes.TextureFormatR16Uint,
-		gputypes.TextureFormatR16Sint,
-		gputypes.TextureFormatR16Float,
-		gputypes.TextureFormatRG8Unorm,
-		gputypes.TextureFormatRG8Snorm,
-		gputypes.TextureFormatRG8Uint,
-		gputypes.TextureFormatRG8Sint:
-		return 2
-	case gputypes.TextureFormatRG16Uint,
-		gputypes.TextureFormatRG16Sint,
-		gputypes.TextureFormatRG16Float,
-		gputypes.TextureFormatRGBA16Uint,
-		gputypes.TextureFormatRGBA16Sint,
-		gputypes.TextureFormatRGBA16Float:
-		return 8
-	case gputypes.TextureFormatR32Uint,
-		gputypes.TextureFormatR32Sint,
-		gputypes.TextureFormatR32Float:
-		return 4
-	case gputypes.TextureFormatRG32Uint,
-		gputypes.TextureFormatRG32Sint,
-		gputypes.TextureFormatRG32Float:
-		return 8
-	case gputypes.TextureFormatRGBA32Uint,
-		gputypes.TextureFormatRGBA32Sint,
-		gputypes.TextureFormatRGBA32Float:
-		return 16
-	default:
-		return 0
-	}
+	return int(t.format.BlockCopySize())
 }
 
 // Destroy releases all GPU resources associated with this texture.

--- a/texture_test.go
+++ b/texture_test.go
@@ -267,9 +267,12 @@ func TestBytesPerPixel(t *testing.T) {
 		{"BGRA8UnormSrgb", gputypes.TextureFormatBGRA8UnormSrgb, 4},
 		{"R8Unorm", gputypes.TextureFormatR8Unorm, 1},
 		{"R16Float", gputypes.TextureFormatR16Float, 2},
+		{"RG16Float", gputypes.TextureFormatRG16Float, 4},
 		{"R32Float", gputypes.TextureFormatR32Float, 4},
+		{"RGBA16Float", gputypes.TextureFormatRGBA16Float, 8},
 		{"RG32Float", gputypes.TextureFormatRG32Float, 8},
 		{"RGBA32Float", gputypes.TextureFormatRGBA32Float, 16},
+		{"unknown", gputypes.TextureFormat(9999), 0},
 	}
 
 	for _, tt := range tests {
@@ -280,46 +283,6 @@ func TestBytesPerPixel(t *testing.T) {
 				t.Errorf("BytesPerPixel() = %d, want %d", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestBytesPerPixelForFormat(t *testing.T) {
-	// Test the internal function directly
-	tests := []struct {
-		format gputypes.TextureFormat
-		want   int
-	}{
-		{gputypes.TextureFormatRGBA8Snorm, 4},
-		{gputypes.TextureFormatRGBA8Uint, 4},
-		{gputypes.TextureFormatRGBA8Sint, 4},
-		{gputypes.TextureFormatR8Snorm, 1},
-		{gputypes.TextureFormatR8Uint, 1},
-		{gputypes.TextureFormatR8Sint, 1},
-		{gputypes.TextureFormatRG8Unorm, 2},
-		{gputypes.TextureFormatRG8Snorm, 2},
-		{gputypes.TextureFormatRG16Float, 8},
-		{gputypes.TextureFormatRGBA16Float, 8},
-		{gputypes.TextureFormatR32Uint, 4},
-		{gputypes.TextureFormatR32Sint, 4},
-		{gputypes.TextureFormatRG32Uint, 8},
-		{gputypes.TextureFormatRG32Sint, 8},
-		{gputypes.TextureFormatRGBA32Uint, 16},
-		{gputypes.TextureFormatRGBA32Sint, 16},
-	}
-
-	for _, tt := range tests {
-		got := bytesPerPixelForFormat(tt.format)
-		if got != tt.want {
-			t.Errorf("bytesPerPixelForFormat(%v) = %d, want %d", tt.format, got, tt.want)
-		}
-	}
-}
-
-func TestBytesPerPixelUnknownFormat(t *testing.T) {
-	// Unknown format should return 0
-	got := bytesPerPixelForFormat(gputypes.TextureFormat(9999))
-	if got != 0 {
-		t.Errorf("bytesPerPixelForFormat(unknown) = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
Delete local bytesPerPixelForFormat, use gputypes.BlockCopySize() (87 formats, Rust parity). Fixes RG16 bug (8→4). deps: gputypes v0.5.1, wgpu v0.30.6. FEAT-GPUTYPES-001 Phase 3.