### PR TITLE
feat: event-driven rendering by default (winit pattern)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.0] - 2026-06-29
+
+### Changed
+
+- **Event-driven rendering by default** — `DefaultConfig()` now sets `ContinuousRender: false` (was `true`). Applications render only on events or `RequestRedraw()` — 0% CPU when idle. Games and animations should use `WithContinuousRender(true)` explicitly. Follows winit 0.29 precedent (`ControlFlow::Poll` → `Wait`). Enterprise refs: Flutter, Qt, GTK4, Iced — all enforce event-driven for UI entry points.
+
 ## [0.42.11] - 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -417,12 +417,11 @@ GoGPU uses a three-state rendering model for optimal power efficiency:
 |-------|-----------|-----------|---------|
 | **Idle** | No activity | 0% (blocks on OS events) | <1ms wakeup |
 | **Animating** | Active animation tokens | VSync (~60fps) | Smooth |
-| **Continuous** | `ContinuousRender=true` | 100% (game loop) | Immediate |
+| **Continuous** | `WithContinuousRender(true)` | 100% (game loop) | Immediate |
 
 ```go
-// Event-driven mode (default for UI apps)
-app := gogpu.NewApp(gogpu.DefaultConfig().
-    WithContinuousRender(false))
+// Event-driven mode (default — 0% CPU when idle)
+app := gogpu.NewApp(gogpu.DefaultConfig())
 
 // Start animation — renders at VSync while token is alive
 token := app.StartAnimation()

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.42.11
+## Current State: v0.43.0
 
 ✅ **Production-ready** with full feature set:
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.

--- a/config.go
+++ b/config.go
@@ -66,8 +66,9 @@ type Config struct {
 
 	// ContinuousRender enables continuous rendering (game loop style).
 	// When false (default), renders only when RequestRedraw() is called
-	// or when events occur (resize, input, etc.) - more power efficient.
-	// When true, renders every frame at VSync rate - suitable for games/animations.
+	// or when events occur (resize, input, etc.) — power efficient for UI apps.
+	// When true, renders every frame at VSync rate — suitable for games/animations.
+	// Use WithContinuousRender(true) for game loops.
 	ContinuousRender bool
 
 	// Frameless removes the OS window chrome (title bar, borders).
@@ -115,8 +116,8 @@ type Config struct {
 }
 
 // DefaultConfig returns a sensible default configuration.
-// By default, uses continuous rendering (game loop style).
-// For power-efficient UI apps, use WithContinuousRender(false).
+// By default, uses event-driven rendering (0% CPU when idle).
+// For game loops, use WithContinuousRender(true).
 //
 // The graphics API can be overridden via the GOGPU_GRAPHICS_API environment variable:
 //
@@ -147,7 +148,7 @@ func DefaultConfig() Config {
 		Height:           600,
 		Resizable:        true,
 		VSync:            true,
-		ContinuousRender: true,
+		ContinuousRender: false,
 		GraphicsAPI:      graphicsAPIFromEnv(),
 		PowerPreference:  powerPreferenceFromEnv(),
 		RenderMode:       renderModeFromEnv(),
@@ -239,8 +240,8 @@ func (c Config) WithVSync(vsync bool) Config {
 }
 
 // WithContinuousRender sets the rendering mode.
-// When true (default): renders every frame at VSync rate - for games/animations.
-// When false: renders only on RequestRedraw() or events - power efficient for UI.
+// When true: renders every frame at VSync rate — for games/animations.
+// When false (default): renders only on RequestRedraw() or events — power efficient.
 func (c Config) WithContinuousRender(continuous bool) Config {
 	c.ContinuousRender = continuous
 	return c

--- a/config_test.go
+++ b/config_test.go
@@ -36,8 +36,8 @@ func TestDefaultConfigValues(t *testing.T) {
 	if cfg.GraphicsAPI != types.GraphicsAPIAuto {
 		t.Errorf("GraphicsAPI = %v, want GraphicsAPIAuto", cfg.GraphicsAPI)
 	}
-	if !cfg.ContinuousRender {
-		t.Error("ContinuousRender = false, want true")
+	if cfg.ContinuousRender {
+		t.Error("ContinuousRender = true, want false")
 	}
 	if cfg.Frameless {
 		t.Error("Frameless = true, want false")
@@ -242,9 +242,9 @@ func TestConfigImmutability(t *testing.T) {
 		t.Errorf("Original GraphicsAPI was mutated to %v, want GraphicsAPIAuto", original.GraphicsAPI)
 	}
 
-	_ = original.WithContinuousRender(false)
-	if !original.ContinuousRender {
-		t.Error("Original ContinuousRender was mutated to false, want true")
+	_ = original.WithContinuousRender(true)
+	if original.ContinuousRender {
+		t.Error("Original ContinuousRender was mutated to true, want false")
 	}
 
 	_ = original.WithFrameless(true)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -446,7 +446,7 @@ The main loop uses a three-state model for optimal power efficiency:
 │       │                                                 │
 │       │ RequestRedraw()                                 │
 │       ▼                                                 │
-│  ┌──────────┐    ContinuousRender=true                  │
+│  ┌──────────┐    WithContinuousRender(true)             │
 │  │ ONE FRAME│ ──────────────────────►┌───────────────┐  │
 │  │  render  │                        │  CONTINUOUS   │  │
 │  │  + idle  │                        │  game loop    │  │
@@ -460,7 +460,7 @@ The main loop uses a three-state model for optimal power efficiency:
 |-------|---------|----------|-----|
 | **IDLE** | No animations, no invalidation | Blocks on `platform.WaitEvents()` | 0% |
 | **ANIMATING** | `StartAnimation()` token active | Renders at VSync rate | ~2-5% |
-| **CONTINUOUS** | `ContinuousRender=true` | Renders every frame | ~100% |
+| **CONTINUOUS** | `WithContinuousRender(true)` | Renders every frame | ~100% |
 
 ### Key Components
 

--- a/examples/hidpi/main.go
+++ b/examples/hidpi/main.go
@@ -13,8 +13,7 @@ import (
 func main() {
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("HiDPI — logical res → physical res (cycles every 2s)").
-		WithSize(800, 600).
-		WithContinuousRender(false))
+		WithSize(800, 600))
 
 	fmt.Printf("ScaleFactor before Run: %.1f\n", app.ScaleFactor())
 


### PR DESCRIPTION
## Summary

- **DefaultConfig().ContinuousRender**: `true` → `false` (safe-by-default, 0% CPU idle)
- Follows **winit 0.29** precedent (`ControlFlow::Poll` → `Wait`)
- Enterprise refs: Flutter, Qt, GTK4, Iced — all enforce event-driven for UI
- Games use `WithContinuousRender(true)` explicitly (particles/pipeline already do)

## Changes

- `config.go` — default + doc comments
- `config_test.go` — updated assertions
- `examples/hidpi/` — removed redundant `WithContinuousRender(false)`
- `README.md` — updated render mode table + code sample
- `docs/ARCHITECTURE.md` — updated state diagram + table
- `CHANGELOG.md` — v0.43.0 entry
- `ROADMAP.md` — version bump

## Breaking Change (pre-v1.0)

Static examples (`triangle`, `gpucontext_integration`) now render event-driven instead of continuous. Both are static scenes — visually identical. Game examples already set `WithContinuousRender(true)` explicitly.

## Follow-up

After merge + release, gg and ui repos will remove redundant `WithContinuousRender(false)` from their examples/docs (separate PRs).

## Test plan

- [x] `go build ./...` — pass
- [x] `go test ./...` — pass (config_test updated)
- [x] `golangci-lint run` — 0 issues
- [ ] CI (all platforms)