### PR TITLE
deps: wgpu v0.30.9 + goffi v0.5.6 (callback stack-move fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.4] - 2026-07-03
+
+### Changed
+
+- **deps:** wgpu v0.30.8 → v0.30.9, goffi v0.5.5 → v0.5.6 — fixes goroutine stack-move corruption in FFI callbacks (@tie, go-webgpu/goffi#59). Return values could be silently lost when a callback grew the stack during a C→Go call.
+
 ## [0.43.3] - 2026-07-01
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.43.3
+## Current State: v0.43.4
 
 ✅ **Production-ready** with full feature set:
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.
@@ -80,6 +80,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.43.4** | 2026-07-03 | **deps:** wgpu v0.30.9, goffi v0.5.6 — callback stack-move corruption fix (@tie, goffi#59) |
 | **v0.43.3** | 2026-07-01 | **Software backend fixes** — WM_PAINT EventExpose (#354), deps wgpu v0.30.8 (MSAA rejection, BGRA blending, dynamic offsets). Reported by @ChristianG1984 |
 | **v0.43.2** | 2026-07-01 | **X11 window icon** (@samyfodil) — `Config.WithIcon(image.Image)` via EWMH `_NET_WM_ICON`. ARGB encoding with un-premultiplication. |
 | **v0.43.1** | 2026-06-30 | **Header alignment + multi-window fixes** (@lkmavi) — `HeaderAlignment` API, macOS live resize, macOS/Wayland/Windows multi-window event routing and CSD fixes |

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/gogpu/gogpu
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.5.5
+	github.com/go-webgpu/goffi v0.5.6
 	github.com/gogpu/gpucontext v0.21.0
 	github.com/gogpu/gputypes v0.5.1
-	github.com/gogpu/wgpu v0.30.8
+	github.com/gogpu/wgpu v0.30.9
 	golang.org/x/sys v0.46.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE=
-github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.5.6 h1:jAN4ciR63DcpU/qdX4A3wbNvcpZ6AdFK+H7OB/1+9Lc=
+github.com/go-webgpu/goffi v0.5.6/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
@@ -8,7 +8,7 @@ github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
 github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.15 h1:uyy4bc8wYlvDaYOpmCBYrJ+d+e7ZqP2BN36csmRVs7o=
 github.com/gogpu/naga v0.17.15/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.30.8 h1:0MWz7V0cyyJALm6BFwGtDvx5b9Y+ynZJCM3CNdib5hk=
-github.com/gogpu/wgpu v0.30.8/go.mod h1:Mfd5ail+nNg8Gl/vt6cijoWMz41cpl2z+Mpx+I+ZkQ8=
+github.com/gogpu/wgpu v0.30.9 h1:mUJ2eOIDrto/fdbwkpg0g5euRdQ8yMUOlGqmEu0ZTDI=
+github.com/gogpu/wgpu v0.30.9/go.mod h1:9TDtAhJmIhh1RfxcLySWEtkwfFMVf0Y7X7TLtVqvTBE=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Summary

- Bump wgpu v0.30.8 → v0.30.9, goffi v0.5.5 → v0.5.6
- goffi#59 (@tie): fixes goroutine stack-move corruption in FFI callbacks — return values silently lost when callback grew the stack during C→Go call

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run` — 0 issues