### PR TITLE
feat/header-positioning-and-resize-fix :   Add header alignment suppo…

### DIFF
--- a/app.go
+++ b/app.go
@@ -492,6 +492,8 @@ func (a *App) initPlatform() (platform.PlatformWindow, error) {
 		a.applyHitTestCallback()
 	}
 
+	applyHeaderAlignment(platWindow, a.config.HeaderAlignment)
+
 	// Ensure input subsystems exist. Both EventSource() and Input() use
 	// lazy init so callers can register callbacks before Run(). We must
 	// NOT overwrite instances that were already created — UI frameworks
@@ -514,6 +516,30 @@ func (a *App) initPlatform() (platform.PlatformWindow, error) {
 	// Future: An independent render thread running on its own schedule
 	// would eliminate this callback entirely. See ROADMAP.md for details.
 	a.platWindow.SetModalFrameCallback(a.modalFrameTick)
+
+	// Enable rendering during macOS live resize.
+	//
+	// On macOS, AppKit runs a modal tracking loop during window resize
+	// (inside sendEvent:) that blocks our outer event loop. Without this hook
+	// the old frame sits in the CAMetalLayer at the old size and macOS stretches
+	// it to fill the new window dimensions, producing visible distortion.
+	//
+	// windowDidResize: fires on every resize step from within AppKit's tracking
+	// loop. We call renderFrameMultiThread from the delegate callback goroutine;
+	// the render goroutine is idle while AppKit's modal loop holds the main
+	// goroutine, so RunOnRenderThreadVoid proceeds without deadlock.
+	if lr, ok := platWindow.(platform.LiveResizeRenderer); ok {
+		lr.SetLiveResizeHook(func() {
+			if a.renderLoop == nil {
+				return
+			}
+			physW, physH := platWindow.PhysicalSize()
+			if physW > 0 && physH > 0 {
+				a.renderLoop.RequestResize(uint32(physW), uint32(physH)) //nolint:gosec // G115: validated positive
+			}
+			a.renderFrameMultiThread()
+		})
+	}
 
 	return platWindow, nil
 }
@@ -562,8 +588,9 @@ func (a *App) processEventsMultiThread() {
 	}
 
 	// Queue primary window resize for render thread (deferred pattern).
-	// Don't apply resize during modal resize loop (Windows).
-	if lastResize != nil && a.platWindow != nil && !a.platWindow.InSizeMove() {
+	// RequestResize is an atomic coalesced store so rapid live-resize events
+	// (macOS) collapse to one configure() call per render frame.
+	if lastResize != nil && a.platWindow != nil {
 		// Queue PHYSICAL size for render thread (GPU surface reconfiguration)
 		physW, physH := lastResize.PhysicalWidth, lastResize.PhysicalHeight
 		if physW > 0 && physH > 0 {
@@ -778,14 +805,15 @@ func (a *App) registerPrimaryWindow(platWindow platform.PlatformWindow) {
 	a.windowManager = newWindowManager()
 	internalID := a.windowManager.allocate()
 	a.primaryWindow = &Window{
-		id:         internalID,
-		platformID: platWindow.ID(),
-		config:     a.config,
-		surface:    a.renderer.primary,
-		platWindow: a.platWindow,
-		onDraw:     a.onDraw,
-		onResize:   a.onResize,
-		visible:    true,
+		id:              internalID,
+		platformID:      platWindow.ID(),
+		config:          a.config,
+		surface:         a.renderer.primary,
+		platWindow:      a.platWindow,
+		onDraw:          a.onDraw,
+		onResize:        a.onResize,
+		headerAlignment: a.config.HeaderAlignment,
+		visible:         true,
 	}
 	a.primaryPlatformID = platWindow.ID()
 	a.windowManager.add(a.primaryWindow)

--- a/app.go
+++ b/app.go
@@ -951,6 +951,12 @@ func (a *App) modalFrameTick() {
 		a.renderLoop.RequestResize(uint32(width), uint32(height)) //nolint:gosec // G115: validated positive
 	}
 
+	// Resize secondary window swapchains to match their current physical size.
+	// During modal drag/resize on a secondary window, WM_SIZE events are
+	// suppressed and processEventsMultiThread doesn't run, so we handle
+	// swapchain updates here. resize() is a no-op when dimensions are unchanged.
+	a.resizeSecondaryWindowsDuringModal()
+
 	// Render frame on render thread (blocks until complete).
 	a.renderFrameMultiThread()
 
@@ -958,6 +964,47 @@ func (a *App) modalFrameTick() {
 	// This ensures our frame and the DWM window border update
 	// appear in the same composition cycle, reducing resize lag.
 	a.platWindow.SyncFrame()
+}
+
+// resizeSecondaryWindowsDuringModal resizes swapchains for secondary windows
+// while a Win32 modal drag/resize loop is active. During the modal loop,
+// WM_SIZE events are suppressed and processEventsMultiThread doesn't run, so
+// secondary swapchains must be updated here instead.
+func (a *App) resizeSecondaryWindowsDuringModal() {
+	if a.windowManager == nil || a.renderer == nil {
+		return
+	}
+
+	type pendingResize struct {
+		ws   *RenderTarget
+		w, h int
+	}
+
+	a.windowManager.mu.RLock()
+	resizes := make([]pendingResize, 0, len(a.windowManager.order))
+	for _, id := range a.windowManager.order {
+		win := a.windowManager.windows[id]
+		if win == nil || win.platWindow == nil || win.surface == nil {
+			continue
+		}
+		if win == a.primaryWindow {
+			continue // primary handled by RequestResize / ConsumePendingResize
+		}
+		pw, ph := win.platWindow.PhysicalSize()
+		if pw > 0 && ph > 0 {
+			resizes = append(resizes, pendingResize{win.surface, pw, ph})
+		}
+	}
+	a.windowManager.mu.RUnlock()
+
+	if len(resizes) == 0 {
+		return
+	}
+	a.renderLoop.RunOnRenderThreadVoid(func() {
+		for _, r := range resizes {
+			r.ws.resize(r.w, r.h, a.renderer.device, a.renderer.adapter)
+		}
+	})
 }
 
 // SetAppName sets the name of the application.

--- a/config.go
+++ b/config.go
@@ -102,6 +102,13 @@ type Config struct {
 	// AppName is the application name (displayed in menus).
 	AppName string
 
+	// HeaderAlignment controls the position of the title in the OS header bar.
+	// HeaderAlignCenter (default): centers the title (standard macOS behavior).
+	// HeaderAlignLeft / HeaderAlignRight: on macOS, enables a full-size content
+	// view with a transparent title bar so GPU-rendered content fills the header.
+	// No-op on Windows and Linux where title position is not OS-configurable.
+	HeaderAlignment HeaderAlignment
+
 	// MinWidth is the minimum window width in logical pixels (0 = no constraint).
 	MinWidth int
 
@@ -321,6 +328,13 @@ func (c Config) WithMinSize(width, height int) Config {
 func (c Config) WithMaxSize(width, height int) Config {
 	c.MaxWidth = width
 	c.MaxHeight = height
+	return c
+}
+
+// WithHeaderAlignment sets the title alignment in the window header bar.
+// See Config.HeaderAlignment for platform-specific behavior.
+func (c Config) WithHeaderAlignment(alignment HeaderAlignment) Config {
+	c.HeaderAlignment = alignment
 	return c
 }
 

--- a/examples/window_header/main.go
+++ b/examples/window_header/main.go
@@ -1,0 +1,168 @@
+// Example: Window header alignment
+//
+// Demonstrates the three header alignment modes available in gogpu,
+// mirroring Flutter's AppBar.centerTitle pattern.
+//
+// Run with:
+//
+//	go run ./examples/window_header
+//
+// Platform behavior:
+//
+//	macOS  — Left: FullSizeContentView + transparent title bar; native title
+//	         visible, positioned after the traffic-light buttons (left side).
+//	         Right: same transparent title bar + a right-aligned NSTextField
+//	         injected into the title bar view; native title is hidden.
+//	         Center: standard opaque title bar with centered native title.
+//	Linux  — Wayland CSD painter positions the title text left/center/right.
+//	         X11 title bar is drawn by the compositor; alignment is accepted
+//	         but has no visual effect.
+//	Windows — title bar is drawn by DWM; alignment is accepted but has no
+//	          visual effect.
+//
+// Keys (focus any window):
+//
+//	L — switch primary window to HeaderAlignLeft
+//	C — switch primary window to HeaderAlignCenter
+//	R — switch primary window to HeaderAlignRight
+//	T — cycle primary window title through three example strings
+//	Q / Esc — quit
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gogpu/gogpu"
+	"github.com/gogpu/gpucontext"
+)
+
+func main() {
+	// --- Primary window: HeaderAlignLeft (via Config builder) ----------------
+	//
+	// On macOS this enables NSWindowStyleMaskFullSizeContentView and makes the
+	// title bar transparent, so the GPU surface covers the full window height.
+	// The native title remains visible (macOS always centers it), while GPU
+	// content fills the entire height including the title-bar zone.
+	app := gogpu.NewApp(
+		gogpu.DefaultConfig().
+			WithTitle("Header: Left — GPU fills title bar").
+			WithSize(680, 420).
+			WithHeaderAlignment(gogpu.HeaderAlignLeft),
+	)
+
+	// Teal background. In a real app draw a header strip in the top ~28 pt
+	// title-bar zone using ggcanvas or a custom shader.
+	app.OnDraw(func(ctx *gogpu.Context) {
+		ctx.Clear(0.07, 0.40, 0.45, 1)
+	})
+
+	// Title cycling state for the T key demo.
+	titles := []string{
+		"Header: Left — GPU fills title bar",
+		"App title updated at runtime",
+		"Window.SetTitle() is per-window",
+	}
+	titleIdx := 0
+
+	app.EventSource().OnKeyPress(func(key gpucontext.Key, _ gpucontext.Modifiers) {
+		switch key {
+		case gpucontext.KeyL:
+			app.SetHeaderAlignment(gogpu.HeaderAlignLeft)
+			fmt.Println("Primary window → HeaderAlignLeft")
+		case gpucontext.KeyC:
+			app.SetHeaderAlignment(gogpu.HeaderAlignCenter)
+			fmt.Println("Primary window → HeaderAlignCenter")
+		case gpucontext.KeyR:
+			app.SetHeaderAlignment(gogpu.HeaderAlignRight)
+			fmt.Println("Primary window → HeaderAlignRight")
+		case gpucontext.KeyT:
+			titleIdx = (titleIdx + 1) % len(titles)
+			app.SetTitle(titles[titleIdx])
+			fmt.Printf("Primary window title → %q\n", titles[titleIdx])
+		case gpucontext.KeyQ, gpucontext.KeyEscape:
+			app.Quit()
+		}
+	})
+
+	// Create secondary windows once the renderer is ready.
+	var secondaryCreated bool
+	app.OnUpdate(func(_ float64) {
+		if secondaryCreated {
+			return
+		}
+		secondaryCreated = true
+
+		// --- Secondary window: HeaderAlignCenter (default) -------------------
+		//
+		// Standard macOS title bar with the title centered. This is the default
+		// behavior — equivalent to omitting WithHeaderAlignment entirely.
+		wCenter, err := app.NewWindow(
+			gogpu.DefaultConfig().
+				WithTitle("Header: Center (default)").
+				WithSize(560, 360).
+				WithHeaderAlignment(gogpu.HeaderAlignCenter),
+		)
+		if err != nil {
+			log.Printf("NewWindow (center): %v", err)
+			return
+		}
+		fmt.Printf("Center window created: ID=%d\n", wCenter.ID())
+
+		// Purple background.
+		wCenter.SetOnDraw(func(ctx *gogpu.Context) {
+			ctx.Clear(0.38, 0.18, 0.55, 1)
+		})
+
+		// Press T while this window is focused to change its title independently
+		// of the primary window — demonstrating per-window SetTitle().
+		wCenter.SetOnKeyPress(func(key gpucontext.Key, _ gpucontext.Modifiers) {
+			if key == gpucontext.KeyT {
+				wCenter.SetTitle("Center — changed via Window.SetTitle()")
+				fmt.Printf("Center window title → %q\n", wCenter.Title())
+			}
+		})
+
+		// --- Secondary window: HeaderAlignRight ------------------------------
+		//
+		// On macOS: transparent title bar (FullSizeContentView) with the native
+		// title hidden; a right-aligned NSTextField is injected into the title bar
+		// view so the title appears at the right edge.
+		// On Wayland: CSD painter draws the title text right-aligned.
+		wRight, err := app.NewWindow(
+			gogpu.DefaultConfig().
+				WithTitle("Header: Right — GPU fills title bar").
+				WithSize(560, 360).
+				WithHeaderAlignment(gogpu.HeaderAlignRight),
+		)
+		if err != nil {
+			log.Printf("NewWindow (right): %v", err)
+			return
+		}
+		fmt.Printf("Right window created: ID=%d\n", wRight.ID())
+
+		// Amber/orange background.
+		wRight.SetOnDraw(func(ctx *gogpu.Context) {
+			ctx.Clear(0.80, 0.45, 0.10, 1)
+		})
+
+		// Demonstrate runtime alignment switching on a secondary window.
+		wRight.SetOnKeyPress(func(key gpucontext.Key, _ gpucontext.Modifiers) {
+			switch key {
+			case gpucontext.KeyL:
+				wRight.SetHeaderAlignment(gogpu.HeaderAlignLeft)
+				fmt.Printf("Right window → HeaderAlignLeft (ID %d)\n", wRight.ID())
+			case gpucontext.KeyC:
+				wRight.SetHeaderAlignment(gogpu.HeaderAlignCenter)
+				fmt.Printf("Right window → HeaderAlignCenter (ID %d)\n", wRight.ID())
+			case gpucontext.KeyR:
+				wRight.SetHeaderAlignment(gogpu.HeaderAlignRight)
+				fmt.Printf("Right window → HeaderAlignRight (ID %d)\n", wRight.ID())
+			}
+		})
+	})
+
+	if err := app.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/platform/darwin/events.go
+++ b/internal/platform/darwin/events.go
@@ -92,6 +92,17 @@ type EventInfo struct {
 	PointingDeviceType NSUInteger
 }
 
+// GetEventWindow returns the NSWindow associated with an NSEvent.
+// Returns the nil ID for events not tied to a specific window (key events
+// after window close, system events, etc.).
+func GetEventWindow(event ID) ID {
+	if event.IsNil() {
+		return ID(0)
+	}
+	initSelectors()
+	return event.Send(selectors.eventWindow)
+}
+
 // GetEventInfo extracts pointer-relevant information from an NSEvent.
 func GetEventInfo(event ID) EventInfo {
 	if event.IsNil() {

--- a/internal/platform/darwin/selectors.go
+++ b/internal/platform/darwin/selectors.go
@@ -111,6 +111,9 @@ var selectors struct {
 	screens      SEL
 	visibleFrame SEL
 
+	// NSEvent
+	eventWindow SEL // [NSEvent window] → NSWindow* (nil for window-less events)
+
 	// NSDate
 	distantPast   SEL
 	distantFuture SEL
@@ -345,6 +348,9 @@ func initSelectors() {
 		selectors.mainScreen = RegisterSelector("mainScreen")
 		selectors.screens = RegisterSelector("screens")
 		selectors.visibleFrame = RegisterSelector("visibleFrame")
+
+		// NSEvent
+		selectors.eventWindow = RegisterSelector("window")
 
 		// NSDate
 		selectors.distantPast = RegisterSelector("distantPast")

--- a/internal/platform/darwin/selectors.go
+++ b/internal/platform/darwin/selectors.go
@@ -61,6 +61,13 @@ var selectors struct {
 	setCollectionBehavior                    SEL
 	windowShouldClose                        SEL
 	windowDidChangeScreen                    SEL
+	windowWillStartLiveResize                SEL
+	windowDidEndLiveResize                   SEL
+	windowDidResize                          SEL
+
+	// NSWindow titlebar transparency / title visibility
+	setTitlebarAppearsTransparent SEL
+	setTitleVisibility            SEL
 
 	// NSView - View management
 	setWantsLayer   SEL
@@ -70,6 +77,31 @@ var selectors struct {
 	bounds          SEL
 	setBounds       SEL
 	setNeedsDisplay SEL
+
+	// NSView - view hierarchy manipulation
+	superview                      SEL
+	addSubview                     SEL
+	addSubviewPositionedRelativeTo SEL
+	removeFromSuperview            SEL
+
+	// NSWindow - button access
+	standardWindowButton SEL
+
+	// NSTextField / NSControl
+	initWithFrame      SEL
+	setEditable        SEL
+	setBezeled         SEL
+	setDrawsBackground SEL
+	setAlignment       SEL
+	setStringValue     SEL
+	setTextColor       SEL
+	setFont            SEL
+
+	// NSFont class methods
+	titleBarFontOfSize SEL
+
+	// NSColor class methods
+	labelColor SEL
 
 	// CALayer - Contents (for software blitting)
 	setContents SEL
@@ -204,6 +236,9 @@ var classes struct {
 	NSPasteboard         Class
 	NSCursor             Class
 	NSWorkspace          Class
+	NSTextField          Class
+	NSColor              Class
+	NSFont               Class
 }
 
 // initSelectors registers all selectors used by the darwin package.
@@ -263,6 +298,11 @@ func initSelectors() {
 		selectors.setCollectionBehavior = RegisterSelector("setCollectionBehavior:")
 		selectors.windowShouldClose = RegisterSelector("windowShouldClose:")
 		selectors.windowDidChangeScreen = RegisterSelector("windowDidChangeScreen:")
+		selectors.windowWillStartLiveResize = RegisterSelector("windowWillStartLiveResize:")
+		selectors.windowDidEndLiveResize = RegisterSelector("windowDidEndLiveResize:")
+		selectors.windowDidResize = RegisterSelector("windowDidResize:")
+		selectors.setTitlebarAppearsTransparent = RegisterSelector("setTitlebarAppearsTransparent:")
+		selectors.setTitleVisibility = RegisterSelector("setTitleVisibility:")
 
 		// NSView
 		selectors.setWantsLayer = RegisterSelector("setWantsLayer:")
@@ -272,6 +312,31 @@ func initSelectors() {
 		selectors.bounds = RegisterSelector("bounds")
 		selectors.setBounds = RegisterSelector("setBounds:")
 		selectors.setNeedsDisplay = RegisterSelector("setNeedsDisplay:")
+
+		// NSView - view hierarchy manipulation
+		selectors.superview = RegisterSelector("superview")
+		selectors.addSubview = RegisterSelector("addSubview:")
+		selectors.addSubviewPositionedRelativeTo = RegisterSelector("addSubview:positioned:relativeTo:")
+		selectors.removeFromSuperview = RegisterSelector("removeFromSuperview")
+
+		// NSWindow - button access
+		selectors.standardWindowButton = RegisterSelector("standardWindowButton:")
+
+		// NSTextField / NSControl
+		selectors.initWithFrame = RegisterSelector("initWithFrame:")
+		selectors.setEditable = RegisterSelector("setEditable:")
+		selectors.setBezeled = RegisterSelector("setBezeled:")
+		selectors.setDrawsBackground = RegisterSelector("setDrawsBackground:")
+		selectors.setAlignment = RegisterSelector("setAlignment:")
+		selectors.setStringValue = RegisterSelector("setStringValue:")
+		selectors.setTextColor = RegisterSelector("setTextColor:")
+		selectors.setFont = RegisterSelector("setFont:")
+
+		// NSFont class methods
+		selectors.titleBarFontOfSize = RegisterSelector("titleBarFontOfSize:")
+
+		// NSColor class methods
+		selectors.labelColor = RegisterSelector("labelColor")
 
 		// CALayer - Contents
 		selectors.setContents = RegisterSelector("setContents:")
@@ -406,6 +471,9 @@ func initClasses() {
 		classes.NSPasteboard = GetClass("NSPasteboard")
 		classes.NSCursor = GetClass("NSCursor")
 		classes.NSWorkspace = GetClass("NSWorkspace")
+		classes.NSTextField = GetClass("NSTextField")
+		classes.NSColor = GetClass("NSColor")
+		classes.NSFont = GetClass("NSFont")
 	})
 }
 

--- a/internal/platform/darwin/types.go
+++ b/internal/platform/darwin/types.go
@@ -79,6 +79,16 @@ const (
 	NSWindowStyleMaskFullSizeContentView NSWindowStyleMask = 1 << 15
 )
 
+// NSWindowTitleVisibility controls whether the title is visible in the title bar.
+type NSWindowTitleVisibility NSInteger
+
+const (
+	// NSWindowTitleVisible shows the native title text in the title bar (default).
+	NSWindowTitleVisible NSWindowTitleVisibility = 0
+	// NSWindowTitleHidden hides the native title text, leaving traffic-light buttons visible.
+	NSWindowTitleHidden NSWindowTitleVisibility = 1
+)
+
 // NSWindowCollectionBehavior controls how the window participates in
 // Spaces, Expose, and fullscreen.
 type NSWindowCollectionBehavior NSUInteger

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -5,6 +5,7 @@ package darwin
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -43,6 +44,22 @@ type Window struct {
 	// with a different backing scale factor (windowDidChangeScreen: delegate).
 	// Capacity 1: rapid transitions are coalesced; consumer need not be realtime.
 	screenChangedCh chan struct{}
+
+	// inLiveResize is true while the user is dragging a resize handle.
+	// Set/cleared by the windowWillStartLiveResize:/windowDidEndLiveResize: delegate.
+	// Atomic so the render thread can safely read it without holding mu.
+	inLiveResize atomic.Bool
+
+	// Header alignment state.
+	alignment      int // 0=center, 1=left, 2=right
+	cachedTitle    string
+	titleTextField ID // NSTextField injected into the traffic-light button container for center/right alignment; 0 when inactive
+
+	// liveResizeHook, if non-nil, is called on every windowDidResize: notification
+	// (including notifications fired during AppKit's live-resize modal loop).
+	// Used by the app layer to render a frame while the event loop is blocked.
+	// Read/written under mu.
+	liveResizeHook func()
 }
 
 // NewWindow creates a new window with the given configuration.
@@ -95,6 +112,7 @@ func NewWindow(config WindowConfig) (*Window, error) {
 
 	// Set window title
 	if config.Title != "" {
+		w.cachedTitle = config.Title
 		title := NewNSString(config.Title)
 		if title != nil {
 			nsWindow.SendPtr(selectors.setTitle, title.ID().Ptr())
@@ -204,9 +222,14 @@ func (w *Window) SetTitle(title string) {
 		return
 	}
 
+	w.cachedTitle = title
 	nsTitle := NewNSString(title)
 	if nsTitle != nil {
 		w.nsWindow.SendPtr(selectors.setTitle, nsTitle.ID().Ptr())
+		// Keep the injected text field in sync when right-alignment is active.
+		if !w.titleTextField.IsNil() {
+			w.titleTextField.SendPtr(selectors.setStringValue, nsTitle.ID().Ptr())
+		}
 		nsTitle.Release()
 	}
 }
@@ -485,6 +508,195 @@ func (w *Window) Zoom() {
 	}
 
 	w.nsWindow.SendPtr(selectors.zoom, 0)
+}
+
+// InLiveResize returns true while the user is dragging a resize handle.
+// Thread-safe; reads an atomic flag set by the NSWindowDelegate callbacks.
+func (w *Window) InLiveResize() bool {
+	return w.inLiveResize.Load()
+}
+
+// StartLiveResize marks the beginning of a live resize operation.
+// Called by the windowWillStartLiveResize: NSWindowDelegate method.
+func (w *Window) StartLiveResize() {
+	w.inLiveResize.Store(true)
+}
+
+// EndLiveResize marks the end of a live resize operation and wakes the event
+// loop so a final EventResize is emitted with the settled dimensions.
+// Called by the windowDidEndLiveResize: NSWindowDelegate method.
+func (w *Window) EndLiveResize() {
+	w.inLiveResize.Store(false)
+	WakeEventLoop()
+}
+
+// SetLiveResizeHook installs a callback that fires on every windowDidResize:
+// notification, including those generated inside AppKit's live-resize modal loop.
+// The hook should trigger a render frame so the GPU surface stays in sync during
+// resize and macOS does not stretch the old frame to fill the new window size.
+func (w *Window) SetLiveResizeHook(fn func()) {
+	w.mu.Lock()
+	w.liveResizeHook = fn
+	w.mu.Unlock()
+}
+
+// liveResizeHookValue returns the current hook under mu.
+func (w *Window) liveResizeHookValue() func() {
+	w.mu.Lock()
+	fn := w.liveResizeHook
+	w.mu.Unlock()
+	return fn
+}
+
+// NSTextAlignment values used when injecting a custom title NSTextField.
+const (
+	nsTextAlignmentLeft   = 0
+	nsTextAlignmentCenter = 1
+	nsTextAlignmentRight  = 2
+)
+
+// SetHeaderAlignment adjusts the native title bar to reflect the requested
+// alignment. alignment values: 0 = center (default), 1 = left, 2 = right.
+//
+// Left:   FullSizeContentView + transparent title bar; native title stays visible
+// and macOS positions it after the traffic-light buttons (left side).
+// Right:  FullSizeContentView + transparent title bar; native title is hidden and
+// an NSTextField is injected into the title bar view, right-aligned.
+// Center: standard opaque title bar; native title hidden; a centered NSTextField
+// is injected to guarantee true horizontal centering on all macOS versions.
+func (w *Window) SetHeaderAlignment(alignment int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	// Remove any previously injected custom title text field.
+	if !w.titleTextField.IsNil() {
+		w.titleTextField.Send(selectors.removeFromSuperview)
+		w.titleTextField.Send(selectors.release)
+		w.titleTextField = 0
+	}
+
+	current := NSWindowStyleMask(w.nsWindow.GetUint64(selectors.styleMask))
+	hasFullSize := current&NSWindowStyleMaskFullSizeContentView != 0
+	switch alignment {
+	case 1: // HeaderAlignLeft
+		if !hasFullSize {
+			w.nsWindow.SendUint(selectors.setStyleMask, uint64(current|NSWindowStyleMaskFullSizeContentView))
+		}
+		w.nsWindow.SendBool(selectors.setTitlebarAppearsTransparent, true)
+		w.nsWindow.SendUint(selectors.setTitleVisibility, uint64(NSWindowTitleVisible))
+	case 2: // HeaderAlignRight
+		if !hasFullSize {
+			w.nsWindow.SendUint(selectors.setStyleMask, uint64(current|NSWindowStyleMaskFullSizeContentView))
+		}
+		w.nsWindow.SendBool(selectors.setTitlebarAppearsTransparent, true)
+		w.nsWindow.SendUint(selectors.setTitleVisibility, uint64(NSWindowTitleHidden))
+		w.injectTitleTextField(nsTextAlignmentRight)
+	default: // HeaderAlignCenter (0)
+		// Only touch the style mask when FullSizeContentView is actually present;
+		// calling setStyleMask: with an unchanged value triggers a title re-layout
+		// that macOS renders left-aligned instead of centered.
+		if hasFullSize {
+			w.nsWindow.SendUint(selectors.setStyleMask, uint64(current&^NSWindowStyleMaskFullSizeContentView))
+		}
+		// Inject a centered NSTextField rather than relying on macOS default title
+		// positioning, which varies across OS versions and window configurations.
+		w.nsWindow.SendBool(selectors.setTitlebarAppearsTransparent, false)
+		w.nsWindow.SendUint(selectors.setTitleVisibility, uint64(NSWindowTitleHidden))
+		w.injectTitleTextField(nsTextAlignmentCenter)
+	}
+	w.alignment = alignment
+}
+
+// injectTitleTextField adds an NSTextField to the title bar's button container
+// (the view that holds the traffic-light buttons) with the given NSTextAlignment.
+// textAlignment: 0 = left, 1 = center, 2 = right. Called with w.mu held.
+func (w *Window) injectTitleTextField(textAlignment uint64) {
+	// Navigate to the view that owns the traffic-light buttons: get the close
+	// button (NSWindowCloseButton = 0) then its superview. This view has a
+	// transparent background so adding our label behind the buttons (with
+	// NSWindowBelow+nil) keeps text visible while clicks reach the buttons.
+	closeBtn := w.nsWindow.SendUint(selectors.standardWindowButton, 0)
+	if closeBtn.IsNil() {
+		return
+	}
+	tbView := closeBtn.Send(selectors.superview)
+	if tbView.IsNil() {
+		return
+	}
+
+	// Compute inset past the traffic-light buttons. NSWindowZoomButton (2) is
+	// the rightmost button; its right edge + a gap gives the safe left margin.
+	tbBounds := tbView.GetRect(selectors.bounds)
+	leftInset := CGFloat(0)
+	zoomBtn := w.nsWindow.SendUint(selectors.standardWindowButton, 2)
+	if !zoomBtn.IsNil() {
+		zf := zoomBtn.GetRect(selectors.frame)
+		leftInset = zf.Origin.X + zf.Size.Width + 8
+	}
+
+	// Anchor the text field's vertical position to the close button's frame.
+	// NSTitlebarView uses flipped coordinates (Y=0 at top), so using Y=0 with
+	// full title-bar height places NSTextField's text at the very top edge.
+	// The close button's Y is already correctly centered by AppKit; mirroring
+	// it keeps our label aligned with the traffic-light buttons.
+	cf := closeBtn.GetRect(selectors.frame)
+	textH := cf.Size.Height + 4 // 4pt taller than button keeps text un-clipped
+	textY := cf.Origin.Y + (cf.Size.Height-textH)/2
+
+	// For center alignment use a symmetric frame so text centers at exactly W/2.
+	// For right alignment the frame extends to the right edge (left-inset only).
+	var frame NSRect
+	if textAlignment == nsTextAlignmentCenter {
+		frame = MakeRect(leftInset, textY, tbBounds.Size.Width-2*leftInset, textH)
+	} else {
+		frame = MakeRect(leftInset, textY, tbBounds.Size.Width-leftInset, textH)
+	}
+
+	tf := classes.NSTextField.Send(selectors.alloc)
+	tf = tf.SendRect(selectors.initWithFrame, frame)
+	if tf.IsNil() {
+		return
+	}
+
+	// Configure as a non-editable, transparent label.
+	tf.SendBool(selectors.setEditable, false)
+	tf.SendBool(selectors.setBezeled, false)
+	tf.SendBool(selectors.setDrawsBackground, false)
+	tf.SendUint(selectors.setAlignment, textAlignment)
+
+	// Apply the standard title bar font (matches system window title).
+	titleFont := ID(classes.NSFont).SendDouble(selectors.titleBarFontOfSize, 13.0)
+	if !titleFont.IsNil() {
+		tf.SendPtr(selectors.setFont, titleFont.Ptr())
+	}
+
+	// Use the system label color so the title is readable in both light and dark mode.
+	labelColor := classes.NSColor.Send(selectors.labelColor)
+	if !labelColor.IsNil() {
+		tf.SendPtr(selectors.setTextColor, labelColor.Ptr())
+	}
+
+	// Set the current title.
+	if w.cachedTitle != "" {
+		nsTitle := NewNSString(w.cachedTitle)
+		if nsTitle != nil {
+			tf.SendPtr(selectors.setStringValue, nsTitle.ID().Ptr())
+			nsTitle.Release()
+		}
+	}
+
+	// NSViewWidthSizable (2): width tracks parent width as the window resizes.
+	tf.SendUint(selectors.setAutoresizingMask, 2)
+
+	// Insert behind all existing subviews (traffic-light buttons) so mouse events
+	// reach the buttons. The button container has a transparent background, so the
+	// label remains visible. NSWindowBelow = -1 as uintptr = ^uintptr(0).
+	tbView.Send5Ptr(selectors.addSubviewPositionedRelativeTo, tf.Ptr(), ^uintptr(0), 0)
+	w.titleTextField = tf
 }
 
 // SetStyleMask sets the window's style mask.

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -62,6 +62,10 @@ type Window struct {
 	liveResizeHook func()
 }
 
+// NSID returns the underlying NSWindow object ID.
+// Used by the platform layer to match NSEvents to their originating window.
+func (w *Window) NSID() ID { return w.nsWindow }
+
 // NewWindow creates a new window with the given configuration.
 func NewWindow(config WindowConfig) (*Window, error) {
 	initSelectors()

--- a/internal/platform/darwin/windowdelegate.go
+++ b/internal/platform/darwin/windowdelegate.go
@@ -75,6 +75,48 @@ func registerWindowDelegateClass() (Class, error) {
 	)
 	ClassAddMethod(cls, selectors.windowDidChangeScreen, screenChangedIMP, "v@:@")
 
+	// windowDidResize: fires after each resize step, including during AppKit's
+	// live-resize modal loop (inside sendEvent:) where our outer event loop is
+	// blocked. Only invoke the hook while InLiveResize is true — this limits
+	// the render trigger to user-drag resize and avoids spurious calls during
+	// programmatic frame changes and window setup.
+	didResizeIMP := ffi.NewCallback(
+		func(self, sel, notification uintptr) uintptr {
+			if win := getWindowFromDelegate(ID(self)); win != nil && win.InLiveResize() {
+				if hook := win.liveResizeHookValue(); hook != nil {
+					hook()
+				}
+			}
+			return 0
+		},
+	)
+	ClassAddMethod(cls, selectors.windowDidResize, didResizeIMP, "v@:@")
+
+	// windowWillStartLiveResize: fires when the user begins dragging a resize handle.
+	// Mark the window as in-resize so the app-level event filter can suppress
+	// intermediate resize events until the user releases the mouse.
+	willStartLiveResizeIMP := ffi.NewCallback(
+		func(self, sel, notification uintptr) uintptr {
+			if win := getWindowFromDelegate(ID(self)); win != nil {
+				win.StartLiveResize()
+			}
+			return 0
+		},
+	)
+	ClassAddMethod(cls, selectors.windowWillStartLiveResize, willStartLiveResizeIMP, "v@:@")
+
+	// windowDidEndLiveResize: fires when the user releases the resize handle.
+	// Clear the flag and wake the event loop so a final EventResize is emitted.
+	didEndLiveResizeIMP := ffi.NewCallback(
+		func(self, sel, notification uintptr) uintptr {
+			if win := getWindowFromDelegate(ID(self)); win != nil {
+				win.EndLiveResize()
+			}
+			return 0
+		},
+	)
+	ClassAddMethod(cls, selectors.windowDidEndLiveResize, didEndLiveResizeIMP, "v@:@")
+
 	RegisterClassPair(cls)
 	return cls, nil
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -321,6 +321,26 @@ const (
 	MenuRoleBringAllToFront
 )
 
+// HeaderAligner is an optional interface for platform windows that support
+// native title bar alignment. Platforms that don't support title alignment
+// simply don't implement this interface — callers use type assertion.
+//
+// alignment values: 0 = center (default), 1 = left, 2 = right.
+// On macOS Left/Right enable NSWindowStyleMaskFullSizeContentView with a
+// transparent title bar so GPU-rendered content fills the header area.
+type HeaderAligner interface {
+	SetHeaderAlignment(alignment int)
+}
+
+// LiveResizeRenderer is an optional interface for platform windows that can
+// receive a callback to trigger a render during live resize. On macOS,
+// AppKit runs a modal tracking loop during window resize that blocks the
+// outer event loop; without this hook the old frame is stretched by the
+// compositor until the drag ends.
+type LiveResizeRenderer interface {
+	SetLiveResizeHook(fn func())
+}
+
 // PlatScaleProvider is an optional interface for platforms that can report the
 // primary display DPI scale factor before a window is created. Callers use a
 // type assertion: if sp, ok := manager.(PlatScaleProvider); ok { ... }

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -193,10 +193,11 @@ func (p *darwinPlatform) PollEvents() Event {
 // all pending events. Uses [NSApp nextEventMatchingMask:untilDate:inMode:dequeue:]
 // with distantFuture, which blocks at kernel level via mach_msg for 0% CPU idle.
 //
-// We use the current key window's handler so that keyboard events are queued
-// under the correct window ID (enabling per-window key routing in multi-window apps).
+// Each NSEvent is routed to the darwinWindow that owns it via [NSEvent window].
+// This ensures pointer coordinates and event WindowIDs are attributed to the
+// correct window even when a non-key window receives input. Events without an
+// associated NSWindow (key events, system events) fall back to the key window.
 func (p *darwinPlatform) WaitEvents() {
-	// Identify the key (focused) window.
 	p.mu.RLock()
 	keyWin := p.primary
 	for _, w := range p.windows {
@@ -205,17 +206,37 @@ func (p *darwinPlatform) WaitEvents() {
 			break
 		}
 	}
+	// Snapshot the window list for routing — avoids holding mu during dispatch.
+	wins := make([]*darwinWindow, len(p.windows))
+	copy(wins, p.windows)
 	p.mu.RUnlock()
 
-	keyWin.eventMu.Lock()
-	defer keyWin.eventMu.Unlock()
-
-	if p.app != nil {
-		p.app.WaitEventsWithHandler(keyWin.handleEvent)
+	// Route each event to the window it came from; fall back to keyWin for
+	// events that carry no NSWindow (e.g. keyboard, mouse-exited-screen).
+	routingHandler := func(event darwin.ID, eventType darwin.NSEventType) bool {
+		target := keyWin
+		if nsWin := darwin.GetEventWindow(event); !nsWin.IsNil() {
+			for _, w := range wins {
+				if w.window != nil && w.window.NSID() == nsWin {
+					target = w
+					break
+				}
+			}
+		}
+		target.eventMu.Lock()
+		result := target.handleEvent(event, eventType)
+		target.eventMu.Unlock()
+		return result
 	}
 
-	// Check for resize after processing events.
+	if p.app != nil {
+		p.app.WaitEventsWithHandler(routingHandler)
+	}
+
+	// Check for resize after all events have been processed.
+	keyWin.eventMu.Lock()
 	keyWin.checkResize()
+	keyWin.eventMu.Unlock()
 }
 
 // WakeUp unblocks WaitEvents from any goroutine by posting a synthetic

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -924,6 +924,7 @@ func (w *darwinWindow) checkResize() {
 		w.physH = newPhysH
 
 		w.queueEvent(Event{
+			WindowID:       w.id,
 			Type:           EventResize,
 			Width:          newWidth,
 			Height:         newHeight,

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -332,6 +332,7 @@ func (dw *darwinPlatformWindow) SetHeaderAlignment(alignment int) {
 		dw.window.SetHeaderAlignment(alignment)
 	}
 }
+
 func (dw *darwinPlatformWindow) SetTitle(title string) {
 	if dw.window != nil {
 		dw.window.SetTitle(title)

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -192,17 +192,30 @@ func (p *darwinPlatform) PollEvents() Event {
 // WaitEvents blocks until at least one OS event is available, then processes
 // all pending events. Uses [NSApp nextEventMatchingMask:untilDate:inMode:dequeue:]
 // with distantFuture, which blocks at kernel level via mach_msg for 0% CPU idle.
+//
+// We use the current key window's handler so that keyboard events are queued
+// under the correct window ID (enabling per-window key routing in multi-window apps).
 func (p *darwinPlatform) WaitEvents() {
-	w := p.primary
-	w.eventMu.Lock()
-	defer w.eventMu.Unlock()
+	// Identify the key (focused) window.
+	p.mu.RLock()
+	keyWin := p.primary
+	for _, w := range p.windows {
+		if w.window != nil && w != p.primary && w.window.IsKeyWindow() {
+			keyWin = w
+			break
+		}
+	}
+	p.mu.RUnlock()
+
+	keyWin.eventMu.Lock()
+	defer keyWin.eventMu.Unlock()
 
 	if p.app != nil {
-		p.app.WaitEventsWithHandler(w.handleEvent)
+		p.app.WaitEventsWithHandler(keyWin.handleEvent)
 	}
 
-	// Check for resize after processing events
-	w.checkResize()
+	// Check for resize after processing events.
+	keyWin.checkResize()
 }
 
 // WakeUp unblocks WaitEvents from any goroutine by posting a synthetic
@@ -546,6 +559,7 @@ func (w *darwinWindow) pollEvents(app *darwin.Application) Event {
 			w.physW = newPhysW
 			w.physH = newPhysH
 			w.events.Push(Event{
+				WindowID:       w.id,
 				Type:           EventResize,
 				Width:          newWidth,
 				Height:         newHeight,
@@ -564,7 +578,7 @@ func (w *darwinWindow) pollEvents(app *darwin.Application) Event {
 			w.focusInited = true
 		} else if isKey != w.lastKeyWindow {
 			w.lastKeyWindow = isKey
-			w.events.Push(Event{Type: EventFocus, Focused: isKey})
+			w.events.Push(Event{WindowID: w.id, Type: EventFocus, Focused: isKey})
 		}
 	}
 
@@ -772,13 +786,13 @@ func (w *darwinWindow) dispatchPointerEvent(ev gpucontext.PointerEvent) {
 	default:
 		evType = EventPointerMove
 	}
-	w.events.Push(Event{Type: evType, Pointer: ev})
+	w.events.Push(Event{WindowID: w.id, Type: evType, Pointer: ev})
 }
 
 // dispatchScrollEvent pushes a scroll event to the event queue.
 // Called from handleEvent with w.eventMu held.
 func (w *darwinWindow) dispatchScrollEvent(ev gpucontext.ScrollEvent) {
-	w.events.Push(Event{Type: EventScroll, Scroll: ev})
+	w.events.Push(Event{WindowID: w.id, Type: EventScroll, Scroll: ev})
 }
 
 // dispatchKeyEvent pushes a keyboard event to the event queue.
@@ -788,7 +802,7 @@ func (w *darwinWindow) dispatchKeyEvent(key gpucontext.Key, mods gpucontext.Modi
 	if !pressed {
 		evType = EventKeyUp
 	}
-	w.events.Push(Event{Type: evType, Key: key, Mods: mods})
+	w.events.Push(Event{WindowID: w.id, Type: evType, Key: key, Mods: mods})
 }
 
 // dispatchCharFromEvent extracts characters from an NSEvent and dispatches them.
@@ -832,7 +846,7 @@ func (w *darwinWindow) dispatchCharFromEvent(event darwin.ID) {
 			continue
 		}
 		if r >= 32 && r != 127 {
-			w.events.Push(Event{Type: EventChar, Char: r})
+			w.events.Push(Event{WindowID: w.id, Type: EventChar, Char: r})
 		}
 		i += size
 	}

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -293,7 +293,32 @@ func (dw *darwinPlatformWindow) ShouldClose() bool {
 	return false
 }
 
-func (dw *darwinPlatformWindow) InSizeMove() bool { return false }
+// InSizeMove returns true while the user is dragging a resize handle.
+// Mirrors the Win32 WM_ENTERSIZEMOVE / WM_EXITSIZEMOVE semantics: when true,
+// the app-level event loop suppresses resize events so the GPU surface is not
+// reconfigured on every mouse-move tick. A final resize fires on release.
+func (dw *darwinPlatformWindow) InSizeMove() bool {
+	if dw.window != nil {
+		return dw.window.InLiveResize()
+	}
+	return false
+}
+
+// SetLiveResizeHook implements platform.LiveResizeRenderer for macOS.
+// The hook is invoked on every windowDidResize: notification so the app layer
+// can reconfigure the GPU surface and render a frame during live resize.
+func (dw *darwinPlatformWindow) SetLiveResizeHook(fn func()) {
+	if dw.window != nil {
+		dw.window.SetLiveResizeHook(fn)
+	}
+}
+
+// SetHeaderAlignment implements platform.HeaderAligner for macOS.
+func (dw *darwinPlatformWindow) SetHeaderAlignment(alignment int) {
+	if dw.window != nil {
+		dw.window.SetHeaderAlignment(alignment)
+	}
+}
 func (dw *darwinPlatformWindow) SetTitle(title string) {
 	if dw.window != nil {
 		dw.window.SetTitle(title)

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -426,6 +426,8 @@ func (w *x11PlatformWindow) IsFullscreen() bool {
 	return w.platform.inner.IsFullscreen()
 }
 
+func (w *x11PlatformWindow) SetHeaderAlignment(_ int) {} // X11 title bar is compositor-controlled
+
 func (w *x11PlatformWindow) Close() { w.platform.inner.CloseWindow() }
 
 func (w *x11PlatformWindow) Show() {
@@ -611,6 +613,18 @@ func (w *waylandPlatformWindow) FrameCallbackReady() bool {
 		return true // Not initialized or gating disabled
 	}
 	return w.platform.libwl.FrameCallbackReady()
+}
+
+func (w *waylandPlatformWindow) SetHeaderAlignment(alignment int) {
+	if w.secondary != nil {
+		if w.secondary.libwl != nil {
+			w.secondary.libwl.SetCSDTitleAlignment(alignment)
+		}
+		return
+	}
+	if w.platform.libwl != nil {
+		w.platform.libwl.SetCSDTitleAlignment(alignment)
+	}
 }
 
 func (w *waylandPlatformWindow) Destroy() {
@@ -984,10 +998,8 @@ func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandC
 		decorName = dg.Name
 		decorVersion = dg.Version
 	}
-	// decorName/decorVersion enable SSD (server-side decorations) on the secondary window.
-	// CSD (client-side decorations) for secondary windows is deferred: each CSD window
-	// requires its own subsurface tree and per-window pointer routing, which adds
-	// significant complexity relative to the primary window path.
+	// decorName/decorVersion enable SSD on the secondary window.
+	// CSD is attempted below when SSD is unavailable.
 
 	libwl, err := wayland.OpenLibwayland(
 		compGlobal.Name, compGlobal.Version,
@@ -1035,17 +1047,60 @@ func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandC
 			w := &sec.state
 			w.eventMu.Lock()
 			defer w.eventMu.Unlock()
-			if width > 0 && height > 0 && (int(width) != w.width || int(height) != w.height) {
-				w.width = int(width)
-				w.height = int(height)
-				w.events.Push(Event{
-					Type:           EventResize,
-					WindowID:       sec.winID,
-					Width:          int(width),
-					Height:         int(height),
-					PhysicalWidth:  int(width),
-					PhysicalHeight: int(height),
-				})
+
+			hasCSD := sec.libwl != nil && sec.libwl.CSDActive()
+			isMaximized := hasCSD && sec.libwl.IsMaximized()
+			isFullscreen := hasCSD && sec.libwl.IsFullscreen()
+
+			// Save pre-maximize size when transitioning to maximized.
+			if isMaximized && w.savedWidth == 0 && w.width > 0 {
+				w.savedWidth = w.width
+				w.savedHeight = w.height
+			}
+			if !isMaximized && w.savedWidth > 0 && width > 0 {
+				w.savedWidth = 0
+				w.savedHeight = 0
+			}
+
+			// width==0, height==0: compositor lets the client choose — restore saved size.
+			if width == 0 && height == 0 && w.savedWidth > 0 {
+				width = int32(w.savedWidth)
+				height = int32(w.savedHeight)
+				w.savedWidth = 0
+				w.savedHeight = 0
+			}
+
+			if width > 0 && height > 0 {
+				vulkanW := int(width)
+				vulkanH := int(height)
+
+				// When CSD is active and maximized, the compositor sends total geometry
+				// (content + title bar); subtract the title bar so the GPU surface
+				// covers only the content area. xdgSurfaceConfigureCb then calls
+				// ResizeCSD with these matching content dimensions.
+				if hasCSD && !isFullscreen && isMaximized {
+					tbH, _ := sec.libwl.CSDBorders()
+					vulkanH = int(height) - tbH
+					if vulkanH < 1 {
+						vulkanH = 1
+					}
+				}
+
+				if vulkanW != w.width || vulkanH != w.height {
+					if hasCSD {
+						sec.libwl.SetPendingCSDResize(vulkanW, vulkanH)
+					}
+					w.width = vulkanW
+					w.height = vulkanH
+					w.events.Push(Event{
+						Type:           EventResize,
+						WindowID:       sec.winID,
+						Width:          vulkanW,
+						Height:         vulkanH,
+						PhysicalWidth:  vulkanW,
+						PhysicalHeight: vulkanH,
+					})
+				}
 			}
 		},
 		func() {
@@ -1061,6 +1116,45 @@ func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandC
 
 	if err := libwl.SetupToplevelListeners(); err != nil {
 		logger().Warn("secondary: xdg_toplevel listener setup failed", "err", err)
+	}
+
+	// Attempt CSD if SSD was not negotiated and the required globals are present.
+	const decorModeServerSide = 2
+	needCSD := decorName == 0 || libwl.DecorationMode() != decorModeServerSide
+	if needCSD && !config.Frameless {
+		subcompGlobal := registry.GetGlobalByInterface(wayland.InterfaceWlSubcompositor)
+		shmGlobal := registry.GetGlobalByInterface(wayland.InterfaceWlShm)
+		if subcompGlobal != nil && shmGlobal != nil {
+			if csGlobal := registry.GetGlobalByInterface(wayland.InterfaceWpCursorShapeManagerV1); csGlobal != nil {
+				if err := sec.libwl.SetupCursorShape(csGlobal.Name, csGlobal.Version); err != nil {
+					logger().Warn("secondary CSD cursor shape setup failed", "err", err)
+				}
+			}
+			var seatName, seatVersion uint32
+			if sg := registry.GetGlobalByInterface(wayland.InterfaceWlSeat); sg != nil {
+				seatName = sg.Name
+				seatVersion = sg.Version
+			}
+			if csdErr := sec.libwl.SetupCSD(
+				subcompGlobal.Name, subcompGlobal.Version,
+				shmGlobal.Name, shmGlobal.Version,
+				seatName, seatVersion,
+				config.Width, config.Height,
+				config.Title,
+				nil, // DefaultCSDPainter
+				func() {
+					logger().Info("secondary CSD close button pressed", "id", sec.winID)
+					w := &sec.state
+					w.eventMu.Lock()
+					w.shouldClose = true
+					w.eventMu.Unlock()
+					w.events.Push(Event{Type: EventClose, WindowID: sec.winID})
+					p.WakeUp()
+				},
+			); csdErr != nil {
+				logger().Warn("secondary window CSD initialization failed", "err", csdErr)
+			}
+		}
 	}
 
 	if err := libwl.Flush(); err != nil {
@@ -2532,6 +2626,12 @@ func (p *waylandPlatform) PollEvents() Event {
 		}
 		if err := sec.libwl.DispatchDefaultQueue(); err != nil {
 			logger().Error("wayland secondary dispatch error", "id", sec.winID, "error", err)
+		}
+		// Process CSD pointer events (separate queue from xdg_toplevel events).
+		if sec.libwl.CSDActive() {
+			if err := sec.libwl.DispatchCSDEvents(); err != nil {
+				logger().Error("secondary CSD dispatch error", "id", sec.winID, "error", err)
+			}
 		}
 		if e, ok := sec.state.events.Pop(); ok {
 			return e

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -962,7 +962,7 @@ func (p *waylandPlatform) initSingleConnection(config Config) error { //nolint:g
 // Each secondary gets its own wl_display, wl_surface, and xdg_toplevel so the
 // compositor presents it as a separate window. Input (keyboard/pointer) is NOT
 // set up on secondary connections — it flows through the primary connection's seat.
-func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandConn, error) { //nolint:gocognit,maintidx // secondary window setup mirrors primary; splitting would scatter related logic
+func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandConn, error) { //nolint:gocognit,maintidx // configure callback has unavoidable branching for maximize/fullscreen/CSD resize
 	// Discover Wayland globals via a short-lived pure-Go connection.
 	display, err := wayland.Connect()
 	if err != nil {
@@ -1122,39 +1122,7 @@ func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandC
 	const decorModeServerSide = 2
 	needCSD := decorName == 0 || libwl.DecorationMode() != decorModeServerSide
 	if needCSD && !config.Frameless {
-		subcompGlobal := registry.GetGlobalByInterface(wayland.InterfaceWlSubcompositor)
-		shmGlobal := registry.GetGlobalByInterface(wayland.InterfaceWlShm)
-		if subcompGlobal != nil && shmGlobal != nil {
-			if csGlobal := registry.GetGlobalByInterface(wayland.InterfaceWpCursorShapeManagerV1); csGlobal != nil {
-				if err := sec.libwl.SetupCursorShape(csGlobal.Name, csGlobal.Version); err != nil {
-					logger().Warn("secondary CSD cursor shape setup failed", "err", err)
-				}
-			}
-			var seatName, seatVersion uint32
-			if sg := registry.GetGlobalByInterface(wayland.InterfaceWlSeat); sg != nil {
-				seatName = sg.Name
-				seatVersion = sg.Version
-			}
-			if csdErr := sec.libwl.SetupCSD(
-				subcompGlobal.Name, subcompGlobal.Version,
-				shmGlobal.Name, shmGlobal.Version,
-				seatName, seatVersion,
-				config.Width, config.Height,
-				config.Title,
-				nil, // DefaultCSDPainter
-				func() {
-					logger().Info("secondary CSD close button pressed", "id", sec.winID)
-					w := &sec.state
-					w.eventMu.Lock()
-					w.shouldClose = true
-					w.eventMu.Unlock()
-					w.events.Push(Event{Type: EventClose, WindowID: sec.winID})
-					p.WakeUp()
-				},
-			); csdErr != nil {
-				logger().Warn("secondary window CSD initialization failed", "err", csdErr)
-			}
-		}
+		p.setupSecondaryCSD(registry, sec, config)
 	}
 
 	if err := libwl.Flush(); err != nil {
@@ -1179,6 +1147,46 @@ func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandC
 		"surface", fmt.Sprintf("%#x", libwl.Surface()))
 
 	return sec, nil
+}
+
+// setupSecondaryCSD attempts client-side decoration on a secondary window.
+// Called when SSD was not negotiated. Errors are logged as warnings — a
+// secondary window without CSD still renders; it just lacks a title bar.
+func (p *waylandPlatform) setupSecondaryCSD(registry *wayland.Registry, sec *secondaryWaylandConn, config Config) {
+	subcompGlobal := registry.GetGlobalByInterface(wayland.InterfaceWlSubcompositor)
+	shmGlobal := registry.GetGlobalByInterface(wayland.InterfaceWlShm)
+	if subcompGlobal == nil || shmGlobal == nil {
+		return
+	}
+	if csGlobal := registry.GetGlobalByInterface(wayland.InterfaceWpCursorShapeManagerV1); csGlobal != nil {
+		if err := sec.libwl.SetupCursorShape(csGlobal.Name, csGlobal.Version); err != nil {
+			logger().Warn("secondary CSD cursor shape setup failed", "err", err)
+		}
+	}
+	var seatName, seatVersion uint32
+	if sg := registry.GetGlobalByInterface(wayland.InterfaceWlSeat); sg != nil {
+		seatName = sg.Name
+		seatVersion = sg.Version
+	}
+	if err := sec.libwl.SetupCSD(
+		subcompGlobal.Name, subcompGlobal.Version,
+		shmGlobal.Name, shmGlobal.Version,
+		seatName, seatVersion,
+		config.Width, config.Height,
+		config.Title,
+		nil, // DefaultCSDPainter
+		func() {
+			logger().Info("secondary CSD close button pressed", "id", sec.winID)
+			w := &sec.state
+			w.eventMu.Lock()
+			w.shouldClose = true
+			w.eventMu.Unlock()
+			w.events.Push(Event{Type: EventClose, WindowID: sec.winID})
+			p.WakeUp()
+		},
+	); err != nil {
+		logger().Warn("secondary window CSD initialization failed", "err", err)
+	}
 }
 
 // initCSD initializes Client-Side Decorations when SSD is unavailable.

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -962,7 +962,7 @@ func (p *waylandPlatform) initSingleConnection(config Config) error { //nolint:g
 // Each secondary gets its own wl_display, wl_surface, and xdg_toplevel so the
 // compositor presents it as a separate window. Input (keyboard/pointer) is NOT
 // set up on secondary connections — it flows through the primary connection's seat.
-func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandConn, error) {
+func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandConn, error) { //nolint:gocognit // secondary window setup mirrors primary; splitting would scatter related logic
 	// Discover Wayland globals via a short-lived pure-Go connection.
 	display, err := wayland.Connect()
 	if err != nil {

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -962,7 +962,7 @@ func (p *waylandPlatform) initSingleConnection(config Config) error { //nolint:g
 // Each secondary gets its own wl_display, wl_surface, and xdg_toplevel so the
 // compositor presents it as a separate window. Input (keyboard/pointer) is NOT
 // set up on secondary connections — it flows through the primary connection's seat.
-func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandConn, error) { //nolint:gocognit // secondary window setup mirrors primary; splitting would scatter related logic
+func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandConn, error) { //nolint:gocognit,maintidx // secondary window setup mirrors primary; splitting would scatter related logic
 	// Discover Wayland globals via a short-lived pure-Go connection.
 	display, err := wayland.Connect()
 	if err != nil {

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -782,6 +782,15 @@ func (p *windowsPlatform) CreateWindow(config Config) (PlatformWindow, error) {
 		if hasPending {
 			p.applyMenu()
 		}
+	} else {
+		// Propagate the render timer callback so secondary windows also fire
+		// modalFrameTick during their own drag/resize modal loops.
+		p.primary.callbackMu.RLock()
+		cb := p.primary.modalFrameCallback
+		p.primary.callbackMu.RUnlock()
+		if cb != nil {
+			w.setModalFrameCallback(cb)
+		}
 	}
 	return w, nil
 }

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -961,6 +961,8 @@ func (w *win32Window) SetModalFrameCallback(fn func()) {
 	w.setModalFrameCallback(fn)
 }
 
+func (w *win32Window) SetHeaderAlignment(_ int) {} // Win32 title bar is drawn by DWM; alignment is not supported
+
 func (w *win32Window) Destroy() {
 	if w.platform != nil {
 		w.platform.windowMu.Lock()

--- a/internal/platform/wayland/csd.go
+++ b/internal/platform/wayland/csd.go
@@ -174,6 +174,12 @@ func (m *CSDManager) SetFocused(focused bool) {
 	m.RepaintTitleBar()
 }
 
+// SetTitleAlignment updates the title alignment (0=left, 1=center, 2=right) and repaints.
+func (m *CSDManager) SetTitleAlignment(alignment int) {
+	m.state.TitleAlignment = alignment
+	m.RepaintTitleBar()
+}
+
 // HitTestTop performs hit-testing on the title bar subsurface.
 func (m *CSDManager) HitTestTop(x, y int) CSDHitResult {
 	if m.top == nil {

--- a/internal/platform/wayland/csd_painter.go
+++ b/internal/platform/wayland/csd_painter.go
@@ -320,11 +320,12 @@ func drawText(buf []byte, stride, x, titleH int, text string, color [4]byte, max
 			break // stop before button area
 		}
 		var ch byte
-		if r >= 32 && r <= 126 {
+		switch {
+		case r >= 32 && r <= 126:
 			ch = byte(r)
-		} else if r == '–' || r == '—' { // en dash, em dash → hyphen
+		case r == '–' || r == '—': // en dash, em dash → hyphen
 			ch = '-'
-		} else {
+		default:
 			ch = '?' // replace other non-ASCII with visible placeholder
 		}
 		glyph := bitmapFont[ch-32]

--- a/internal/platform/wayland/csd_painter.go
+++ b/internal/platform/wayland/csd_painter.go
@@ -46,7 +46,7 @@ type CSDState struct {
 	Close          CSDButtonState
 	Maximize       CSDButtonState
 	Minimize       CSDButtonState
-	TitleAlignment int // 0 = left (default), 1 = center, 2 = right
+	TitleAlignment int // 0 = center (default), 1 = left, 2 = right — matches gogpu.HeaderAlignment constants
 }
 
 // CSDPainter renders CSD decoration pixels into ARGB8888 buffers.

--- a/internal/platform/wayland/csd_painter.go
+++ b/internal/platform/wayland/csd_painter.go
@@ -39,13 +39,14 @@ type CSDButtonState struct {
 
 // CSDState holds the current decoration state for painting.
 type CSDState struct {
-	Title      string
-	Focused    bool
-	Maximized  bool
-	Fullscreen bool
-	Close      CSDButtonState
-	Maximize   CSDButtonState
-	Minimize   CSDButtonState
+	Title          string
+	Focused        bool
+	Maximized      bool
+	Fullscreen     bool
+	Close          CSDButtonState
+	Maximize       CSDButtonState
+	Minimize       CSDButtonState
+	TitleAlignment int // 0 = left (default), 1 = center, 2 = right
 }
 
 // CSDPainter renders CSD decoration pixels into ARGB8888 buffers.
@@ -139,8 +140,37 @@ func (DefaultCSDPainter) PaintTitleBar(buf []byte, width, height int, state CSDS
 		drawCloseIcon(buf, width, closeX, 0, btnW, height, colorIconFg)
 	}
 
-	// Title text — bitmap font, left-padded, vertically centered.
-	drawText(buf, width, 12, height, state.Title, colorIconFg, minX)
+	// Title text — bitmap font, vertically centered; x position follows alignment.
+	const (
+		leftPad  = 12
+		rightPad = 12
+		glyphW   = 7
+	)
+	var titleX int
+	var runeCount int
+	for range state.Title {
+		runeCount++
+	}
+	textW := runeCount * glyphW
+	switch state.TitleAlignment {
+	case 0: // HeaderAlignCenter — center in full window width, not just button-free area
+		titleX = (width - textW) / 2
+		if titleX < leftPad {
+			titleX = leftPad
+		}
+		if titleX+textW > minX-rightPad {
+			// Narrow window: fall back to left edge to avoid button overlap
+			titleX = leftPad
+		}
+	case 2: // HeaderAlignRight
+		titleX = minX - rightPad - textW
+		if titleX < leftPad {
+			titleX = leftPad
+		}
+	default: // HeaderAlignLeft (1) and fallback
+		titleX = leftPad
+	}
+	drawText(buf, width, titleX, height, state.Title, colorIconFg, minX)
 }
 
 func (DefaultCSDPainter) PaintBorder(buf []byte, width, height int, _ CSDEdge) {
@@ -285,13 +315,17 @@ func drawText(buf []byte, stride, x, titleH int, text string, color [4]byte, max
 	}
 
 	cx := x
-	for i := 0; i < len(text); i++ {
-		ch := text[i]
+	for _, r := range text {
 		if cx+glyphW > maxX {
 			break // stop before button area
 		}
-		if ch < 32 || ch > 126 {
-			ch = '?' // replace non-printable
+		var ch byte
+		if r >= 32 && r <= 126 {
+			ch = byte(r)
+		} else if r == '–' || r == '—' { // en dash, em dash → hyphen
+			ch = '-'
+		} else {
+			ch = '?' // replace other non-ASCII with visible placeholder
 		}
 		glyph := bitmapFont[ch-32]
 		for row := 0; row < glyphH; row++ {

--- a/internal/platform/wayland/csd_painter_test.go
+++ b/internal/platform/wayland/csd_painter_test.go
@@ -1,0 +1,108 @@
+//go:build linux
+
+package wayland
+
+import "testing"
+
+// titleStartX scans the buffer left-to-right in columns [0, beforeX) and
+// rows [yLo, yHi) and returns the leftmost column that contains a colorIconFg
+// pixel. Returns -1 when no text pixel is found.
+func titleStartX(buf []byte, stride, beforeX, yLo, yHi int) int {
+	for col := 0; col < beforeX; col++ {
+		for row := yLo; row < yHi; row++ {
+			off := (row*stride + col) * 4
+			if off+3 < len(buf) &&
+				buf[off] == colorIconFg[0] &&
+				buf[off+1] == colorIconFg[1] &&
+				buf[off+2] == colorIconFg[2] &&
+				buf[off+3] == colorIconFg[3] {
+				return col
+			}
+		}
+	}
+	return -1
+}
+
+func TestPaintTitleBarAlignment(t *testing.T) {
+	const (
+		winH    = defaultTitleBarHeight // 32
+		btnW    = defaultButtonWidth    // 46
+		glyphW  = 7
+		leftPad = 12
+		rightPad = 12
+	)
+	// 'B' glyph (char 66): rows 2-8 are 0xF0/0x88, so column 0 is always lit.
+	// Using 'B' ensures the leftmost glyph pixel lands exactly at titleX.
+	const wideTitle = "BB"
+	const narrowTitle = "BBBBBBBBBBBBBBBBBBBBBBBB" // 24 chars = 168 px wide
+
+	painter := DefaultCSDPainter{}
+	yOff := (winH - 13) / 2 // vertical start of glyph rows in the buffer
+
+	tests := []struct {
+		name      string
+		winW      int
+		title     string
+		alignment int // 0=center, 1=left, 2=right
+		wantX     int
+	}{
+		{
+			name:      "left",
+			winW:      600,
+			title:     wideTitle,
+			alignment: 1,
+			wantX:     leftPad,
+		},
+		{
+			name:      "center_wide",
+			winW:      600,
+			title:     wideTitle,
+			alignment: 0,
+			// titleX = (600 - 2*7) / 2 = 293; fits without overlap
+			wantX: (600 - len(wideTitle)*glyphW) / 2,
+		},
+		{
+			name:      "center_narrow_fallback",
+			winW:      300,
+			title:     narrowTitle,
+			alignment: 0,
+			// titleX = (300 - 168) / 2 = 66; 66+168=234 > minX(162)-rightPad(12)=150 → fallback
+			wantX: leftPad,
+		},
+		{
+			name:      "right_wide",
+			winW:      600,
+			title:     wideTitle,
+			alignment: 2,
+			// minX = 600 - 3*46 = 462; titleX = 462 - 12 - 14 = 436
+			wantX: (600 - 3*btnW) - rightPad - len(wideTitle)*glyphW,
+		},
+		{
+			name:      "right_narrow_fallback",
+			winW:      200,
+			title:     narrowTitle,
+			alignment: 2,
+			// minX = 200 - 138 = 62; titleX = 62 - 12 - 168 = -118 < leftPad → fallback
+			wantX: leftPad,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := make([]byte, tc.winW*winH*4)
+			state := CSDState{
+				Title:          tc.title,
+				TitleAlignment: tc.alignment,
+				Focused:        true,
+			}
+			painter.PaintTitleBar(buf, tc.winW, winH, state)
+
+			minX := tc.winW - 3*btnW
+			got := titleStartX(buf, tc.winW, minX, yOff, yOff+13)
+			if got != tc.wantX {
+				t.Errorf("alignment=%d winW=%d title=%q: first text pixel at col %d, want %d",
+					tc.alignment, tc.winW, tc.title, got, tc.wantX)
+			}
+		})
+	}
+}

--- a/internal/platform/wayland/csd_painter_test.go
+++ b/internal/platform/wayland/csd_painter_test.go
@@ -25,10 +25,10 @@ func titleStartX(buf []byte, stride, beforeX, yLo, yHi int) int {
 
 func TestPaintTitleBarAlignment(t *testing.T) {
 	const (
-		winH    = defaultTitleBarHeight // 32
-		btnW    = defaultButtonWidth    // 46
-		glyphW  = 7
-		leftPad = 12
+		winH     = defaultTitleBarHeight // 32
+		btnW     = defaultButtonWidth    // 46
+		glyphW   = 7
+		leftPad  = 12
 		rightPad = 12
 	)
 	// 'B' glyph (char 66): rows 2-8 are 0xF0/0x88, so column 0 is always lit.

--- a/internal/platform/wayland/libwayland_csd.go
+++ b/internal/platform/wayland/libwayland_csd.go
@@ -167,7 +167,6 @@ func (h *LibwaylandHandle) SetupCSD(subcompName, subcompVersion, shmName, shmVer
 	h.csdPainter = painter
 	h.csdState = state
 	h.onCSDClose = onClose
-	csdCallbackHandle = h
 
 	// Setup pointer input for CSD hit-testing
 	if err := h.setupCSDPointer(seatName, seatVersion); err != nil {
@@ -186,6 +185,16 @@ func (h *LibwaylandHandle) SetupCSD(subcompName, subcompVersion, shmName, shmVer
 // CSDActive returns true if client-side decorations are active.
 func (h *LibwaylandHandle) CSDActive() bool {
 	return h.csdActive
+}
+
+// SetCSDTitleAlignment sets the title text alignment (0=left, 1=center, 2=right)
+// and triggers a CSD repaint. No-op when CSD is not active.
+func (h *LibwaylandHandle) SetCSDTitleAlignment(alignment int) {
+	if !h.csdActive {
+		return
+	}
+	h.csdState.TitleAlignment = alignment
+	h.repaintCSDTitleBar()
 }
 
 // IsMaximized returns true if the window is currently maximized.
@@ -328,9 +337,11 @@ func (h *LibwaylandHandle) setupCSDPointer(seatName, seatVersion uint32) error {
 	ptrQueueArgs := [2]unsafe.Pointer{unsafe.Pointer(&pointer), unsafe.Pointer(&queue)}
 	ffi.CallFunction(&h.cifSetQueue, h.fnProxySetQueue, nil, ptrQueueArgs[:])
 
-	// Add pointer listener (9 events)
+	// Add pointer listener (9 events). Pass h as data so each callback can
+	// identify which LibwaylandHandle to update — this avoids the single global
+	// and allows multiple concurrent CSD instances (primary + secondary windows).
 	initCSDPointerListeners()
-	if err := h.addListener(pointer, uintptr(unsafe.Pointer(&csdPointerListener[0]))); err != nil {
+	if err := h.addListenerWithData(pointer, uintptr(unsafe.Pointer(&csdPointerListener[0])), uintptr(unsafe.Pointer(h))); err != nil {
 		return fmt.Errorf("add pointer listener: %w", err)
 	}
 
@@ -346,7 +357,6 @@ func (h *LibwaylandHandle) setupCSDPointer(seatName, seatVersion uint32) error {
 var (
 	csdPointerListener [9]uintptr // 9 wl_pointer events
 	csdListenersOnce   sync.Once
-	csdCallbackHandle  *LibwaylandHandle // global ref for callbacks
 )
 
 func initCSDPointerListeners() {
@@ -365,7 +375,7 @@ func initCSDPointerListeners() {
 
 // csdPointerEnterCb: void(data, wl_pointer, serial, surface, sx_fixed, sy_fixed)
 func csdPointerEnterCb(data, pointer, serial, surface, sxFixed, syFixed uintptr) {
-	h := csdCallbackHandle
+	h := (*LibwaylandHandle)(unsafe.Pointer(data))
 	if h == nil {
 		return
 	}
@@ -378,7 +388,7 @@ func csdPointerEnterCb(data, pointer, serial, surface, sxFixed, syFixed uintptr)
 
 // csdPointerLeaveCb: void(data, wl_pointer, serial, surface)
 func csdPointerLeaveCb(data, pointer, serial, surface uintptr) {
-	h := csdCallbackHandle
+	h := (*LibwaylandHandle)(unsafe.Pointer(data))
 	if h == nil {
 		return
 	}
@@ -393,7 +403,7 @@ func csdPointerLeaveCb(data, pointer, serial, surface uintptr) {
 
 // csdPointerMotionCb: void(data, wl_pointer, time, sx_fixed, sy_fixed)
 func csdPointerMotionCb(data, pointer, time, sxFixed, syFixed uintptr) {
-	h := csdCallbackHandle
+	h := (*LibwaylandHandle)(unsafe.Pointer(data))
 	if h == nil {
 		return
 	}
@@ -404,7 +414,7 @@ func csdPointerMotionCb(data, pointer, time, sxFixed, syFixed uintptr) {
 
 // csdPointerButtonCb: void(data, wl_pointer, serial, time, button, state)
 func csdPointerButtonCb(data, pointer, serial, time, button, state uintptr) {
-	h := csdCallbackHandle
+	h := (*LibwaylandHandle)(unsafe.Pointer(data))
 	if h == nil {
 		return
 	}

--- a/internal/platform/wayland/libwayland_csd.go
+++ b/internal/platform/wayland/libwayland_csd.go
@@ -374,8 +374,8 @@ func initCSDPointerListeners() {
 }
 
 // csdPointerEnterCb: void(data, wl_pointer, serial, surface, sx_fixed, sy_fixed)
-func csdPointerEnterCb(data, pointer, serial, surface, sxFixed, syFixed uintptr) {
-	h := (*LibwaylandHandle)(unsafe.Pointer(data)) //nolint:govet // uintptr registered via addListenerWithData; Go object kept alive by caller
+func csdPointerEnterCb(data unsafe.Pointer, pointer, serial, surface, sxFixed, syFixed uintptr) {
+	h := (*LibwaylandHandle)(data)
 	if h == nil {
 		return
 	}
@@ -387,8 +387,8 @@ func csdPointerEnterCb(data, pointer, serial, surface, sxFixed, syFixed uintptr)
 }
 
 // csdPointerLeaveCb: void(data, wl_pointer, serial, surface)
-func csdPointerLeaveCb(data, pointer, serial, surface uintptr) {
-	h := (*LibwaylandHandle)(unsafe.Pointer(data)) //nolint:govet // see csdPointerEnterCb
+func csdPointerLeaveCb(data unsafe.Pointer, pointer, serial, surface uintptr) {
+	h := (*LibwaylandHandle)(data)
 	if h == nil {
 		return
 	}
@@ -402,8 +402,8 @@ func csdPointerLeaveCb(data, pointer, serial, surface uintptr) {
 }
 
 // csdPointerMotionCb: void(data, wl_pointer, time, sx_fixed, sy_fixed)
-func csdPointerMotionCb(data, pointer, time, sxFixed, syFixed uintptr) {
-	h := (*LibwaylandHandle)(unsafe.Pointer(data)) //nolint:govet // see csdPointerEnterCb
+func csdPointerMotionCb(data unsafe.Pointer, pointer, time, sxFixed, syFixed uintptr) {
+	h := (*LibwaylandHandle)(data)
 	if h == nil {
 		return
 	}
@@ -413,8 +413,8 @@ func csdPointerMotionCb(data, pointer, time, sxFixed, syFixed uintptr) {
 }
 
 // csdPointerButtonCb: void(data, wl_pointer, serial, time, button, state)
-func csdPointerButtonCb(data, pointer, serial, time, button, state uintptr) {
-	h := (*LibwaylandHandle)(unsafe.Pointer(data)) //nolint:govet // see csdPointerEnterCb
+func csdPointerButtonCb(data unsafe.Pointer, pointer, serial, time, button, state uintptr) {
+	h := (*LibwaylandHandle)(data)
 	if h == nil {
 		return
 	}

--- a/internal/platform/wayland/libwayland_csd.go
+++ b/internal/platform/wayland/libwayland_csd.go
@@ -375,7 +375,7 @@ func initCSDPointerListeners() {
 
 // csdPointerEnterCb: void(data, wl_pointer, serial, surface, sx_fixed, sy_fixed)
 func csdPointerEnterCb(data, pointer, serial, surface, sxFixed, syFixed uintptr) {
-	h := (*LibwaylandHandle)(unsafe.Pointer(data))
+	h := (*LibwaylandHandle)(unsafe.Pointer(data)) //nolint:govet // uintptr registered via addListenerWithData; Go object kept alive by caller
 	if h == nil {
 		return
 	}
@@ -388,7 +388,7 @@ func csdPointerEnterCb(data, pointer, serial, surface, sxFixed, syFixed uintptr)
 
 // csdPointerLeaveCb: void(data, wl_pointer, serial, surface)
 func csdPointerLeaveCb(data, pointer, serial, surface uintptr) {
-	h := (*LibwaylandHandle)(unsafe.Pointer(data))
+	h := (*LibwaylandHandle)(unsafe.Pointer(data)) //nolint:govet // see csdPointerEnterCb
 	if h == nil {
 		return
 	}
@@ -403,7 +403,7 @@ func csdPointerLeaveCb(data, pointer, serial, surface uintptr) {
 
 // csdPointerMotionCb: void(data, wl_pointer, time, sx_fixed, sy_fixed)
 func csdPointerMotionCb(data, pointer, time, sxFixed, syFixed uintptr) {
-	h := (*LibwaylandHandle)(unsafe.Pointer(data))
+	h := (*LibwaylandHandle)(unsafe.Pointer(data)) //nolint:govet // see csdPointerEnterCb
 	if h == nil {
 		return
 	}
@@ -414,7 +414,7 @@ func csdPointerMotionCb(data, pointer, time, sxFixed, syFixed uintptr) {
 
 // csdPointerButtonCb: void(data, wl_pointer, serial, time, button, state)
 func csdPointerButtonCb(data, pointer, serial, time, button, state uintptr) {
-	h := (*LibwaylandHandle)(unsafe.Pointer(data))
+	h := (*LibwaylandHandle)(unsafe.Pointer(data)) //nolint:govet // see csdPointerEnterCb
 	if h == nil {
 		return
 	}

--- a/internal/platform/wayland/libwayland_xdg.go
+++ b/internal/platform/wayland/libwayland_xdg.go
@@ -462,12 +462,18 @@ func (h *LibwaylandHandle) marshalVoid(proxy uintptr, opcode uint32, args ...uin
 
 // addListener calls wl_proxy_add_listener(proxy, listener, NULL).
 func (h *LibwaylandHandle) addListener(proxy uintptr, listener uintptr) error {
-	var nullData uintptr
+	return h.addListenerWithData(proxy, listener, 0)
+}
+
+// addListenerWithData calls wl_proxy_add_listener with an explicit user-data pointer.
+// Pass uintptr(unsafe.Pointer(h)) to have each callback receive h as its first argument,
+// which avoids the need for a per-type global handle variable.
+func (h *LibwaylandHandle) addListenerWithData(proxy, listener, data uintptr) error {
 	var result int32
 	args := [3]unsafe.Pointer{
 		unsafe.Pointer(&proxy),
 		unsafe.Pointer(&listener),
-		unsafe.Pointer(&nullData),
+		unsafe.Pointer(&data),
 	}
 	_ = ffi.CallFunction(&h.cifAddListener, h.fnAddListener, unsafe.Pointer(&result), args[:])
 	if result < 0 {

--- a/window_header.go
+++ b/window_header.go
@@ -1,0 +1,91 @@
+package gogpu
+
+import "github.com/gogpu/gogpu/internal/platform"
+
+// HeaderAlignment controls the horizontal position of the title in the OS
+// window header bar. It mirrors the Flutter AppBar.centerTitle pattern.
+type HeaderAlignment int
+
+const (
+	// HeaderAlignCenter centers the title in the header bar.
+	// This is the default macOS behavior and requires no platform changes.
+	HeaderAlignCenter HeaderAlignment = iota
+
+	// HeaderAlignLeft positions the title on the left side of the header bar.
+	// On macOS: enables NSWindowStyleMaskFullSizeContentView and a transparent
+	// title bar so GPU-rendered content extends into the title bar area.
+	// The native title text is hidden; the application draws its own header.
+	// On Windows/Linux: stored but not applied (not OS-configurable).
+	HeaderAlignLeft
+
+	// HeaderAlignRight positions the title on the right side of the header bar.
+	// On macOS: same behavior as HeaderAlignLeft — content fills the title bar.
+	// On Windows/Linux: stored but not applied (not OS-configurable).
+	HeaderAlignRight
+)
+
+// SetTitle changes the OS window title for this specific window.
+// This is the per-window equivalent of App.SetTitle.
+func (w *Window) SetTitle(title string) {
+	w.config.Title = title
+	if w.platWindow != nil {
+		w.platWindow.SetTitle(title)
+	}
+}
+
+// Title returns the current OS window title.
+func (w *Window) Title() string {
+	return w.config.Title
+}
+
+// SetHeaderAlignment configures title alignment in the native OS header bar.
+// Applied immediately when the platform window exists; deferred otherwise.
+//
+// Platform notes:
+//   - macOS: Left/Right enable NSWindowStyleMaskFullSizeContentView with a
+//     transparent title bar. The native title text is hidden, leaving the
+//     traffic-light buttons visible. GPU content fills the header area.
+//   - Windows/Linux: alignment is stored for API consistency but has no
+//     visual effect — the OS controls title position on those platforms.
+func (w *Window) SetHeaderAlignment(alignment HeaderAlignment) {
+	w.headerAlignment = alignment
+	if w.platWindow != nil {
+		applyHeaderAlignment(w.platWindow, alignment)
+	}
+}
+
+// HeaderAlignment returns the window's current header title alignment.
+func (w *Window) HeaderAlignment() HeaderAlignment {
+	return w.headerAlignment
+}
+
+// SetHeaderAlignment sets the primary window's header title alignment.
+// When called before Run(), the value is stored and applied when the
+// platform window is created (same deferred pattern as SetHitTestCallback).
+func (a *App) SetHeaderAlignment(alignment HeaderAlignment) {
+	a.config.HeaderAlignment = alignment
+	if a.primaryWindow != nil {
+		a.primaryWindow.SetHeaderAlignment(alignment)
+		return
+	}
+	if a.platWindow != nil {
+		applyHeaderAlignment(a.platWindow, alignment)
+	}
+}
+
+// HeaderAlignment returns the primary window's current header title alignment.
+func (a *App) HeaderAlignment() HeaderAlignment {
+	if a.primaryWindow != nil {
+		return a.primaryWindow.HeaderAlignment()
+	}
+	return a.config.HeaderAlignment
+}
+
+// applyHeaderAlignment delegates to platform.HeaderAligner when the platform
+// window supports it. Platforms that don't implement HeaderAligner are silently
+// skipped — the alignment is stored in the Window for API consistency.
+func applyHeaderAlignment(pw platform.PlatformWindow, alignment HeaderAlignment) {
+	if ha, ok := pw.(platform.HeaderAligner); ok {
+		ha.SetHeaderAlignment(int(alignment))
+	}
+}

--- a/window_header_test.go
+++ b/window_header_test.go
@@ -1,0 +1,406 @@
+package gogpu
+
+import (
+	"testing"
+
+	"github.com/gogpu/gogpu/internal/platform"
+)
+
+// --- helpers -----------------------------------------------------------------
+
+// mockHeaderAlignerWindow extends mockWindow and implements platform.HeaderAligner.
+type mockHeaderAlignerWindow struct {
+	mockWindow
+	headerAlignment int
+	alignmentCalled bool
+}
+
+func (m *mockHeaderAlignerWindow) SetHeaderAlignment(alignment int) {
+	m.headerAlignment = alignment
+	m.alignmentCalled = true
+}
+
+// --- HeaderAlignment constants -----------------------------------------------
+
+func TestHeaderAlignmentConstants(t *testing.T) {
+	if HeaderAlignCenter != 0 {
+		t.Errorf("HeaderAlignCenter = %d, want 0", HeaderAlignCenter)
+	}
+	if HeaderAlignLeft != 1 {
+		t.Errorf("HeaderAlignLeft = %d, want 1", HeaderAlignLeft)
+	}
+	if HeaderAlignRight != 2 {
+		t.Errorf("HeaderAlignRight = %d, want 2", HeaderAlignRight)
+	}
+	// Verify they are distinct.
+	if HeaderAlignCenter == HeaderAlignLeft || HeaderAlignCenter == HeaderAlignRight || HeaderAlignLeft == HeaderAlignRight {
+		t.Error("HeaderAlignment constants must be distinct")
+	}
+}
+
+// --- Window.SetTitle / Title -------------------------------------------------
+
+func TestWindow_SetTitle_NilPlatform(t *testing.T) {
+	w := &Window{config: Config{Title: "original"}}
+
+	w.SetTitle("new title")
+	if w.Title() != "new title" {
+		t.Errorf("Title() = %q, want %q", w.Title(), "new title")
+	}
+}
+
+func TestWindow_SetTitle_UpdatesConfig(t *testing.T) {
+	w := &Window{config: Config{Title: "old"}}
+	w.SetTitle("updated")
+	if w.config.Title != "updated" {
+		t.Errorf("config.Title = %q, want %q", w.config.Title, "updated")
+	}
+}
+
+func TestWindow_SetTitle_DelegatesToPlatform(t *testing.T) {
+	rm := &mockTitleWindow{}
+	w := &Window{config: Config{Title: "init"}, platWindow: rm}
+	w.SetTitle("hello")
+
+	if rm.lastSetTitle != "hello" {
+		t.Errorf("platform.SetTitle called with %q, want %q", rm.lastSetTitle, "hello")
+	}
+	if w.Title() != "hello" {
+		t.Errorf("Title() = %q, want %q", w.Title(), "hello")
+	}
+}
+
+// mockTitleWindow is a minimal platform.PlatformWindow that records SetTitle calls.
+type mockTitleWindow struct {
+	mockWindow
+	lastSetTitle string
+}
+
+func (m *mockTitleWindow) SetTitle(title string) { m.lastSetTitle = title }
+
+func TestWindow_Title_DefaultFromConfig(t *testing.T) {
+	w := &Window{config: Config{Title: "My App"}}
+	if w.Title() != "My App" {
+		t.Errorf("Title() = %q, want %q", w.Title(), "My App")
+	}
+}
+
+// --- Window.SetHeaderAlignment / HeaderAlignment ----------------------------
+
+func TestWindow_SetHeaderAlignment_NilPlatform(t *testing.T) {
+	w := &Window{}
+
+	// Must not panic with nil platWindow.
+	w.SetHeaderAlignment(HeaderAlignLeft)
+
+	if w.HeaderAlignment() != HeaderAlignLeft {
+		t.Errorf("HeaderAlignment() = %d, want HeaderAlignLeft", w.HeaderAlignment())
+	}
+}
+
+func TestWindow_SetHeaderAlignment_DefaultIsCenter(t *testing.T) {
+	w := &Window{}
+	if w.HeaderAlignment() != HeaderAlignCenter {
+		t.Errorf("default HeaderAlignment() = %d, want HeaderAlignCenter", w.HeaderAlignment())
+	}
+}
+
+func TestWindow_SetHeaderAlignment_WithHeaderAligner(t *testing.T) {
+	mock := &mockHeaderAlignerWindow{}
+	w := &Window{platWindow: mock}
+
+	tests := []struct {
+		alignment HeaderAlignment
+		wantInt   int
+	}{
+		{HeaderAlignCenter, 0},
+		{HeaderAlignLeft, 1},
+		{HeaderAlignRight, 2},
+	}
+
+	for _, tt := range tests {
+		mock.alignmentCalled = false
+		w.SetHeaderAlignment(tt.alignment)
+
+		if !mock.alignmentCalled {
+			t.Errorf("alignment %d: SetHeaderAlignment was not called on platform", tt.alignment)
+		}
+		if mock.headerAlignment != tt.wantInt {
+			t.Errorf("alignment %d: platform got %d, want %d", tt.alignment, mock.headerAlignment, tt.wantInt)
+		}
+		if w.HeaderAlignment() != tt.alignment {
+			t.Errorf("HeaderAlignment() = %d, want %d", w.HeaderAlignment(), tt.alignment)
+		}
+	}
+}
+
+func TestWindow_SetHeaderAlignment_NonAlignerPlatform(t *testing.T) {
+	// mockWindow does not implement HeaderAligner — must not panic.
+	mock := &mockWindow{}
+	w := &Window{platWindow: mock}
+
+	w.SetHeaderAlignment(HeaderAlignLeft) // must not panic
+	if w.HeaderAlignment() != HeaderAlignLeft {
+		t.Errorf("HeaderAlignment() = %d, want HeaderAlignLeft", w.HeaderAlignment())
+	}
+}
+
+func TestWindow_HeaderAlignment_RoundTrip(t *testing.T) {
+	w := &Window{}
+
+	for _, a := range []HeaderAlignment{HeaderAlignCenter, HeaderAlignLeft, HeaderAlignRight} {
+		w.SetHeaderAlignment(a)
+		if got := w.HeaderAlignment(); got != a {
+			t.Errorf("HeaderAlignment() = %d after Set(%d)", got, a)
+		}
+	}
+}
+
+// --- App.SetHeaderAlignment / HeaderAlignment --------------------------------
+
+func TestApp_SetHeaderAlignment_NilPlatform(t *testing.T) {
+	app := NewApp(DefaultConfig())
+
+	app.SetHeaderAlignment(HeaderAlignLeft) // must not panic
+	if app.HeaderAlignment() != HeaderAlignLeft {
+		t.Errorf("HeaderAlignment() = %d, want HeaderAlignLeft", app.HeaderAlignment())
+	}
+}
+
+func TestApp_SetHeaderAlignment_DefaultIsCenter(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	if app.HeaderAlignment() != HeaderAlignCenter {
+		t.Errorf("default HeaderAlignment() = %d, want HeaderAlignCenter", app.HeaderAlignment())
+	}
+}
+
+func TestApp_SetHeaderAlignment_WithPlatformWindow(t *testing.T) {
+	mock := &mockHeaderAlignerWindow{}
+	app := &App{platWindow: mock, config: DefaultConfig()}
+
+	app.SetHeaderAlignment(HeaderAlignRight)
+
+	if !mock.alignmentCalled {
+		t.Error("SetHeaderAlignment was not delegated to platform window")
+	}
+	if mock.headerAlignment != 2 {
+		t.Errorf("platform got alignment=%d, want 2 (Right)", mock.headerAlignment)
+	}
+	if app.HeaderAlignment() != HeaderAlignRight {
+		t.Errorf("HeaderAlignment() = %d, want HeaderAlignRight", app.HeaderAlignment())
+	}
+}
+
+func TestApp_SetHeaderAlignment_DelegatesToPrimaryWindow(t *testing.T) {
+	mock := &mockHeaderAlignerWindow{}
+	wm := newWindowManager()
+	id := wm.allocate()
+	primary := &Window{id: id, platWindow: mock}
+	wm.add(primary)
+
+	app := &App{
+		config:        DefaultConfig(),
+		primaryWindow: primary,
+		windowManager: wm,
+	}
+
+	app.SetHeaderAlignment(HeaderAlignLeft)
+
+	if !mock.alignmentCalled {
+		t.Error("SetHeaderAlignment not delegated to primary window platform")
+	}
+	if primary.HeaderAlignment() != HeaderAlignLeft {
+		t.Errorf("primary window HeaderAlignment() = %d, want HeaderAlignLeft", primary.HeaderAlignment())
+	}
+	if app.HeaderAlignment() != HeaderAlignLeft {
+		t.Errorf("App.HeaderAlignment() = %d, want HeaderAlignLeft", app.HeaderAlignment())
+	}
+}
+
+func TestApp_SetHeaderAlignment_StoresWhenNoPlatformWindow(t *testing.T) {
+	app := &App{config: DefaultConfig()}
+
+	app.SetHeaderAlignment(HeaderAlignRight)
+
+	if app.config.HeaderAlignment != HeaderAlignRight {
+		t.Errorf("config.HeaderAlignment = %d, want HeaderAlignRight", app.config.HeaderAlignment)
+	}
+	if app.HeaderAlignment() != HeaderAlignRight {
+		t.Errorf("HeaderAlignment() = %d, want HeaderAlignRight", app.HeaderAlignment())
+	}
+}
+
+func TestApp_HeaderAlignment_ReadsFromPrimaryWindowWhenSet(t *testing.T) {
+	mock := &mockHeaderAlignerWindow{}
+	wm := newWindowManager()
+	id := wm.allocate()
+	primary := &Window{id: id, platWindow: mock, headerAlignment: HeaderAlignRight}
+	wm.add(primary)
+
+	app := &App{
+		config:        DefaultConfig(),
+		primaryWindow: primary,
+		windowManager: wm,
+	}
+
+	if app.HeaderAlignment() != HeaderAlignRight {
+		t.Errorf("HeaderAlignment() = %d, want HeaderAlignRight (from primary window)", app.HeaderAlignment())
+	}
+}
+
+// --- Config.WithHeaderAlignment ----------------------------------------------
+
+func TestConfigWithHeaderAlignment_Default(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.HeaderAlignment != HeaderAlignCenter {
+		t.Errorf("DefaultConfig().HeaderAlignment = %d, want HeaderAlignCenter", cfg.HeaderAlignment)
+	}
+}
+
+func TestConfigWithHeaderAlignment_Left(t *testing.T) {
+	cfg := DefaultConfig().WithHeaderAlignment(HeaderAlignLeft)
+	if cfg.HeaderAlignment != HeaderAlignLeft {
+		t.Errorf("HeaderAlignment = %d, want HeaderAlignLeft", cfg.HeaderAlignment)
+	}
+}
+
+func TestConfigWithHeaderAlignment_Right(t *testing.T) {
+	cfg := DefaultConfig().WithHeaderAlignment(HeaderAlignRight)
+	if cfg.HeaderAlignment != HeaderAlignRight {
+		t.Errorf("HeaderAlignment = %d, want HeaderAlignRight", cfg.HeaderAlignment)
+	}
+}
+
+func TestConfigWithHeaderAlignment_Center(t *testing.T) {
+	cfg := DefaultConfig().
+		WithHeaderAlignment(HeaderAlignLeft).
+		WithHeaderAlignment(HeaderAlignCenter)
+	if cfg.HeaderAlignment != HeaderAlignCenter {
+		t.Errorf("HeaderAlignment = %d, want HeaderAlignCenter after reset", cfg.HeaderAlignment)
+	}
+}
+
+func TestConfigWithHeaderAlignment_DoesNotAffectOtherFields(t *testing.T) {
+	base := DefaultConfig().WithTitle("Test").WithSize(1024, 768)
+	cfg := base.WithHeaderAlignment(HeaderAlignLeft)
+
+	if cfg.Title != "Test" {
+		t.Errorf("Title = %q, want %q", cfg.Title, "Test")
+	}
+	if cfg.Width != 1024 || cfg.Height != 768 {
+		t.Errorf("Size = (%d, %d), want (1024, 768)", cfg.Width, cfg.Height)
+	}
+	if cfg.HeaderAlignment != HeaderAlignLeft {
+		t.Errorf("HeaderAlignment = %d, want HeaderAlignLeft", cfg.HeaderAlignment)
+	}
+}
+
+// --- applyHeaderAlignment helper ---------------------------------------------
+
+func TestApplyHeaderAlignment_SkipsNonAligner(t *testing.T) {
+	// mockWindow does not implement HeaderAligner — must not panic.
+	mock := &mockWindow{}
+	applyHeaderAlignment(mock, HeaderAlignLeft) // must not panic
+}
+
+func TestApplyHeaderAlignment_DelegatesToAligner(t *testing.T) {
+	mock := &mockHeaderAlignerWindow{}
+
+	applyHeaderAlignment(mock, HeaderAlignLeft)
+	if mock.headerAlignment != 1 {
+		t.Errorf("headerAlignment = %d, want 1 (Left)", mock.headerAlignment)
+	}
+
+	applyHeaderAlignment(mock, HeaderAlignRight)
+	if mock.headerAlignment != 2 {
+		t.Errorf("headerAlignment = %d, want 2 (Right)", mock.headerAlignment)
+	}
+
+	applyHeaderAlignment(mock, HeaderAlignCenter)
+	if mock.headerAlignment != 0 {
+		t.Errorf("headerAlignment = %d, want 0 (Center)", mock.headerAlignment)
+	}
+}
+
+// --- HeaderAligner interface compliance -------------------------------------
+
+func TestHeaderAlignerInterface(t *testing.T) {
+	// Compile-time check: mockHeaderAlignerWindow implements platform.HeaderAligner.
+	var _ platform.HeaderAligner = (*mockHeaderAlignerWindow)(nil)
+}
+
+// --- Window header alignment propagates through config ----------------------
+
+func TestWindow_HeaderAlignmentFromConfig(t *testing.T) {
+	mock := &mockHeaderAlignerWindow{}
+	cfg := Config{
+		Width:           800,
+		Height:          600,
+		HeaderAlignment: HeaderAlignLeft,
+	}
+	w := &Window{
+		config:          cfg,
+		platWindow:      mock,
+		headerAlignment: cfg.HeaderAlignment,
+	}
+	// Simulate what NewWindow does after creation.
+	if cfg.HeaderAlignment != HeaderAlignCenter {
+		applyHeaderAlignment(w.platWindow, cfg.HeaderAlignment)
+	}
+
+	if !mock.alignmentCalled {
+		t.Error("SetHeaderAlignment not called on platform window")
+	}
+	if mock.headerAlignment != 1 {
+		t.Errorf("platform headerAlignment = %d, want 1 (Left)", mock.headerAlignment)
+	}
+	if w.HeaderAlignment() != HeaderAlignLeft {
+		t.Errorf("w.HeaderAlignment() = %d, want HeaderAlignLeft", w.HeaderAlignment())
+	}
+}
+
+func TestWindow_HeaderAlignmentCenterSkipsApply(t *testing.T) {
+	mock := &mockHeaderAlignerWindow{}
+	cfg := Config{HeaderAlignment: HeaderAlignCenter}
+	// Simulate NewWindow path: Center means no call to applyHeaderAlignment.
+	if cfg.HeaderAlignment != HeaderAlignCenter {
+		applyHeaderAlignment(mock, cfg.HeaderAlignment)
+	}
+	if mock.alignmentCalled {
+		t.Error("applyHeaderAlignment should not be called for HeaderAlignCenter")
+	}
+}
+
+// --- Window.SetTitle per-window independence --------------------------------
+
+func TestWindow_SetTitle_IndependentOfApp(t *testing.T) {
+	rm1 := &mockTitleWindow{}
+	rm2 := &mockTitleWindow{}
+
+	wm := newWindowManager()
+	id1, id2 := wm.allocate(), wm.allocate()
+	w1 := &Window{id: id1, platWindow: rm1, config: Config{Title: "Window1"}}
+	w2 := &Window{id: id2, platWindow: rm2, config: Config{Title: "Window2"}}
+	wm.add(w1)
+	wm.add(w2)
+
+	w1.SetTitle("New Title 1")
+	w2.SetTitle("New Title 2")
+
+	if w1.Title() != "New Title 1" {
+		t.Errorf("w1.Title() = %q, want %q", w1.Title(), "New Title 1")
+	}
+	if w2.Title() != "New Title 2" {
+		t.Errorf("w2.Title() = %q, want %q", w2.Title(), "New Title 2")
+	}
+	if rm1.lastSetTitle != "New Title 1" {
+		t.Errorf("rm1.lastSetTitle = %q, want %q", rm1.lastSetTitle, "New Title 1")
+	}
+	if rm2.lastSetTitle != "New Title 2" {
+		t.Errorf("rm2.lastSetTitle = %q, want %q", rm2.lastSetTitle, "New Title 2")
+	}
+	// Verify windows don't interfere with each other.
+	if w1.Title() == w2.Title() {
+		t.Error("w1 and w2 titles should be independent")
+	}
+}

--- a/window_manager.go
+++ b/window_manager.go
@@ -439,6 +439,12 @@ func (a *App) closeSecondaryWindow(id WindowID) {
 	a.windowManager.remove(id)
 	a.windowManager.release(id)
 
+	// Clear the live resize hook before destroying the surface so AppKit
+	// cannot fire windowDidResize: on a torn-down RenderTarget.
+	if lr, ok := w.platWindow.(platform.LiveResizeRenderer); ok {
+		lr.SetLiveResizeHook(nil)
+	}
+
 	// Release GPU surface on the render thread.
 	if w.surface != nil {
 		a.renderLoop.RunOnRenderThreadVoid(func() {

--- a/window_manager.go
+++ b/window_manager.go
@@ -375,6 +375,30 @@ func (a *App) NewWindow(config Config) (*Window, error) {
 	applyHeaderAlignment(platWindow, config.HeaderAlignment)
 	a.windowManager.add(w)
 
+	// Install live-resize hook for macOS so this window re-renders during drag.
+	// Without it, AppKit stretches the last frame to fill the new window size.
+	// Mirrors the primary window hook in registerPrimaryWindow.
+	if lr, ok := platWindow.(platform.LiveResizeRenderer); ok {
+		capturedW := w
+		capturedWS := ws
+		lr.SetLiveResizeHook(func() {
+			if a.renderLoop == nil {
+				return
+			}
+			physW, physH := platWindow.PhysicalSize()
+			if physW > 0 && physH > 0 {
+				a.renderLoop.RunOnRenderThreadVoid(func() {
+					capturedWS.resize(physW, physH, a.renderer.device, a.renderer.adapter)
+				})
+			}
+			logW, logH := platWindow.LogicalSize()
+			if capturedW.onResize != nil && logW > 0 && logH > 0 {
+				capturedW.onResize(logW, logH)
+			}
+			a.renderFrameMultiThread()
+		})
+	}
+
 	// Request a redraw so the new window gets its first frame.
 	if a.invalidator != nil {
 		a.invalidator.Invalidate()

--- a/window_manager.go
+++ b/window_manager.go
@@ -33,6 +33,9 @@ type Window struct {
 	surface    *RenderTarget
 	platWindow platform.PlatformWindow // underlying platform window
 
+	// Header configuration
+	headerAlignment HeaderAlignment
+
 	// Per-window callbacks
 	onDraw       func(*Context)
 	onResize     func(int, int)
@@ -360,13 +363,16 @@ func (a *App) NewWindow(config Config) (*Window, error) {
 
 	// Create Window and register in WindowManager.
 	w := &Window{
-		id:         internalID,
-		platformID: platWindow.ID(),
-		config:     config,
-		surface:    ws,
-		platWindow: platWindow,
-		visible:    true,
+		id:              internalID,
+		platformID:      platWindow.ID(),
+		config:          config,
+		surface:         ws,
+		platWindow:      platWindow,
+		headerAlignment: config.HeaderAlignment,
+		visible:         true,
 	}
+
+	applyHeaderAlignment(platWindow, config.HeaderAlignment)
 	a.windowManager.add(w)
 
 	// Request a redraw so the new window gets its first frame.


### PR DESCRIPTION
  ## Summary                                                                                                                
  - Add HeaderAlignment interface for cross-platform title bar alignment control                                            
  - macOS: Implement custom NSTextField injection for center and right alignment                                            
  - Linux/Wayland: Add CSD title alignment support via DefaultCSDPainter                                                    
  - Windows/X11: Stub implementations (platform-controlled title positioning)                                               
  - Update Config with HeaderAlignment field and builder method 
  
 ## Changes                                                                                                                
  - New window_header.go with HeaderAligner interface and applyHeaderAlignment helper                                       
  - darwin/window.go: injectTitleTextField logic for custom title positioning                                               
  - Wayland CSD support for title alignment state and rendering                                                             
  - Secondary window support for header alignment on all platforms  
 
 ## Test plan                                                                                                              
  - [x] macOS: Verify center/left/right alignment rendering correctly                                                       
  - [x] Wayland: Test CSD title alignment with DefaultCSDPainter                                                            
  - [x] Secondary windows: Confirm alignment applies to new windows                                                         
  - [x] Cross-platform: Verify stubs don't break Windows/X11 
  
  
<img width="1103" height="760" alt="Снимок экрана 2026-06-29 в 23 51 17" src="https://github.com/user-attachments/assets/723a0627-6825-4a60-b058-f75d897d8bc8" />
<img width="701" height="598" alt="Снимок экрана 2026-06-29 в 23 52 01" src="https://github.com/user-attachments/assets/7f81a1df-d253-4fd7-b97a-35b6b3975f98" />
