### PR TITLE
feat(x11): wire _NET_WM_ICON for taskbar/decoration icon support

### DIFF
--- a/app.go
+++ b/app.go
@@ -480,6 +480,7 @@ func (a *App) initPlatform() (platform.PlatformWindow, error) {
 		MinHeight:  a.config.MinHeight,
 		MaxWidth:   a.config.MaxWidth,
 		MaxHeight:  a.config.MaxHeight,
+		Icon:       a.config.Icon,
 	})
 	if err != nil {
 		return nil, err

--- a/app.go
+++ b/app.go
@@ -431,12 +431,15 @@ func (a *App) Run() error {
 	return nil
 }
 
+// newPlatformManagerFn creates a platform manager; replaced in tests to inject mocks.
+var newPlatformManagerFn func() platform.PlatformManager = platform.NewManager
+
 // initPlatform initializes the platform manager, applies pending menu,
 // and creates the primary window. All operations must be on the main thread.
 func (a *App) initPlatform() (platform.PlatformWindow, error) {
 	// Initialize platform manager (process-level) — must be on main thread.
 	platform.SetLogger(slogger())
-	a.manager = platform.NewManager()
+	a.manager = newPlatformManagerFn()
 	if err := a.manager.Init(); err != nil {
 		return nil, err
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -1,6 +1,7 @@
 package gogpu
 
 import (
+	"image"
 	"testing"
 
 	"github.com/gogpu/gogpu/input"
@@ -1130,5 +1131,33 @@ func TestAppSetMinMaxSizeNilPlatform(t *testing.T) {
 	}
 	if app.config.MaxWidth != 1920 || app.config.MaxHeight != 1080 {
 		t.Errorf("config MaxSize = %dx%d, want 1920x1080", app.config.MaxWidth, app.config.MaxHeight)
+	}
+}
+
+// configCapturingManager wraps mockManager and records the Config passed to CreateWindow.
+type configCapturingManager struct {
+	mockManager
+	got platform.Config
+}
+
+func (m *configCapturingManager) CreateWindow(cfg platform.Config) (platform.PlatformWindow, error) {
+	m.got = cfg
+	return &mockWindow{}, nil
+}
+
+func TestInitPlatform_PropagatesIcon(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 16, 16))
+	app := NewApp(DefaultConfig().WithIcon(img))
+
+	capturing := &configCapturingManager{}
+	old := newPlatformManagerFn
+	newPlatformManagerFn = func() platform.PlatformManager { return capturing }
+	defer func() { newPlatformManagerFn = old }()
+
+	if _, err := app.initPlatform(); err != nil {
+		t.Fatalf("initPlatform: %v", err)
+	}
+	if capturing.got.Icon != img {
+		t.Error("initPlatform: Icon not propagated to platform.Config")
 	}
 }

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package gogpu
 
 import (
+	"image"
 	"os"
 	"strings"
 
@@ -120,6 +121,10 @@ type Config struct {
 
 	// MaxHeight is the maximum window height in logical pixels (0 = no constraint).
 	MaxHeight int
+
+	// Icon is the window icon displayed in taskbars and window decorations.
+	// On X11: set via _NET_WM_ICON. On Windows/macOS: no-op (icons come from app resources).
+	Icon image.Image
 }
 
 // DefaultConfig returns a sensible default configuration.
@@ -343,6 +348,13 @@ func (c Config) WithHeaderAlignment(alignment HeaderAlignment) Config {
 // When false: window size is fixed at the values set by WithSize.
 func (c Config) WithResizable(resizable bool) Config {
 	c.Resizable = resizable
+	return c
+}
+
+// WithIcon sets the window icon shown in taskbars and decorations.
+// On X11: set via _NET_WM_ICON (EWMH). No-op on Windows/macOS.
+func (c Config) WithIcon(img image.Image) Config {
+	c.Icon = img
 	return c
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package gogpu
 
 import (
+	"image"
 	"testing"
 
 	"github.com/gogpu/gogpu/gpu/types"
@@ -426,5 +427,17 @@ func TestConfigTabbing(t *testing.T) {
 	}
 	if cfg.TabbingIdentifier != "test.id" {
 		t.Fatalf("expected test.id, got %v", cfg.TabbingIdentifier)
+	}
+}
+
+func TestConfigWithIcon(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 32, 32))
+	cfg := DefaultConfig().WithIcon(img)
+	if cfg.Icon != img {
+		t.Fatal("WithIcon: Icon field not set")
+	}
+	cfg2 := cfg.WithIcon(nil)
+	if cfg2.Icon != nil {
+		t.Fatal("WithIcon(nil): Icon field not cleared")
 	}
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -2,6 +2,7 @@
 package platform
 
 import (
+	"image"
 	"sync/atomic"
 
 	"github.com/gogpu/gpucontext"
@@ -31,6 +32,7 @@ type Config struct {
 	MinHeight         int // 0 = no minimum constraint
 	MaxWidth          int // 0 = no maximum constraint
 	MaxHeight         int // 0 = no maximum constraint
+	Icon              image.Image
 }
 
 // Event represents a platform event.

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -220,6 +220,7 @@ func (p *x11Platform) CreateWindow(config Config) (PlatformWindow, error) {
 		MinHeight:  config.MinHeight,
 		MaxWidth:   config.MaxWidth,
 		MaxHeight:  config.MaxHeight,
+		Icon:       config.Icon,
 	}
 	if err := p.inner.Init(x11Config); err != nil {
 		return nil, err

--- a/internal/platform/x11/atoms.go
+++ b/internal/platform/x11/atoms.go
@@ -186,6 +186,7 @@ type StandardAtoms struct {
 	NetWMPID                Atom
 	UTF8String              Atom
 	MotifWMHints            Atom
+	NetWMIcon               Atom
 	Clipboard               Atom // CLIPBOARD selection atom (not XA_PRIMARY)
 	Targets                 Atom // TARGETS atom for selection target negotiation
 	GogpuSelection          Atom // Property name for clipboard data transfer
@@ -283,6 +284,11 @@ func (c *Connection) InternStandardAtoms() (*StandardAtoms, error) {
 	}
 
 	atoms.GogpuSelection, err = c.InternAtom(AtomNameGogpuSelection, false)
+	if err != nil {
+		return nil, err
+	}
+
+	atoms.NetWMIcon, err = c.InternAtom(AtomNameNetWMIcon, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/platform/x11/icon_test.go
+++ b/internal/platform/x11/icon_test.go
@@ -8,6 +8,29 @@ import (
 	"testing"
 )
 
+// TestSetNetWMIcon_NoOp verifies the early-return paths that need no X server.
+func TestSetNetWMIcon_NoOp(t *testing.T) {
+	atoms := &StandardAtoms{NetWMIcon: AtomNone}
+
+	// nil img with AtomNone → nil error, no panic
+	if err := (*Connection)(nil).SetNetWMIcon(0, atoms, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// non-nil img but AtomNone → still returns early
+	img := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+	if err := (*Connection)(nil).SetNetWMIcon(0, atoms, img); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// zero-size image with a valid atom → returns early before any X call
+	atoms2 := &StandardAtoms{NetWMIcon: Atom(1)}
+	empty := image.NewNRGBA(image.Rect(0, 0, 0, 0))
+	if err := (*Connection)(nil).SetNetWMIcon(0, atoms2, empty); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // TestSetNetWMIcon_E2E creates a real X11 window, sets _NET_WM_ICON, reads it
 // back with GetProperty and verifies the ARGB encoding round-trips correctly.
 // Skips when no X server is reachable.

--- a/internal/platform/x11/icon_test.go
+++ b/internal/platform/x11/icon_test.go
@@ -1,0 +1,90 @@
+//go:build linux
+
+package x11
+
+import (
+	"image"
+	"image/color"
+	"testing"
+)
+
+// TestSetNetWMIcon_E2E creates a real X11 window, sets _NET_WM_ICON, reads it
+// back with GetProperty and verifies the ARGB encoding round-trips correctly.
+// Skips when no X server is reachable.
+func TestSetNetWMIcon_E2E(t *testing.T) {
+	conn, err := Connect()
+	if err != nil {
+		t.Skipf("no X server: %v", err)
+	}
+	defer conn.Close()
+
+	atoms, err := conn.InternStandardAtoms()
+	if err != nil {
+		t.Fatalf("InternStandardAtoms: %v", err)
+	}
+	if atoms.NetWMIcon == AtomNone {
+		t.Skip("_NET_WM_ICON atom not supported by this X server")
+	}
+
+	window, err := conn.CreateWindow(WindowConfig{Width: 1, Height: 1})
+	if err != nil {
+		t.Fatalf("CreateWindow: %v", err)
+	}
+	defer conn.DestroyWindow(window)
+
+	// 2×2 image with four distinct cases: opaque, semi-transparent, transparent, mixed.
+	img := image.NewNRGBA(image.Rect(0, 0, 2, 2))
+	img.SetNRGBA(0, 0, color.NRGBA{R: 255, G: 0, B: 0, A: 255})   // opaque red
+	img.SetNRGBA(1, 0, color.NRGBA{R: 0, G: 255, B: 0, A: 128})   // half-alpha green
+	img.SetNRGBA(0, 1, color.NRGBA{R: 0, G: 0, B: 255, A: 0})     // fully transparent
+	img.SetNRGBA(1, 1, color.NRGBA{R: 255, G: 255, B: 0, A: 200}) // yellow, partial alpha
+
+	if err := conn.SetNetWMIcon(window, atoms, img); err != nil {
+		t.Fatalf("SetNetWMIcon: %v", err)
+	}
+
+	// Read back: 2 header words + 4 pixels = 6 CARDINAL elements.
+	data, actualType, format, err := conn.GetProperty(window, atoms.NetWMIcon, AtomCardinal, 0, 6, false)
+	if err != nil {
+		t.Fatalf("GetProperty: %v", err)
+	}
+	if actualType == AtomNone {
+		t.Fatal("_NET_WM_ICON property not set after SetNetWMIcon")
+	}
+	if format != 32 {
+		t.Errorf("format = %d, want 32", format)
+	}
+	if len(data) < 6*4 {
+		t.Fatalf("data too short: %d bytes, want at least 24", len(data))
+	}
+
+	get := func(off int) uint32 {
+		return uint32(data[off]) | uint32(data[off+1])<<8 |
+			uint32(data[off+2])<<16 | uint32(data[off+3])<<24
+	}
+
+	if got := get(0); got != 2 {
+		t.Errorf("width = %d, want 2", got)
+	}
+	if got := get(4); got != 2 {
+		t.Errorf("height = %d, want 2", got)
+	}
+
+	tests := []struct {
+		name string
+		off  int
+		want uint32
+	}{
+		{"(0,0) opaque red", 8, 0xFFFF0000},
+		{"(1,0) half-alpha green", 12, 0x8000FF00},
+		{"(0,1) transparent", 16, 0x00000000},
+		{"(1,1) yellow A=200", 20, 0xC8FFFF00},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := get(tt.off); got != tt.want {
+				t.Errorf("pixel = %08x, want %08x", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -344,53 +344,9 @@ func (p *Platform) Init(config Config) error {
 	}
 
 	// Set window properties
-	if err := conn.SetWindowTitle(window, config.Title, atoms); err != nil {
+	if err := p.applyWindowProperties(conn, window, atoms, config); err != nil {
 		_ = conn.Close()
-		return fmt.Errorf("x11: failed to set title: %w", err)
-	}
-
-	// Set WM protocols (for close button)
-	if err := conn.SetWMProtocols(window, atoms); err != nil {
-		_ = conn.Close()
-		return fmt.Errorf("x11: failed to set WM protocols: %w", err)
-	}
-
-	// Set WM class
-	if err := conn.SetWMClass(window, "gogpu", "GoGPU"); err != nil {
-		_ = conn.Close()
-		return fmt.Errorf("x11: failed to set WM class: %w", err)
-	}
-
-	// Set PID (non-fatal, some WMs don't support this)
-	_ = conn.SetWMPID(window, atoms)
-
-	// Set window type (non-fatal, some WMs don't support this)
-	_ = conn.SetNetWMWindowType(window, atoms.NetWMWindowTypeNormal, atoms)
-
-	// Set window icon (non-fatal)
-	if config.Icon != nil {
-		_ = conn.SetNetWMIcon(window, atoms, config.Icon)
-	}
-
-	// Handle frameless windows via Motif hints
-	if config.Frameless {
-		_ = conn.SetWindowBorderless(window, atoms)
-	}
-
-	// Handle non-resizable windows via Motif hints
-	if !config.Resizable && !config.Frameless {
-		hints := &MotifWMHints{
-			Flags:       MotifHintsDecorations | MotifHintsFunctions,
-			Decorations: MotifDecorBorder | MotifDecorTitle | MotifDecorMenu | MotifDecorMinimize,
-			Functions:   1 | 2 | 8, // Move | Minimize | Close (no Resize or Maximize)
-		}
-		// Non-fatal, some WMs don't support Motif hints
-		_ = conn.SetMotifWMHints(window, hints, atoms)
-	}
-
-	// Apply initial min/max size constraints (non-fatal).
-	if config.MinWidth > 0 || config.MinHeight > 0 || config.MaxWidth > 0 || config.MaxHeight > 0 {
-		_ = conn.SetWMSizeHints(window, config.MinWidth, config.MinHeight, config.MaxWidth, config.MaxHeight)
+		return err
 	}
 
 	// Get keyboard mapping (non-fatal - keyboard input may not work correctly without it)
@@ -490,6 +446,40 @@ func (p *Platform) Init(config Config) error {
 		logger().Warn("x11 init without xlib", "window", fmt.Sprintf("%#x", w.window))
 	}
 
+	return nil
+}
+
+// applyWindowProperties sets all WM properties on a newly created window.
+// Fatal properties (title, protocols, class) return an error; the rest are non-fatal.
+func (p *Platform) applyWindowProperties(conn *Connection, window ResourceID, atoms *StandardAtoms, config Config) error {
+	if err := conn.SetWindowTitle(window, config.Title, atoms); err != nil {
+		return fmt.Errorf("x11: failed to set title: %w", err)
+	}
+	if err := conn.SetWMProtocols(window, atoms); err != nil {
+		return fmt.Errorf("x11: failed to set WM protocols: %w", err)
+	}
+	if err := conn.SetWMClass(window, "gogpu", "GoGPU"); err != nil {
+		return fmt.Errorf("x11: failed to set WM class: %w", err)
+	}
+	_ = conn.SetWMPID(window, atoms)
+	_ = conn.SetNetWMWindowType(window, atoms.NetWMWindowTypeNormal, atoms)
+	if config.Icon != nil {
+		_ = conn.SetNetWMIcon(window, atoms, config.Icon)
+	}
+	if config.Frameless {
+		_ = conn.SetWindowBorderless(window, atoms)
+	}
+	if !config.Resizable && !config.Frameless {
+		hints := &MotifWMHints{
+			Flags:       MotifHintsDecorations | MotifHintsFunctions,
+			Decorations: MotifDecorBorder | MotifDecorTitle | MotifDecorMenu | MotifDecorMinimize,
+			Functions:   1 | 2 | 8, // Move | Minimize | Close (no Resize or Maximize)
+		}
+		_ = conn.SetMotifWMHints(window, hints, atoms)
+	}
+	if config.MinWidth > 0 || config.MinHeight > 0 || config.MaxWidth > 0 || config.MaxHeight > 0 {
+		_ = conn.SetWMSizeHints(window, config.MinWidth, config.MinHeight, config.MaxWidth, config.MaxHeight)
+	}
 	return nil
 }
 

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -4,6 +4,7 @@ package x11
 
 import (
 	"fmt"
+	"image"
 	"math"
 	"os"
 	"strconv"
@@ -32,6 +33,7 @@ type Config struct {
 	MinHeight  int // 0 = no minimum constraint
 	MaxWidth   int // 0 = no maximum constraint
 	MaxHeight  int // 0 = no maximum constraint
+	Icon       image.Image
 }
 
 // EventType represents the type of platform event.
@@ -364,6 +366,11 @@ func (p *Platform) Init(config Config) error {
 
 	// Set window type (non-fatal, some WMs don't support this)
 	_ = conn.SetNetWMWindowType(window, atoms.NetWMWindowTypeNormal, atoms)
+
+	// Set window icon (non-fatal)
+	if config.Icon != nil {
+		_ = conn.SetNetWMIcon(window, atoms, config.Icon)
+	}
 
 	// Handle frameless windows via Motif hints
 	if config.Frameless {

--- a/internal/platform/x11/window.go
+++ b/internal/platform/x11/window.go
@@ -268,7 +268,7 @@ func (c *Connection) SetNetWMIcon(window ResourceID, atoms *StandardAtoms, img i
 			var argb uint32
 			if a16 > 0 {
 				a8 := a16 >> 8
-				argb = (a8 << 24) | ((r16*255/a16) << 16) | ((g16*255/a16) << 8) | (b16 * 255 / a16)
+				argb = (a8 << 24) | ((r16 * 255 / a16) << 16) | ((g16 * 255 / a16) << 8) | (b16 * 255 / a16)
 			}
 			put(off, argb)
 			off += 4

--- a/internal/platform/x11/window.go
+++ b/internal/platform/x11/window.go
@@ -4,6 +4,7 @@ package x11
 
 import (
 	"fmt"
+	"image"
 	"os"
 )
 
@@ -236,6 +237,44 @@ func (c *Connection) SetNetWMWindowType(window ResourceID, windowType Atom, atom
 	}
 
 	return c.ChangeProperty(window, atoms.NetWMWindowType, AtomAtom, 32, PropModeReplace, data)
+}
+
+// SetNetWMIcon sets the _NET_WM_ICON property so window managers display
+// the application icon in taskbars and window decorations.
+// EWMH format: [width, height, w*h ARGB pixels] as CARDINAL/32,
+// each pixel 0xAARRGGBB, non-premultiplied.
+func (c *Connection) SetNetWMIcon(window ResourceID, atoms *StandardAtoms, img image.Image) error {
+	if atoms.NetWMIcon == AtomNone || img == nil {
+		return nil
+	}
+	bounds := img.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	if w == 0 || h == 0 {
+		return nil
+	}
+	data := make([]byte, (2+w*h)*4)
+	put := func(off int, v uint32) {
+		data[off] = byte(v)
+		data[off+1] = byte(v >> 8)
+		data[off+2] = byte(v >> 16)
+		data[off+3] = byte(v >> 24)
+	}
+	put(0, uint32(w))
+	put(4, uint32(h))
+	off := 8
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r16, g16, b16, a16 := img.At(x, y).RGBA()
+			var argb uint32
+			if a16 > 0 {
+				a8 := a16 >> 8
+				argb = (a8 << 24) | ((r16*255/a16) << 16) | ((g16*255/a16) << 8) | (b16 * 255 / a16)
+			}
+			put(off, argb)
+			off += 4
+		}
+	}
+	return c.ChangeProperty(window, atoms.NetWMIcon, AtomCardinal, 32, PropModeReplace, data)
 }
 
 // GetProperty reads a window property.


### PR DESCRIPTION
## Summary

- Adds `Config.WithIcon(image.Image)` to set a window icon on X11 via the EWMH `_NET_WM_ICON` property
- Converts `image.Image` to the CARDINAL/32 ARGB wire format (non-premultiplied `0xAARRGGBB`) expected by EWMH, handling un-premultiplication from Go's `color.RGBA()` output
- No-op on Windows/macOS where icons come from app resources

## Changes

- **`x11/atoms.go`**: intern `_NET_WM_ICON` in `StandardAtoms` at connection time
- **`x11/window.go`**: add `SetNetWMIcon(*Connection, ResourceID, *StandardAtoms, image.Image)` — encodes image to EWMH wire format and calls `ChangeProperty`
- **`x11/platform.go`**: add `Icon image.Image` to x11 `Config`; call `SetNetWMIcon` during window init alongside PID/window-type (non-fatal)
- **`platform/platform.go`**, **`platform_linux.go`**, **`config.go`**, **`app.go`**: thread `Icon image.Image` through every config layer

## Test plan

- [ ] `go test ./internal/platform/x11/... -run TestSetNetWMIcon_E2E -v` — connects to a real X server, creates a window, sets the icon, reads back `_NET_WM_ICON` via `GetProperty`, verifies ARGB encoding for four pixel cases (opaque, semi-transparent, transparent, mixed); skips cleanly in CI without `DISPLAY`
- [ ] `go build ./...` — clean build across all platforms