### PR TITLE
fix(app): live-resize hook — eliminate IOSurface churn, add transaction-present toggle

### DIFF
--- a/app.go
+++ b/app.go
@@ -324,9 +324,31 @@ func (a *App) Run() error {
 	}
 
 	platWindow.Show()
+	a.syncInitialSurfaceSize()
 
-	// macOS can report 0×0 PhysicalSize until the first layout pass; configureSurface
-	// during initRenderer may skip. Sync once after Show so the first OnDraw can present.
+	defer a.shutdown(platWindow)
+
+	a.registerPrimaryWindow(platWindow)
+	a.startRunLoop()
+
+	// Main loop with three rendering modes (ADR-023):
+	//   1. IDLE: No activity — block on OS events (0% CPU, <1ms response)
+	//   2. ANIMATING: StartAnimation() — loop active, onUpdate every tick,
+	//      OnDraw ONLY when RequestRedraw() called (demand-driven, <1% GPU)
+	//   3. CONTINUOUS: ContinuousRender=true — OnDraw every VSync (game loop)
+	for a.running && (a.platWindow == nil || !a.platWindow.ShouldClose()) {
+		a.runFrame()
+	}
+
+	a.lifecycle = AppIdle
+	return nil
+}
+
+// syncInitialSurfaceSize resizes the GPU surface once after the window is
+// shown. macOS can report 0×0 PhysicalSize until the first layout pass, so
+// configureSurface during initRenderer may skip; this sync lets the first
+// OnDraw present.
+func (a *App) syncInitialSurfaceSize() {
 	a.renderLoop.RunOnRenderThreadVoid(func() {
 		if a.renderer != nil && a.platWindow != nil && a.renderer.primary != nil {
 			pw, ph := a.platWindow.PhysicalSize()
@@ -335,50 +357,48 @@ func (a *App) Run() error {
 			}
 		}
 	})
+}
 
-	// Shutdown sequence — order matters on X11/NVIDIA (see step 4 below).
-	// All GPU steps run on the render thread for thread safety.
-	// 1. WaitForGPU / DrainDeferredDestroys / tracker.CloseAll / onClose
-	// 2. Renderer.Destroy()     — release GPU surface/device/adapter (NOT instance)
-	// 3. platWindow + manager   — close the OS window and the X11 Display
-	// 4. Renderer.ReleaseInstance() — unload the Vulkan driver (ICD) LAST
-	// 5. renderLoop.Stop()      — stop the render thread last of all
-	//
-	// Step 3 must precede step 4: the X11 close path is manager.Destroy()
-	// (x11PlatformWindow.Destroy is a no-op — teardown is on the platform).
-	// XCloseDisplay invokes the NVIDIA driver's XESetCloseDisplay hook; if the
-	// Vulkan instance — and thus the ICD — was already released, that hook
-	// points into unloaded code and SIGSEGVs. Close the display while the ICD
-	// is still loaded, release the instance afterwards.
-	defer func() {
-		a.renderLoop.RunOnRenderThreadVoid(func() {
-			a.renderer.WaitForGPU()
-			a.renderer.DrainDeferredDestroys()
-			if a.tracker != nil {
-				_ = a.tracker.CloseAll()
-			}
-			if a.onClose != nil {
-				a.onClose()
-			}
-		})
-		a.renderLoop.RunOnRenderThreadVoid(func() {
-			a.renderer.Destroy()
-		})
-		platWindow.Destroy()
-		a.manager.Destroy()
-		a.renderLoop.RunOnRenderThreadVoid(func() {
-			a.renderer.ReleaseInstance()
-		})
-		a.renderLoop.Stop()
-	}()
+// shutdown runs the Run() teardown sequence. Order matters on X11/NVIDIA
+// (see step 4 below). All GPU steps run on the render thread for thread
+// safety.
+//  1. WaitForGPU / DrainDeferredDestroys / tracker.CloseAll / onClose
+//  2. Renderer.Destroy()     — release GPU surface/device/adapter (NOT instance)
+//  3. platWindow + manager   — close the OS window and the X11 Display
+//  4. Renderer.ReleaseInstance() — unload the Vulkan driver (ICD) LAST
+//  5. renderLoop.Stop()      — stop the render thread last of all
+//
+// Step 3 must precede step 4: the X11 close path is manager.Destroy()
+// (x11PlatformWindow.Destroy is a no-op — teardown is on the platform).
+// XCloseDisplay invokes the NVIDIA driver's XESetCloseDisplay hook; if the
+// Vulkan instance — and thus the ICD — was already released, that hook
+// points into unloaded code and SIGSEGVs. Close the display while the ICD
+// is still loaded, release the instance afterwards.
+func (a *App) shutdown(platWindow platform.PlatformWindow) {
+	a.renderLoop.RunOnRenderThreadVoid(func() {
+		a.renderer.WaitForGPU()
+		a.renderer.DrainDeferredDestroys()
+		if a.tracker != nil {
+			_ = a.tracker.CloseAll()
+		}
+		if a.onClose != nil {
+			a.onClose()
+		}
+	})
+	a.renderLoop.RunOnRenderThreadVoid(func() {
+		a.renderer.Destroy()
+	})
+	platWindow.Destroy()
+	a.manager.Destroy()
+	a.renderLoop.RunOnRenderThreadVoid(func() {
+		a.renderer.ReleaseInstance()
+	})
+	a.renderLoop.Stop()
+}
 
-	a.registerPrimaryWindow(platWindow)
-
-	// Main loop with three rendering modes (ADR-023):
-	//   1. IDLE: No activity — block on OS events (0% CPU, <1ms response)
-	//   2. ANIMATING: StartAnimation() — loop active, onUpdate every tick,
-	//      OnDraw ONLY when RequestRedraw() called (demand-driven, <1% GPU)
-	//   3. CONTINUOUS: ContinuousRender=true — OnDraw every VSync (game loop)
+// startRunLoop marks the app running and primes state consumed by the
+// first iteration of the main loop in Run().
+func (a *App) startRunLoop() {
 	a.running = true
 	a.lifecycle = AppRunning
 
@@ -393,68 +413,67 @@ func (a *App) Run() error {
 		a.invalidator.Invalidate()
 	}
 	a.invalidator.Invalidate() // Request initial frame
+}
 
-	for a.running && (a.platWindow == nil || !a.platWindow.ShouldClose()) {
-		// Three-mode state detection (ADR-023)
-		continuousRender := a.config.ContinuousRender
-		animating := a.animations.IsAnimating()
-		invalidated := a.invalidator.Consume()
+// runFrame executes one iteration of the main loop in Run(): waits for
+// events when idle, processes platform events, ticks onUpdate, and draws
+// a frame when the three-mode state detection (ADR-023) calls for one.
+func (a *App) runFrame() {
+	continuousRender := a.config.ContinuousRender
+	animating := a.animations.IsAnimating()
+	invalidated := a.invalidator.Consume()
 
-		if !continuousRender && !animating && !invalidated {
-			// IDLE: block on OS events (0% CPU, <1ms response)
-			a.manager.WaitEvents()
-		}
-
-		// Process all pending platform events.
-		// Events may call RequestRedraw() which sets invalidated for next check.
-		a.processEventsMultiThread()
-
-		// Check if invalidation arrived during event processing
-		// (e.g., resize or UI framework responding to hover/click).
-		if a.invalidator.Consume() {
-			invalidated = true
-		}
-
-		// Calculate delta time
-		now := time.Now()
-		deltaTime := now.Sub(a.lastFrame).Seconds()
-		a.lastFrame = now
-
-		// Clamp deltaTime after long idle (WaitEvents can block for seconds/minutes).
-		// Without clamping, physics and animations would jump on the first frame.
-		// 66ms = ~15 FPS minimum, a safe upper bound for a single frame step.
-		if deltaTime > 0.066 {
-			deltaTime = 0.066
-		}
-
-		// Update input state for next frame (Ebiten-style polling)
-		// This must be called before onUpdate so JustPressed/JustReleased work correctly
-		if a.inputState != nil {
-			a.inputState.Update()
-		}
-
-		// onUpdate: ALWAYS when loop is active (ANIMATING + CONTINUOUS).
-		// UI frameworks tick animations, process signals, run layout here.
-		// If something changed, they call RequestRedraw() → invalidated = true.
-		if a.onUpdate != nil {
-			a.onUpdate(deltaTime)
-		}
-
-		// Check if onUpdate triggered RequestRedraw (UI spinner, animation tick).
-		if a.invalidator.Consume() {
-			invalidated = true
-		}
-
-		// OnDraw: CONTINUOUS = every VSync (games), otherwise only when dirty.
-		// ANIMATING mode: onUpdate runs every tick, OnDraw only on RequestRedraw.
-		// Lazy acquire inside: if OnDraw doesn't draw, no swapchain acquire.
-		if (continuousRender || invalidated) && a.frameCallbackReady() {
-			a.renderFrameMultiThread()
-		}
+	if !continuousRender && !animating && !invalidated {
+		// IDLE: block on OS events (0% CPU, <1ms response)
+		a.manager.WaitEvents()
 	}
 
-	a.lifecycle = AppIdle
-	return nil
+	// Process all pending platform events.
+	// Events may call RequestRedraw() which sets invalidated for next check.
+	a.processEventsMultiThread()
+
+	// Check if invalidation arrived during event processing
+	// (e.g., resize or UI framework responding to hover/click).
+	if a.invalidator.Consume() {
+		invalidated = true
+	}
+
+	// Calculate delta time
+	now := time.Now()
+	deltaTime := now.Sub(a.lastFrame).Seconds()
+	a.lastFrame = now
+
+	// Clamp deltaTime after long idle (WaitEvents can block for seconds/minutes).
+	// Without clamping, physics and animations would jump on the first frame.
+	// 66ms = ~15 FPS minimum, a safe upper bound for a single frame step.
+	if deltaTime > 0.066 {
+		deltaTime = 0.066
+	}
+
+	// Update input state for next frame (Ebiten-style polling)
+	// This must be called before onUpdate so JustPressed/JustReleased work correctly
+	if a.inputState != nil {
+		a.inputState.Update()
+	}
+
+	// onUpdate: ALWAYS when loop is active (ANIMATING + CONTINUOUS).
+	// UI frameworks tick animations, process signals, run layout here.
+	// If something changed, they call RequestRedraw() → invalidated = true.
+	if a.onUpdate != nil {
+		a.onUpdate(deltaTime)
+	}
+
+	// Check if onUpdate triggered RequestRedraw (UI spinner, animation tick).
+	if a.invalidator.Consume() {
+		invalidated = true
+	}
+
+	// OnDraw: CONTINUOUS = every VSync (games), otherwise only when dirty.
+	// ANIMATING mode: onUpdate runs every tick, OnDraw only on RequestRedraw.
+	// Lazy acquire inside: if OnDraw doesn't draw, no swapchain acquire.
+	if (continuousRender || invalidated) && a.frameCallbackReady() {
+		a.renderFrameMultiThread()
+	}
 }
 
 // newPlatformManagerFn creates a platform manager; replaced in tests to inject mocks.
@@ -475,27 +494,7 @@ func (a *App) initPlatform() (platform.PlatformWindow, error) {
 		a.manager.SetAppName(a.config.AppName)
 	}
 
-	// Apply any menu set before Run().
-	if a.menu != nil || len(a.customMenus) > 0 {
-		a.updateNativeMenu()
-	}
-	// Apply pending system menu items.
-	if a.pendingSystemMenuItems != nil {
-		for menu, items := range a.pendingSystemMenuItems {
-			if mgr, ok := a.manager.(platform.PlatMenuManager); ok {
-				for _, item := range items {
-					mgr.AddToSystemMenu(platform.SystemMenu(menu), []platform.MenuItem{{
-						Title:     item.Title,
-						Action:    item.Action,
-						Role:      platform.MenuRole(item.Role),
-						Disabled:  item.Disabled,
-						Separator: item.Separator,
-					}})
-				}
-			}
-		}
-		a.pendingSystemMenuItems = nil
-	}
+	a.applyPendingMenus()
 
 	// Create primary platform window.
 	platWindow, err := a.manager.CreateWindow(platform.Config{
@@ -547,71 +546,105 @@ func (a *App) initPlatform() (platform.PlatformWindow, error) {
 	// would eliminate this callback entirely. See ROADMAP.md for details.
 	a.platWindow.SetModalFrameCallback(a.modalFrameTick)
 
-	// Enable rendering during macOS live resize (Rio/winit pattern).
-	//
-	// On macOS, AppKit runs a modal tracking loop during window resize
-	// (inside sendEvent:) that blocks our outer event loop. The hook fires on
-	// every windowDidResize: tick; we resize the GPU surface to the current
-	// window size and render a full frame synchronously, exactly like Rio
-	// renders inside drawRect: during live resize. The main thread blocks in
-	// renderFrameMultiThread until the render thread has presented, so the
-	// frame lands inside the same AppKit resize tick — no stretch, no crop.
-	//
-	// Leak prevention (multi-GB IOSurface churn of earlier iterations):
-	//  1. Transaction present during drag (LiveResizePhaser below): the
-	//     drawable swap commits atomically with the resize CA transaction,
-	//     so Core Animation releases superseded drawables immediately
-	//     instead of stockpiling them until the drag ends.
-	//  2. allowsNextDrawableTimeout=false: nextDrawable blocks instead of
-	//     failing under pool pressure, which previously triggered a
-	//     reconfigure-allocate spiral via recoverFromAcquireError.
-	if lr, ok := platWindow.(platform.LiveResizeRenderer); ok {
-		lr.SetLiveResizeHook(func() {
-			if a.renderLoop == nil {
-				return
-			}
-			// Queue the current physical size for the render thread; the
-			// swapchain is reconfigured there before OnDraw (Rio: set_drawable_size
-			// on every Resized event). onResize (user layout callback) still
-			// fires once after the drag via the normal event path.
-			physW, physH := platWindow.PhysicalSize()
-			if physW > 0 && physH > 0 {
-				a.renderLoop.RequestResize(uint32(physW), uint32(physH)) //nolint:gosec // G115: validated positive
-			}
-			a.renderFrameMultiThread()
-		})
-	}
-
-	// Toggle Metal transaction-based present around the live resize drag.
-	// Enabled only for the duration of the drag: outside a main-thread CA
-	// transaction, transaction present would defer frames until the next
-	// AppKit event (blank window).
-	if ph, ok := platWindow.(platform.LiveResizePhaser); ok {
-		ph.SetLiveResizePhaseHooks(
-			func() {
-				if a.renderLoop == nil || a.renderer == nil {
-					return
-				}
-				a.renderLoop.RunOnRenderThreadVoid(func() {
-					if a.renderer.primary != nil {
-						a.renderer.primary.setTransactionPresent(true)
-					}
-				})
-			},
-			func() {
-				if a.renderLoop == nil || a.renderer == nil {
-					return
-				}
-				a.renderLoop.RunOnRenderThreadVoid(func() {
-					if a.renderer.primary != nil {
-						a.renderer.primary.setTransactionPresent(false)
-					}
-				})
-			},
-		)
-	}
+	a.setupLiveResizeHook(platWindow)
+	a.setupLiveResizePhaseHooks(platWindow)
 
 	return platWindow, nil
+}
+
+// applyPendingMenus installs the menu bar and any system menu items that
+// were configured before Run(). Must run after the platform manager is
+// initialized but before the primary window is created.
+func (a *App) applyPendingMenus() {
+	if a.menu != nil || len(a.customMenus) > 0 {
+		a.updateNativeMenu()
+	}
+	if a.pendingSystemMenuItems == nil {
+		return
+	}
+	for menu, items := range a.pendingSystemMenuItems {
+		mgr, ok := a.manager.(platform.PlatMenuManager)
+		if !ok {
+			continue
+		}
+		for _, item := range items {
+			mgr.AddToSystemMenu(platform.SystemMenu(menu), []platform.MenuItem{{
+				Title:     item.Title,
+				Action:    item.Action,
+				Role:      platform.MenuRole(item.Role),
+				Disabled:  item.Disabled,
+				Separator: item.Separator,
+			}})
+		}
+	}
+	a.pendingSystemMenuItems = nil
+}
+
+// setupLiveResizeHook enables rendering during macOS live resize (Rio/winit pattern).
+//
+// On macOS, AppKit runs a modal tracking loop during window resize (inside
+// sendEvent:) that blocks our outer event loop. The hook fires on every
+// windowDidResize: tick; we resize the GPU surface to the current window
+// size and render a full frame synchronously, exactly like Rio renders
+// inside drawRect: during live resize. The main thread blocks in
+// renderFrameMultiThread until the render thread has presented, so the
+// frame lands inside the same AppKit resize tick — no stretch, no crop.
+//
+// Leak prevention (multi-GB IOSurface churn of earlier iterations):
+//  1. Transaction present during drag (setupLiveResizePhaseHooks below): the
+//     drawable swap commits atomically with the resize CA transaction,
+//     so Core Animation releases superseded drawables immediately
+//     instead of stockpiling them until the drag ends.
+//  2. allowsNextDrawableTimeout=false: nextDrawable blocks instead of
+//     failing under pool pressure, which previously triggered a
+//     reconfigure-allocate spiral via recoverFromAcquireError.
+func (a *App) setupLiveResizeHook(platWindow platform.PlatformWindow) {
+	lr, ok := platWindow.(platform.LiveResizeRenderer)
+	if !ok {
+		return
+	}
+	lr.SetLiveResizeHook(func() {
+		if a.renderLoop == nil {
+			return
+		}
+		// Queue the current physical size for the render thread; the
+		// swapchain is reconfigured there before OnDraw (Rio: set_drawable_size
+		// on every Resized event). onResize (user layout callback) still
+		// fires once after the drag via the normal event path.
+		physW, physH := platWindow.PhysicalSize()
+		if physW > 0 && physH > 0 {
+			a.renderLoop.RequestResize(uint32(physW), uint32(physH)) //nolint:gosec // G115: validated positive
+		}
+		a.renderFrameMultiThread()
+	})
+}
+
+// setupLiveResizePhaseHooks toggles Metal transaction-based present around
+// the live resize drag. Enabled only for the duration of the drag: outside
+// a main-thread CA transaction, transaction present would defer frames
+// until the next AppKit event (blank window).
+func (a *App) setupLiveResizePhaseHooks(platWindow platform.PlatformWindow) {
+	ph, ok := platWindow.(platform.LiveResizePhaser)
+	if !ok {
+		return
+	}
+	ph.SetLiveResizePhaseHooks(
+		func() { a.setTransactionPresent(true) },
+		func() { a.setTransactionPresent(false) },
+	)
+}
+
+// setTransactionPresent toggles Metal transaction-based present on the
+// render thread. Called from the live-resize phase hooks (see initPlatform).
+func (a *App) setTransactionPresent(enabled bool) {
+	if a.renderLoop == nil || a.renderer == nil {
+		return
+	}
+	a.renderLoop.RunOnRenderThreadVoid(func() {
+		if a.renderer.primary != nil {
+			a.renderer.primary.setTransactionPresent(enabled)
+		}
+	})
 }
 
 // initRenderer creates the render loop and initializes the renderer

--- a/app.go
+++ b/app.go
@@ -3,6 +3,7 @@ package gogpu
 import (
 	"io"
 	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogpu/gogpu/input"
@@ -58,8 +59,9 @@ type App struct {
 	lastFrame              time.Time
 
 	// Event-driven rendering
-	invalidator *Invalidator
-	animations  *AnimationController
+	invalidator   *Invalidator
+	pendingRedraw atomic.Bool
+	animations    *AnimationController
 
 	// Event source for gpucontext integration
 	eventSource *eventSourceAdapter
@@ -223,6 +225,16 @@ func (a *App) OnFocus(fn func(focused bool)) *App {
 	return a
 }
 
+// InSizeMove reports whether the user is in a modal window resize/move loop.
+// While true, applications should defer expensive content relayout (e.g. terminal
+// grid changes) but may still repaint at the current content resolution.
+func (a *App) InSizeMove() bool {
+	if a.platWindow == nil {
+		return false
+	}
+	return a.platWindow.InSizeMove()
+}
+
 // HasFocus reports whether the window currently has keyboard focus.
 func (a *App) HasFocus() bool {
 	return a.focused
@@ -313,6 +325,17 @@ func (a *App) Run() error {
 
 	platWindow.Show()
 
+	// macOS can report 0×0 PhysicalSize until the first layout pass; configureSurface
+	// during initRenderer may skip. Sync once after Show so the first OnDraw can present.
+	a.renderLoop.RunOnRenderThreadVoid(func() {
+		if a.renderer != nil && a.platWindow != nil && a.renderer.primary != nil {
+			pw, ph := a.platWindow.PhysicalSize()
+			if pw > 0 && ph > 0 {
+				a.renderer.Resize(pw, ph)
+			}
+		}
+	})
+
 	// Shutdown sequence — order matters on X11/NVIDIA (see step 4 below).
 	// All GPU steps run on the render thread for thread safety.
 	// 1. WaitForGPU / DrainDeferredDestroys / tracker.CloseAll / onClose
@@ -366,6 +389,9 @@ func (a *App) Run() error {
 	a.lastFrame = time.Now()
 	a.invalidator = newInvalidator(a.manager.WakeUp)
 	a.animations = &AnimationController{}
+	if a.pendingRedraw.Swap(false) {
+		a.invalidator.Invalidate()
+	}
 	a.invalidator.Invalidate() // Request initial frame
 
 	for a.running && (a.platWindow == nil || !a.platWindow.ShouldClose()) {
@@ -521,28 +547,68 @@ func (a *App) initPlatform() (platform.PlatformWindow, error) {
 	// would eliminate this callback entirely. See ROADMAP.md for details.
 	a.platWindow.SetModalFrameCallback(a.modalFrameTick)
 
-	// Enable rendering during macOS live resize.
+	// Enable rendering during macOS live resize (Rio/winit pattern).
 	//
 	// On macOS, AppKit runs a modal tracking loop during window resize
-	// (inside sendEvent:) that blocks our outer event loop. Without this hook
-	// the old frame sits in the CAMetalLayer at the old size and macOS stretches
-	// it to fill the new window dimensions, producing visible distortion.
+	// (inside sendEvent:) that blocks our outer event loop. The hook fires on
+	// every windowDidResize: tick; we resize the GPU surface to the current
+	// window size and render a full frame synchronously, exactly like Rio
+	// renders inside drawRect: during live resize. The main thread blocks in
+	// renderFrameMultiThread until the render thread has presented, so the
+	// frame lands inside the same AppKit resize tick — no stretch, no crop.
 	//
-	// windowDidResize: fires on every resize step from within AppKit's tracking
-	// loop. We call renderFrameMultiThread from the delegate callback goroutine;
-	// the render goroutine is idle while AppKit's modal loop holds the main
-	// goroutine, so RunOnRenderThreadVoid proceeds without deadlock.
+	// Leak prevention (multi-GB IOSurface churn of earlier iterations):
+	//  1. Transaction present during drag (LiveResizePhaser below): the
+	//     drawable swap commits atomically with the resize CA transaction,
+	//     so Core Animation releases superseded drawables immediately
+	//     instead of stockpiling them until the drag ends.
+	//  2. allowsNextDrawableTimeout=false: nextDrawable blocks instead of
+	//     failing under pool pressure, which previously triggered a
+	//     reconfigure-allocate spiral via recoverFromAcquireError.
 	if lr, ok := platWindow.(platform.LiveResizeRenderer); ok {
 		lr.SetLiveResizeHook(func() {
 			if a.renderLoop == nil {
 				return
 			}
+			// Queue the current physical size for the render thread; the
+			// swapchain is reconfigured there before OnDraw (Rio: set_drawable_size
+			// on every Resized event). onResize (user layout callback) still
+			// fires once after the drag via the normal event path.
 			physW, physH := platWindow.PhysicalSize()
 			if physW > 0 && physH > 0 {
 				a.renderLoop.RequestResize(uint32(physW), uint32(physH)) //nolint:gosec // G115: validated positive
 			}
 			a.renderFrameMultiThread()
 		})
+	}
+
+	// Toggle Metal transaction-based present around the live resize drag.
+	// Enabled only for the duration of the drag: outside a main-thread CA
+	// transaction, transaction present would defer frames until the next
+	// AppKit event (blank window).
+	if ph, ok := platWindow.(platform.LiveResizePhaser); ok {
+		ph.SetLiveResizePhaseHooks(
+			func() {
+				if a.renderLoop == nil || a.renderer == nil {
+					return
+				}
+				a.renderLoop.RunOnRenderThreadVoid(func() {
+					if a.renderer.primary != nil {
+						a.renderer.primary.setTransactionPresent(true)
+					}
+				})
+			},
+			func() {
+				if a.renderLoop == nil || a.renderer == nil {
+					return
+				}
+				a.renderLoop.RunOnRenderThreadVoid(func() {
+					if a.renderer.primary != nil {
+						a.renderer.primary.setTransactionPresent(false)
+					}
+				})
+			},
+		)
 	}
 
 	return platWindow, nil
@@ -594,7 +660,7 @@ func (a *App) processEventsMultiThread() {
 	// Queue primary window resize for render thread (deferred pattern).
 	// RequestResize is an atomic coalesced store so rapid live-resize events
 	// (macOS) collapse to one configure() call per render frame.
-	if lastResize != nil && a.platWindow != nil {
+	if lastResize != nil && a.platWindow != nil && !a.platWindow.InSizeMove() {
 		// Queue PHYSICAL size for render thread (GPU surface reconfiguration)
 		physW, physH := lastResize.PhysicalWidth, lastResize.PhysicalHeight
 		if physW > 0 && physH > 0 {
@@ -837,9 +903,6 @@ func (a *App) renderFrameMultiThread() {
 			continue
 		}
 		pw, ph := w.platWindow.PhysicalSize()
-		if pw <= 0 || ph <= 0 {
-			continue // Minimized
-		}
 		onDraw := w.onDraw
 		if onDraw == nil {
 			// On Wayland (and for consistency everywhere) the compositor only
@@ -849,6 +912,10 @@ func (a *App) renderFrameMultiThread() {
 			// committed at least once on startup and on any subsequent invalidation.
 			onDraw = func(ctx *Context) { ctx.Clear(0, 0, 0, 1) }
 		}
+		// Do NOT skip when PhysicalSize is 0 — macOS can report 0×0 before the
+		// first layout while the window is already visible. Skipping drops the
+		// invalidation without calling OnDraw; resize later is the only redraw.
+		// renderFrameGPU syncs the GPU surface from the platform before drawing.
 		frames = append(frames, windowFrame{
 			window: w,
 			onDraw: onDraw,
@@ -865,52 +932,90 @@ func (a *App) renderFrameMultiThread() {
 
 	// Execute GPU operations on render thread.
 	a.renderLoop.RunOnRenderThreadVoid(func() {
-		// Apply pending resize for the primary window (if still alive).
-		if w, h, ok := a.renderLoop.ConsumePendingResize(); ok {
-			if a.renderer.primary != nil {
-				a.renderer.Resize(int(w), int(h))
+		runInFramePool(func() {
+			a.renderFrameGPU(frames)
+		})
+	})
+}
+
+// renderFrameGPU performs GPU work for all visible windows.
+// Must run on the render thread inside runInFramePool on macOS.
+func (a *App) renderFrameGPU(frames []windowFrame) {
+	// Apply pending resize for the primary window (if still alive).
+	// Applied during live resize too (Rio pattern): the surface tracks the
+	// window every tick; resize() skips no-op reconfigures, and the Metal
+	// layer's blocking nextDrawable + transaction present pace pool churn.
+	if w, h, ok := a.renderLoop.ConsumePendingResize(); ok {
+		if a.renderer.primary != nil {
+			a.renderer.Resize(int(w), int(h))
+		}
+	}
+
+	// Keep the GPU surface in sync with the platform window. On macOS the
+	// renderer can hold 0×0 until the first layout; without this, OnDraw
+	// sees FramebufferSize()==0 and returns without presenting.
+	if a.platWindow != nil && a.renderer != nil && a.renderer.primary != nil {
+		pw, ph := a.platWindow.PhysicalSize()
+		if pw > 0 && ph > 0 {
+			a.renderer.Resize(pw, ph)
+		}
+	}
+
+	// Drain deferred destroys once per frame, not per window.
+	a.renderer.DrainDeferredDestroys()
+
+	for _, frame := range frames {
+		ws := frame.window.surface
+		if ws == nil {
+			continue
+		}
+
+		// initRenderer may leave the surface unconfigured when PhysicalSize was 0.
+		if !ws.CanRender() && ws.platWindow != nil {
+			pw, ph := ws.platWindow.PhysicalSize()
+			if pw > 0 && ph > 0 {
+				ws.resize(pw, ph, a.renderer.device, a.renderer.adapter)
 			}
 		}
 
-		// Drain deferred destroys once per frame, not per window.
-		a.renderer.DrainDeferredDestroys()
+		// Lazy acquire: reset per-frame state for deferred beginFrame.
+		// beginFrame is called on first draw call, not upfront.
+		// If OnDraw produces no GPU work → no acquire, no present.
+		ws.prepareLazyAcquire()
 
-		for _, frame := range frames {
-			ws := frame.window.surface
-			if ws == nil {
-				continue
-			}
+		// Set renderer's currentSurface so draw methods target this window.
+		a.renderer.currentSurface = ws
 
-			// Lazy acquire: reset per-frame state for deferred beginFrame.
-			// beginFrame is called on first draw call, not upfront.
-			// If OnDraw produces no GPU work → no acquire, no present.
-			ws.prepareLazyAcquire()
+		// Call per-window draw callback.
+		ctx := newContextForSurface(a.renderer, ws, frame.scale)
+		frame.onDraw(ctx)
 
-			// Set renderer's currentSurface so draw methods target this window.
-			a.renderer.currentSurface = ws
-
-			// Call per-window draw callback.
-			ctx := newContextForSurface(a.renderer, ws, frame.scale)
-			frame.onDraw(ctx)
-
-			// On outdated, present() reconfigured the surface; re-render once at the
-			// live scale (a DPI change is an outdated trigger, so frame.scale may be
-			// stale). One retry only — looping can livelock a live resize; if still
-			// outdated, request another frame since nothing else reschedules on-demand.
-			if ws.frameStarted && a.renderer.endFrameForSurface(ws) {
-				ws.prepareLazyAcquire()
-				frame.onDraw(newContextForSurface(a.renderer, ws, ws.platWindow.ScaleFactor()))
-				if ws.frameStarted && a.renderer.endFrameForSurface(ws) {
-					a.RequestRedraw()
-				}
-			}
+		// beginFrame can fail (outdated / not yet configured). Demand-driven mode
+		// already consumed the invalidation — schedule another frame.
+		if !ws.frameStarted {
+			a.RequestRedraw()
 			ws.resetLazyState()
 			a.renderer.currentSurface = nil
+			continue
 		}
 
-		// Poll submissions once after all windows are presented.
-		a.renderer.pollSubmissions()
-	})
+		// On outdated, present() reconfigured the surface; re-render once at the
+		// live scale (a DPI change is an outdated trigger, so frame.scale may be
+		// stale). One retry only — looping can livelock a live resize; if still
+		// outdated, request another frame since nothing else reschedules on-demand.
+		if ws.frameStarted && a.renderer.endFrameForSurface(ws) {
+			ws.prepareLazyAcquire()
+			frame.onDraw(newContextForSurface(a.renderer, ws, ws.platWindow.ScaleFactor()))
+			if ws.frameStarted && a.renderer.endFrameForSurface(ws) {
+				a.RequestRedraw()
+			}
+		}
+		ws.resetLazyState()
+		a.renderer.currentSurface = nil
+	}
+
+	// Poll submissions once after all windows are presented.
+	a.renderer.pollSubmissions()
 }
 
 // modalFrameTick executes one update+render cycle during the Win32 modal
@@ -1045,7 +1150,9 @@ func (a *App) frameCallbackReady() bool {
 func (a *App) RequestRedraw() {
 	if a.invalidator != nil {
 		a.invalidator.Invalidate()
+		return
 	}
+	a.pendingRedraw.Store(true)
 }
 
 // StartAnimation signals that an animation is starting.

--- a/app_coverage_test.go
+++ b/app_coverage_test.go
@@ -1,0 +1,300 @@
+package gogpu
+
+import (
+	"testing"
+
+	"github.com/gogpu/gogpu/internal/platform"
+)
+
+// mockWindowWithSizeMove wraps mockWindow and allows InSizeMove() to return true.
+type mockWindowWithSizeMove struct {
+	mockWindow
+	inSizeMove bool
+}
+
+func (m *mockWindowWithSizeMove) InSizeMove() bool { return m.inSizeMove }
+
+// mockLiveResizePhaserWindow wraps mockWindow and implements platform.LiveResizePhaser.
+type mockLiveResizePhaserWindow struct {
+	mockWindow
+	startHook func()
+	endHook   func()
+}
+
+func (m *mockLiveResizePhaserWindow) SetLiveResizePhaseHooks(start, end func()) {
+	m.startHook = start
+	m.endHook = end
+}
+
+// mockManagerWithWindow replaces CreateWindow to return a specific platform window.
+type mockManagerWithWindow struct {
+	mockManager
+	win platform.PlatformWindow
+}
+
+func (m *mockManagerWithWindow) CreateWindow(_ platform.Config) (platform.PlatformWindow, error) {
+	return m.win, nil
+}
+
+// singleEventManager returns one event from PollEvents and then EventNone.
+type singleEventManager struct {
+	mockManager
+	event platform.Event
+	sent  bool
+}
+
+func (m *singleEventManager) PollEvents() platform.Event {
+	if !m.sent {
+		m.sent = true
+		return m.event
+	}
+	return platform.Event{}
+}
+
+// mockRenderLoopResizing returns ok=true from ConsumePendingResize.
+type mockRenderLoopResizing struct {
+	mockRenderLoop
+	w, h uint32
+}
+
+func (m *mockRenderLoopResizing) ConsumePendingResize() (uint32, uint32, bool) {
+	return m.w, m.h, true
+}
+
+// =============================================================================
+// App.InSizeMove
+// =============================================================================
+
+func TestAppInSizeMove_NilPlatWindow(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	if app.InSizeMove() {
+		t.Error("InSizeMove() should return false when platWindow is nil")
+	}
+}
+
+func TestAppInSizeMove_ReturnsFalse(t *testing.T) {
+	app := &App{platWindow: &mockWindowWithSizeMove{inSizeMove: false}}
+	if app.InSizeMove() {
+		t.Error("InSizeMove() should return false when platform reports false")
+	}
+}
+
+func TestAppInSizeMove_ReturnsTrue(t *testing.T) {
+	app := &App{platWindow: &mockWindowWithSizeMove{inSizeMove: true}}
+	if !app.InSizeMove() {
+		t.Error("InSizeMove() should return true when platform reports true")
+	}
+}
+
+// =============================================================================
+// processEventsMultiThread — InSizeMove guard
+// =============================================================================
+
+func TestProcessEventsMultiThread_InSizeMoveBlocksResize(t *testing.T) {
+	// A resize event that would normally trigger onResize.
+	mgr := &singleEventManager{
+		event: platform.Event{
+			Type:     platform.EventResize,
+			WindowID: 0, // primary window (WindowID 0 is always primary)
+			Width:    800, Height: 600,
+			PhysicalWidth: 1600, PhysicalHeight: 1200,
+		},
+	}
+
+	app := &App{
+		manager:    mgr,
+		renderLoop: &mockRenderLoop{},
+		platWindow: &mockWindowWithSizeMove{inSizeMove: true},
+	}
+
+	var resizeCalled bool
+	app.onResize = func(w, h int) { resizeCalled = true }
+
+	app.processEventsMultiThread()
+
+	if resizeCalled {
+		t.Error("onResize must not be called while InSizeMove() returns true")
+	}
+}
+
+func TestProcessEventsMultiThread_InSizeMoveAllowsResize(t *testing.T) {
+	mgr := &singleEventManager{
+		event: platform.Event{
+			Type:     platform.EventResize,
+			WindowID: 0,
+			Width:    800, Height: 600,
+			PhysicalWidth: 1600, PhysicalHeight: 1200,
+		},
+	}
+	invalidateCalled := false
+	app := &App{
+		manager:     mgr,
+		renderLoop:  &mockRenderLoop{},
+		platWindow:  &mockWindowWithSizeMove{inSizeMove: false},
+		invalidator: newInvalidator(func() { invalidateCalled = true }),
+	}
+
+	var resizeW, resizeH int
+	app.onResize = func(w, h int) { resizeW, resizeH = w, h }
+
+	app.processEventsMultiThread()
+
+	if resizeW != 800 || resizeH != 600 {
+		t.Errorf("onResize got (%d,%d), want (800,600)", resizeW, resizeH)
+	}
+	if !invalidateCalled {
+		t.Error("RequestRedraw should have been called after resize")
+	}
+}
+
+// =============================================================================
+// initPlatform — LiveResizePhaser hooks
+// =============================================================================
+
+func TestInitPlatform_LiveResizePhaserHooks(t *testing.T) {
+	mockWin := &mockLiveResizePhaserWindow{}
+
+	old := newPlatformManagerFn
+	newPlatformManagerFn = func() platform.PlatformManager {
+		return &mockManagerWithWindow{win: mockWin}
+	}
+	defer func() { newPlatformManagerFn = old }()
+
+	app := NewApp(DefaultConfig())
+	platWin, err := app.initPlatform()
+	if err != nil {
+		t.Fatalf("initPlatform: %v", err)
+	}
+	defer platWin.Destroy()
+
+	if mockWin.startHook == nil || mockWin.endHook == nil {
+		t.Skip("window did not implement LiveResizePhaser — hooks not registered")
+	}
+
+	// Case 1: renderLoop == nil → both hooks return early.
+	mockWin.startHook()
+	mockWin.endHook()
+
+	// Case 2: renderLoop set, renderer == nil → both hooks return early.
+	app.renderLoop = &mockRenderLoop{}
+	mockWin.startHook()
+	mockWin.endHook()
+
+	// Case 3: renderLoop + renderer set, primary == nil → RunOnRenderThread called
+	// but inner setTransactionPresent guard prevents GPU access.
+	app.renderer = &Renderer{}
+	mockWin.startHook()
+	mockWin.endHook()
+
+	// Case 4: primary non-nil (surface nil) → setTransactionPresent is a no-op
+	// (ws.surface == nil early-return).
+	app.renderer.primary = &RenderTarget{}
+	mockWin.startHook()
+	mockWin.endHook()
+}
+
+// =============================================================================
+// renderFrameGPU — targeted paths without GPU
+// =============================================================================
+
+// TestRenderFrameGPU_NilSurfaces exercises the ws==nil continue path.
+func TestRenderFrameGPU_NilSurfaces(t *testing.T) {
+	app := &App{
+		renderLoop: &mockRenderLoop{},
+		renderer:   &Renderer{},
+		platWindow: nil,
+	}
+	frames := []windowFrame{
+		{window: &Window{surface: nil}, onDraw: func(*Context) {}, scale: 1.0},
+		{window: &Window{surface: nil}, onDraw: func(*Context) {}, scale: 1.0},
+	}
+	app.renderFrameGPU(frames)
+}
+
+// TestRenderFrameGPU_UnconfiguredSurface exercises ws!=nil but CanRender()==false
+// with no platWindow set on the RenderTarget.
+func TestRenderFrameGPU_UnconfiguredSurface(t *testing.T) {
+	ws := &RenderTarget{} // CanRender()==false, platWindow==nil
+
+	app := &App{
+		renderLoop: &mockRenderLoop{},
+		renderer:   &Renderer{},
+		platWindow: nil,
+	}
+	frames := []windowFrame{
+		{window: &Window{surface: ws}, onDraw: func(*Context) {}, scale: 1.0},
+	}
+	app.renderFrameGPU(frames)
+
+	// The frame had no GPU work, so RequestRedraw must have been queued.
+	if !app.pendingRedraw.Load() {
+		t.Error("renderFrameGPU should queue a redraw when frameStarted==false")
+	}
+}
+
+// TestRenderFrameGPU_UnconfiguredSurfaceWithWindow exercises the !CanRender &&
+// platWindow!=nil path, where PhysicalSize()==(0,0) so ws.resize is skipped.
+func TestRenderFrameGPU_UnconfiguredSurfaceWithWindow(t *testing.T) {
+	ws := &RenderTarget{
+		platWindow: &mockWindow{width: 0, height: 0},
+	}
+
+	app := &App{
+		renderLoop: &mockRenderLoop{},
+		renderer:   &Renderer{},
+		platWindow: nil,
+	}
+	frames := []windowFrame{
+		{window: &Window{surface: ws}, onDraw: func(*Context) {}, scale: 1.0},
+	}
+	app.renderFrameGPU(frames)
+}
+
+// TestRenderFrameGPU_PendingResizeNoPrimary exercises ConsumePendingResize
+// returning ok=true when renderer.primary is nil (Resize skipped).
+func TestRenderFrameGPU_PendingResizeNoPrimary(t *testing.T) {
+	app := &App{
+		renderLoop: &mockRenderLoopResizing{w: 100, h: 200},
+		renderer:   &Renderer{primary: nil},
+		platWindow: nil,
+	}
+	app.renderFrameGPU(nil)
+}
+
+// TestRenderFrameGPU_PlatWindowSyncSkipsResizeAtZeroSize exercises the
+// platWindow sync block (platWindow!=nil, primary!=nil) when PhysicalSize==(0,0),
+// so the inner Resize call is skipped.
+func TestRenderFrameGPU_PlatWindowSyncSkipsResizeAtZeroSize(t *testing.T) {
+	primary := &RenderTarget{}
+	app := &App{
+		renderLoop: &mockRenderLoop{},
+		renderer:   &Renderer{primary: primary},
+		platWindow: &mockWindow{width: 0, height: 0},
+	}
+	app.renderFrameGPU(nil)
+}
+
+// =============================================================================
+// renderFrameMultiThread — exercises the runInFramePool wrapper.
+// On Linux CI (!darwin) this also covers framepool_other.go:runInFramePool.
+// =============================================================================
+
+func TestRenderFrameMultiThread_InvokesFramePool(t *testing.T) {
+	app := &App{
+		renderLoop:    &mockRenderLoop{},
+		renderer:      &Renderer{},
+		windowManager: newWindowManager(),
+	}
+
+	id := app.windowManager.allocate()
+	w := &Window{
+		id:         id,
+		visible:    true,
+		platWindow: &mockWindow{},
+		onDraw:     func(*Context) {}, // no GPU work
+		surface:    nil,               // ws==nil → continue in renderFrameGPU
+	}
+	app.windowManager.add(w)
+
+	app.renderFrameMultiThread()
+}

--- a/app_run_coverage_test.go
+++ b/app_run_coverage_test.go
@@ -1,0 +1,402 @@
+package gogpu
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gogpu/gogpu/input"
+	"github.com/gogpu/gogpu/internal/platform"
+	"github.com/gogpu/gpucontext"
+)
+
+// mockFrameGaterWindow wraps mockWindow and implements platform.FrameGater.
+type mockFrameGaterWindow struct {
+	mockWindow
+	ready bool
+}
+
+func (m *mockFrameGaterWindow) FrameCallbackReady() bool { return m.ready }
+
+// =============================================================================
+// SetQuitOnLastWindowClosed
+// =============================================================================
+
+func TestApp_SetQuitOnLastWindowClosed(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	ret := app.SetQuitOnLastWindowClosed(false)
+	if ret != app {
+		t.Error("SetQuitOnLastWindowClosed should return the App for chaining")
+	}
+	if app.quitOnLastWindowClosed {
+		t.Error("quitOnLastWindowClosed should be false after SetQuitOnLastWindowClosed(false)")
+	}
+}
+
+// =============================================================================
+// startRunLoop
+// =============================================================================
+
+func TestApp_StartRunLoop(t *testing.T) {
+	var wokeUp bool
+	app := &App{
+		manager: &mockManager{},
+	}
+	app.invalidator = newInvalidator(func() { wokeUp = true })
+	_ = wokeUp
+
+	var surfaceAvailableCalled bool
+	app.onSurfaceAvailable = func() { surfaceAvailableCalled = true }
+	app.pendingRedraw.Store(true)
+
+	app.startRunLoop()
+
+	if !app.running {
+		t.Error("startRunLoop should set running=true")
+	}
+	if app.lifecycle != AppRunning {
+		t.Errorf("lifecycle = %v, want AppRunning", app.lifecycle)
+	}
+	if !surfaceAvailableCalled {
+		t.Error("onSurfaceAvailable should be called")
+	}
+	if app.animations == nil {
+		t.Error("animations should be initialized")
+	}
+	if app.pendingRedraw.Load() {
+		t.Error("pendingRedraw should be consumed into the invalidator")
+	}
+}
+
+func TestApp_StartRunLoop_NoPendingRedrawNoCallback(t *testing.T) {
+	app := &App{manager: &mockManager{}}
+	app.invalidator = newInvalidator(func() {})
+
+	app.startRunLoop()
+
+	if !app.running {
+		t.Error("startRunLoop should set running=true")
+	}
+}
+
+// =============================================================================
+// runFrame
+// =============================================================================
+
+func TestApp_RunFrame_IdleThenResizeInvalidates(t *testing.T) {
+	mgr := &singleEventManager{
+		event: platform.Event{
+			Type:           platform.EventResize,
+			WindowID:       0,
+			Width:          800,
+			Height:         600,
+			PhysicalWidth:  1600,
+			PhysicalHeight: 1200,
+		},
+	}
+	app := &App{
+		manager:       mgr,
+		renderLoop:    &mockRenderLoop{},
+		platWindow:    &mockWindow{},
+		windowManager: newWindowManager(),
+		animations:    &AnimationController{},
+		lastFrame:     time.Now(),
+	}
+	app.invalidator = newInvalidator(func() {})
+
+	app.runFrame()
+}
+
+func TestApp_RunFrame_ContinuousWithUpdateAndInput(t *testing.T) {
+	app := &App{
+		manager:       &mockManager{},
+		renderLoop:    &mockRenderLoop{},
+		windowManager: newWindowManager(),
+		animations:    &AnimationController{},
+		inputState:    input.New(),
+		config:        Config{ContinuousRender: true},
+	}
+	app.invalidator = newInvalidator(func() {})
+
+	var updateCalled bool
+	app.onUpdate = func(dt float64) {
+		updateCalled = true
+		app.RequestRedraw()
+	}
+
+	app.runFrame()
+
+	if !updateCalled {
+		t.Error("onUpdate should have been called")
+	}
+}
+
+// =============================================================================
+// registerPrimaryWindow
+// =============================================================================
+
+func TestApp_RegisterPrimaryWindow(t *testing.T) {
+	win := &mockWindow{windowID: 42}
+	app := &App{
+		config:   DefaultConfig(),
+		renderer: &Renderer{},
+	}
+
+	app.registerPrimaryWindow(win)
+
+	if app.windowManager == nil {
+		t.Fatal("windowManager should be initialized")
+	}
+	if app.primaryWindow == nil {
+		t.Fatal("primaryWindow should be set")
+	}
+	if app.primaryPlatformID != win.ID() {
+		t.Errorf("primaryPlatformID = %v, want %v", app.primaryPlatformID, win.ID())
+	}
+	if !app.primaryWindow.visible {
+		t.Error("primaryWindow should be visible")
+	}
+}
+
+// =============================================================================
+// modalFrameTick
+// =============================================================================
+
+func TestApp_ModalFrameTick_NilPlatWindowReturnsEarly(t *testing.T) {
+	app := &App{
+		lastFrame: time.Now(),
+	}
+	var updateCalled bool
+	app.onUpdate = func(dt float64) { updateCalled = true }
+
+	app.modalFrameTick()
+
+	if !updateCalled {
+		t.Error("onUpdate should run before the nil-platWindow early return")
+	}
+}
+
+func TestApp_ModalFrameTick_FullCycle(t *testing.T) {
+	app := &App{
+		lastFrame:     time.Now(),
+		platWindow:    &mockWindow{width: 100, height: 100},
+		renderLoop:    &mockRenderLoop{},
+		renderer:      &Renderer{},
+		windowManager: newWindowManager(),
+		inputState:    input.New(),
+	}
+
+	app.modalFrameTick()
+}
+
+// =============================================================================
+// resizeSecondaryWindowsDuringModal
+// =============================================================================
+
+func TestApp_ResizeSecondaryWindowsDuringModal_NilGuards(t *testing.T) {
+	app := &App{}
+	app.resizeSecondaryWindowsDuringModal() // windowManager and renderer nil
+
+	app.windowManager = newWindowManager()
+	app.resizeSecondaryWindowsDuringModal() // renderer still nil
+}
+
+func TestApp_ResizeSecondaryWindowsDuringModal_NoEligibleWindows(t *testing.T) {
+	app := &App{
+		windowManager: newWindowManager(),
+		renderer:      &Renderer{},
+		renderLoop:    &mockRenderLoop{},
+	}
+	id := app.windowManager.allocate()
+	// Zero physical size -- excluded from the resize set.
+	w := &Window{id: id, platWindow: &mockWindow{width: 0, height: 0}, surface: &RenderTarget{}}
+	app.windowManager.add(w)
+	app.primaryWindow = w
+
+	app.resizeSecondaryWindowsDuringModal()
+}
+
+// =============================================================================
+// frameCallbackReady
+// =============================================================================
+
+func TestApp_FrameCallbackReady_NoFrameGater(t *testing.T) {
+	app := &App{platWindow: &mockWindow{}}
+	if !app.frameCallbackReady() {
+		t.Error("frameCallbackReady should default to true when platform lacks FrameGater")
+	}
+}
+
+func TestApp_FrameCallbackReady_NilPlatWindow(t *testing.T) {
+	app := &App{}
+	if !app.frameCallbackReady() {
+		t.Error("frameCallbackReady should default to true when platWindow is nil")
+	}
+}
+
+func TestApp_FrameCallbackReady_FrameGater(t *testing.T) {
+	app := &App{platWindow: &mockFrameGaterWindow{ready: false}}
+	if app.frameCallbackReady() {
+		t.Error("frameCallbackReady should reflect FrameGater's result")
+	}
+}
+
+// =============================================================================
+// SetAppName
+// =============================================================================
+
+func TestApp_SetAppName_NilManager(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	app.SetAppName("MyApp")
+	if app.config.AppName != "MyApp" {
+		t.Errorf("config.AppName = %q, want MyApp", app.config.AppName)
+	}
+}
+
+func TestApp_SetAppName_WithManager(t *testing.T) {
+	app := &App{manager: &mockManager{}}
+	app.SetAppName("MyApp")
+	if app.config.AppName != "MyApp" {
+		t.Errorf("config.AppName = %q, want MyApp", app.config.AppName)
+	}
+}
+
+// =============================================================================
+// SetCursorMode / CursorMode
+// =============================================================================
+
+func TestApp_SetCursorMode_CursorMode(t *testing.T) {
+	app := &App{}
+	// Nil platWindow: no-op, default mode.
+	app.SetCursorMode(gpucontext.CursorModeLocked)
+	if app.CursorMode() != gpucontext.CursorModeNormal {
+		t.Error("CursorMode should default to Normal with nil platWindow")
+	}
+
+	app.platWindow = &mockWindow{}
+	app.SetCursorMode(gpucontext.CursorModeLocked)
+	_ = app.CursorMode()
+}
+
+// =============================================================================
+// SetFullscreen / IsFullscreen / ToggleFullscreen
+// =============================================================================
+
+func TestApp_Fullscreen_NilPlatWindow(t *testing.T) {
+	app := &App{}
+	app.SetFullscreen(true)
+	if app.IsFullscreen() {
+		t.Error("IsFullscreen should be false with nil platWindow")
+	}
+	app.ToggleFullscreen()
+}
+
+func TestApp_Fullscreen_WithPlatWindow(t *testing.T) {
+	win := &mockWindow{}
+	app := &App{platWindow: win}
+
+	app.SetFullscreen(true)
+	if !app.IsFullscreen() {
+		t.Error("IsFullscreen should be true after SetFullscreen(true)")
+	}
+
+	app.ToggleFullscreen()
+	if app.IsFullscreen() {
+		t.Error("ToggleFullscreen should flip fullscreen state to false")
+	}
+}
+
+// =============================================================================
+// GetSystemMenu
+// =============================================================================
+
+func TestApp_GetSystemMenu_NilManager(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	handle := app.GetSystemMenu(SystemMenuApplication)
+	if handle == nil {
+		t.Fatal("GetSystemMenu should return a handle even before Run()")
+	}
+	if app.pendingSystemMenuItems == nil {
+		t.Error("pendingSystemMenuItems should be initialized")
+	}
+}
+
+func TestApp_GetSystemMenu_WithMenuManager(t *testing.T) {
+	app := &App{manager: &mockMenuManager{}}
+	handle := app.GetSystemMenu(SystemMenuApplication)
+	if handle == nil {
+		t.Fatal("GetSystemMenu should return a non-nil handle")
+	}
+}
+
+func TestApp_GetSystemMenu_ManagerWithoutMenuSupport(t *testing.T) {
+	app := &App{manager: &mockManager{}}
+	handle := app.GetSystemMenu(SystemMenuApplication)
+	if handle != nil {
+		t.Error("GetSystemMenu should return nil when the manager lacks PlatMenuManager")
+	}
+}
+
+// =============================================================================
+// SetCustomMenu
+// =============================================================================
+
+func TestApp_SetCustomMenu_UpdatesExistingEntry(t *testing.T) {
+	app := &App{manager: &mockMenuManager{}}
+	first := &Menu{Title: "Edit"}
+	second := &Menu{Title: "Edit2"}
+
+	app.SetCustomMenu("edit", first)
+	app.SetCustomMenu("edit", second)
+
+	if len(app.customMenus) != 1 {
+		t.Fatalf("expected 1 custom menu entry, got %d", len(app.customMenus))
+	}
+	if app.customMenus[0].menu != second {
+		t.Error("SetCustomMenu should update the existing entry's menu")
+	}
+}
+
+// =============================================================================
+// DeviceProvider
+// =============================================================================
+
+func TestApp_DeviceProvider_WithRenderer(t *testing.T) {
+	app := &App{renderer: &Renderer{}}
+	provider := app.DeviceProvider()
+	if provider == nil {
+		t.Error("DeviceProvider should be non-nil once the renderer is set")
+	}
+}
+
+// =============================================================================
+// OnDraw / OnResize sync primary window
+// =============================================================================
+
+func TestApp_OnDraw_OnResize_SyncsPrimaryWindow(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	app.primaryWindow = &Window{}
+
+	drawFn := func(*Context) {}
+	resizeFn := func(int, int) {}
+	app.OnDraw(drawFn)
+	app.OnResize(resizeFn)
+
+	if app.primaryWindow.onDraw == nil {
+		t.Error("primaryWindow.onDraw should be synced by OnDraw")
+	}
+	if app.primaryWindow.onResize == nil {
+		t.Error("primaryWindow.onResize should be synced by OnResize")
+	}
+}
+
+// =============================================================================
+// UntrackResource
+// =============================================================================
+
+func TestApp_UntrackResource_RemovesTrackedResource(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	closer := newMockCloser("res")
+	app.TrackResource(closer)
+
+	app.UntrackResource(closer)
+}

--- a/context_texture_test.go
+++ b/context_texture_test.go
@@ -152,8 +152,9 @@ func TestDrawTextureExValidTexture(t *testing.T) {
 		height:  64,
 	}
 
-	// Should return nil when no frame is in progress (currentView == nil).
-	// This is the correct behavior - it silently succeeds without drawing.
+	// Should return an error when no frame is in progress (currentView == nil):
+	// callers rely on the error to reschedule the frame (RequestRedraw) instead
+	// of silently dropping the draw.
 	err := ctx.DrawTextureEx(tex, DrawTextureOptions{
 		X:      100,
 		Y:      200,
@@ -162,8 +163,8 @@ func TestDrawTextureExValidTexture(t *testing.T) {
 		Alpha:  0.5,
 	})
 
-	if err != nil {
-		t.Errorf("DrawTextureEx(valid) = %v, want nil", err)
+	if err == nil {
+		t.Error("DrawTextureEx(valid, no frame) = nil, want error")
 	}
 }
 
@@ -185,9 +186,9 @@ func TestDrawTextureExDefaultValues(t *testing.T) {
 		// Alpha is 0 - should default to 1.0
 	})
 
-	// Should return nil when no frame is in progress
-	if err != nil {
-		t.Errorf("DrawTextureEx(defaults) = %v, want nil", err)
+	// Defaults must pass validation; the only error is the missing surface frame.
+	if err == nil {
+		t.Error("DrawTextureEx(defaults, no frame) = nil, want error")
 	}
 }
 
@@ -261,8 +262,9 @@ func TestDrawTextureOptions(t *testing.T) {
 
 func TestDrawTextureExAlphaClamping(t *testing.T) {
 	// This test verifies the alpha clamping logic conceptually.
-	// All alpha values (including out-of-range) should pass validation and
-	// return nil when no frame is in progress.
+	// All alpha values (including out-of-range) pass validation; the draw then
+	// fails with a missing-surface-frame error (no frame in progress), which
+	// proves clamping did not reject the value.
 	ctx := &Context{renderer: newTestRenderer(800, 600)}
 
 	tex := &Texture{
@@ -284,9 +286,9 @@ func TestDrawTextureExAlphaClamping(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ctx.DrawTextureEx(tex, DrawTextureOptions{Alpha: tt.alpha})
-			// All should pass validation and return nil (no frame in progress)
-			if err != nil {
-				t.Errorf("DrawTextureEx(alpha=%f) = %v, want nil", tt.alpha, err)
+			// Alpha never fails validation; the only error is the missing frame.
+			if err == nil {
+				t.Errorf("DrawTextureEx(alpha=%f, no frame) = nil, want error", tt.alpha)
 			}
 		})
 	}

--- a/framepool_darwin.go
+++ b/framepool_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package gogpu
+
+import "github.com/gogpu/gogpu/internal/platform/darwin"
+
+func runInFramePool(fn func()) {
+	darwin.RunInFramePool(fn)
+}

--- a/framepool_other.go
+++ b/framepool_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package gogpu
+
+func runInFramePool(fn func()) {
+	fn()
+}

--- a/internal/platform/darwin/framepool.go
+++ b/internal/platform/darwin/framepool.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package darwin
+
+// RunInFramePool executes fn inside a fresh NSAutoreleasePool.
+//
+// Use on the render thread once per frame. Metal drawables and transient ObjC
+// objects are autoreleased; without per-frame draining, IOSurface memory grows
+// during live window resize (Apple MTLBestPracticesGuide, imgui #2910).
+func RunInFramePool(fn func()) {
+	initSelectors()
+	initClasses()
+
+	pool := classes.NSAutoreleasePool.Send(selectors.new)
+	defer pool.Send(selectors.drain)
+	fn()
+}

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -60,6 +60,12 @@ type Window struct {
 	// Used by the app layer to render a frame while the event loop is blocked.
 	// Read/written under mu.
 	liveResizeHook func()
+
+	// liveResizeStartHook / liveResizeEndHook fire on windowWillStartLiveResize: /
+	// windowDidEndLiveResize:. Used by the app layer to toggle Metal
+	// transaction-based present around the drag. Read/written under mu.
+	liveResizeStartHook func()
+	liveResizeEndHook   func()
 }
 
 // NSID returns the underlying NSWindow object ID.
@@ -524,6 +530,12 @@ func (w *Window) InLiveResize() bool {
 // Called by the windowWillStartLiveResize: NSWindowDelegate method.
 func (w *Window) StartLiveResize() {
 	w.inLiveResize.Store(true)
+	w.mu.Lock()
+	fn := w.liveResizeStartHook
+	w.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
 }
 
 // EndLiveResize marks the end of a live resize operation and wakes the event
@@ -531,7 +543,26 @@ func (w *Window) StartLiveResize() {
 // Called by the windowDidEndLiveResize: NSWindowDelegate method.
 func (w *Window) EndLiveResize() {
 	w.inLiveResize.Store(false)
+	w.mu.Lock()
+	fn := w.liveResizeEndHook
+	w.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
+	// Live resize can break the responder chain; restore keyboard focus.
+	if !w.nsWindow.IsNil() && !w.contentView.IsNil() {
+		w.nsWindow.SendPtr(selectors.makeFirstResponder, w.contentView.Ptr())
+	}
 	WakeEventLoop()
+}
+
+// SetLiveResizePhaseHooks installs callbacks fired at the start and end of a
+// live resize drag (windowWillStartLiveResize: / windowDidEndLiveResize:).
+func (w *Window) SetLiveResizePhaseHooks(start, end func()) {
+	w.mu.Lock()
+	w.liveResizeStartHook = start
+	w.liveResizeEndHook = end
+	w.mu.Unlock()
 }
 
 // SetLiveResizeHook installs a callback that fires on every windowDidResize:

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -343,6 +343,15 @@ type LiveResizeRenderer interface {
 	SetLiveResizeHook(fn func())
 }
 
+// LiveResizePhaser is an optional interface for platform windows that report
+// the start and end of a live resize drag. The app layer uses these to toggle
+// Metal transaction-based present (macOS): enabled during the drag so the
+// drawable swap commits atomically with the resize CA transaction, disabled
+// afterwards so normal rendering presents without main-thread coupling.
+type LiveResizePhaser interface {
+	SetLiveResizePhaseHooks(start, end func())
+}
+
 // PlatScaleProvider is an optional interface for platforms that can report the
 // primary display DPI scale factor before a window is created. Callers use a
 // type assertion: if sp, ok := manager.(PlatScaleProvider); ok { ... }

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -347,6 +347,14 @@ func (dw *darwinPlatformWindow) SetLiveResizeHook(fn func()) {
 	}
 }
 
+// SetLiveResizePhaseHooks implements platform.LiveResizePhaser for macOS.
+// start fires on windowWillStartLiveResize:, end on windowDidEndLiveResize:.
+func (dw *darwinPlatformWindow) SetLiveResizePhaseHooks(start, end func()) {
+	if dw.window != nil {
+		dw.window.SetLiveResizePhaseHooks(start, end)
+	}
+}
+
 // SetHeaderAlignment implements platform.HeaderAligner for macOS.
 func (dw *darwinPlatformWindow) SetHeaderAlignment(alignment int) {
 	if dw.window != nil {
@@ -559,7 +567,7 @@ func (w *darwinWindow) pollEvents(app *darwin.Application) Event {
 	//
 	// Physical-size tracking (physW/physH) catches Retina↔1× transitions
 	// where logical dims are unchanged but the framebuffer resolution changes.
-	if w.window != nil {
+	if w.window != nil && !w.window.InLiveResize() {
 		// Drain the screen-change signal from windowDidChangeScreen:.
 		// The signal already woke WaitEvents; draining resets the channel
 		// for the next display transition.
@@ -929,6 +937,11 @@ func (w *darwinWindow) queueEvent(event Event) {
 // Must be called with w.eventMu held.
 func (w *darwinWindow) checkResize() {
 	if w.window == nil {
+		return
+	}
+	// During live resize, defer GPU surface reconfiguration until the user
+	// releases the mouse (windowDidEndLiveResize → WakeEventLoop → here).
+	if w.window.InLiveResize() {
 		return
 	}
 

--- a/invalidator.go
+++ b/invalidator.go
@@ -19,15 +19,15 @@ func newInvalidator(wakeup func()) *Invalidator {
 
 // Invalidate requests a redraw. Safe to call from any goroutine.
 // Multiple concurrent calls coalesce into a single redraw.
+// WakeUp is always called so the main thread unblocks from WaitEvents
+// even when the signal was already pending (PTY output during idle).
 func (inv *Invalidator) Invalidate() {
 	select {
 	case inv.ch <- struct{}{}:
-		// First signal — wake the event loop
-		if inv.wakeup != nil {
-			inv.wakeup()
-		}
 	default:
-		// Already signaled — coalesced
+	}
+	if inv.wakeup != nil {
+		inv.wakeup()
 	}
 }
 

--- a/invalidator_test.go
+++ b/invalidator_test.go
@@ -74,13 +74,12 @@ func TestInvalidator_WakeupNotCalledOnCoalesced(t *testing.T) {
 		called.Add(1)
 	})
 
-	// First Invalidate — wakeup should fire
+	// Both Invalidate calls wake the event loop even when signals coalesce.
 	inv.Invalidate()
-	// Second Invalidate — channel full, wakeup should NOT fire
 	inv.Invalidate()
 
-	if got := called.Load(); got != 1 {
-		t.Errorf("expected wakeup called exactly 1 time, got %d", got)
+	if got := called.Load(); got != 2 {
+		t.Errorf("expected wakeup called 2 times, got %d", got)
 	}
 }
 
@@ -125,10 +124,10 @@ func TestInvalidator_ConcurrentAccess(t *testing.T) {
 		t.Error("expected second Consume to return false — all signals should coalesce")
 	}
 
-	// Wakeup should have been called at least once (first signal) but at most once
-	// (channel blocks subsequent signals from reaching the wakeup branch).
-	if got := wakeups.Load(); got != 1 {
-		t.Errorf("expected wakeup called exactly 1 time, got %d", got)
+	// Wakeup is called on every Invalidate so WaitEvents unblocks even when
+	// the channel signal was already pending.
+	if got := wakeups.Load(); got != goroutines {
+		t.Errorf("expected wakeup called %d times, got %d", goroutines, got)
 	}
 }
 

--- a/renderer.go
+++ b/renderer.go
@@ -532,12 +532,6 @@ func (r *Renderer) EndFrame() {
 // Returns true if present() reconfigured an outdated surface (see present).
 func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	ws.flushClear(r.device, r)
-	if ws.hasGPUWork {
-		// Metal presents via a separate command buffer (transaction path). Ensure
-		// draw/submit work finishes before present or the window stays blank until
-		// a later resize triggers WaitIdle during surface reconfigure.
-		r.WaitForGPU()
-	}
 	// Request frame callback BEFORE present (winit pre_present_notify pattern).
 	// Wayland spec: "The frame request will take effect on the next commit."
 	// The present's internal wl_surface.commit activates it atomically.

--- a/renderer.go
+++ b/renderer.go
@@ -552,6 +552,9 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 // pollSubmissions performs non-blocking submission tracking: frees GPU resources
 // for completed submissions. Called once per frame after all windows are presented.
 func (r *Renderer) pollSubmissions() {
+	if r.device == nil {
+		return
+	}
 	completedIdx := r.device.Queue().Poll()
 	r.tracker.triage(completedIdx, r.device)
 }

--- a/renderer.go
+++ b/renderer.go
@@ -444,12 +444,12 @@ func (ws *RenderTarget) beginFrame(platWin platform.PlatformWindow, device *wgpu
 
 	// Before acquiring surface texture, let platform update surface state
 	// (e.g., CAMetalLayer.contentsScale on macOS for HiDPI/multi-monitor).
+	// Reconfigure when the physical surface dimensions changed — including
+	// during live resize (Rio pattern): the surface must match the window
+	// every tick so the presented frame is pixel-exact, and the Metal layer's
+	// blocking nextDrawable + transaction present keep pool churn bounded.
 	if platWin != nil {
 		result := platWin.PrepareFrame()
-		// Reconfigure when the physical surface dimensions changed — covers both
-		// Retina scale transitions (ScaleChanged) and live resize (size mismatch).
-		// Acting here, before nextDrawable, eliminates the 1-frame blank square
-		// that appears when CAMetalLayer grows before the wgpu surface catches up.
 		if result.PhysicalWidth > 0 && result.PhysicalHeight > 0 &&
 			(result.PhysicalWidth != ws.width || result.PhysicalHeight != ws.height) {
 			ws.width = result.PhysicalWidth
@@ -532,6 +532,12 @@ func (r *Renderer) EndFrame() {
 // Returns true if present() reconfigured an outdated surface (see present).
 func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	ws.flushClear(r.device, r)
+	if ws.hasGPUWork {
+		// Metal presents via a separate command buffer (transaction path). Ensure
+		// draw/submit work finishes before present or the window stays blank until
+		// a later resize triggers WaitIdle during surface reconfigure.
+		r.WaitForGPU()
+	}
 	// Request frame callback BEFORE present (winit pre_present_notify pattern).
 	// Wayland spec: "The frame request will take effect on the next commit."
 	// The present's internal wl_surface.commit activates it atomically.
@@ -593,6 +599,20 @@ func (ws *RenderTarget) present() (reconfigured bool) {
 	return false
 }
 
+// setTransactionPresent toggles Core Animation transaction-based present on
+// Metal surfaces (no-op elsewhere). Enabled during macOS live resize so the
+// drawable swap commits atomically with the window-resize CA transaction —
+// eliminating both frame stretching and IOSurface drawable stockpiling.
+// Must be called on the render thread.
+func (ws *RenderTarget) setTransactionPresent(enabled bool) {
+	if ws.surface == nil {
+		return
+	}
+	if tp, ok := any(ws.surface).(interface{ SetPresentsWithTransaction(bool) }); ok {
+		tp.SetPresentsWithTransaction(enabled)
+	}
+}
+
 // prepareLazyAcquire resets per-frame state for deferred beginFrame.
 // The actual swapchain acquire happens on first draw call via ensureFrameStarted.
 // Uses ws.platWindow and ws.renderer.{device,adapter} — no parameters needed.
@@ -607,8 +627,22 @@ func (ws *RenderTarget) ensureFrameStarted() bool {
 	if ws.frameStarted {
 		return ws.currentView != nil
 	}
-	ws.frameStarted = true
-	return ws.beginFrame(ws.platWindow, ws.renderer.device, ws.renderer.adapter)
+	if ws.beginFrame(ws.platWindow, ws.renderer.device, ws.renderer.adapter) {
+		ws.frameStarted = true
+		return true
+	}
+	// Surface may not be configured yet (0×0 at init). Retry once after resize.
+	if !ws.CanRender() && ws.platWindow != nil {
+		pw, ph := ws.platWindow.PhysicalSize()
+		if pw > 0 && ph > 0 {
+			ws.resize(pw, ph, ws.renderer.device, ws.renderer.adapter)
+			if ws.beginFrame(ws.platWindow, ws.renderer.device, ws.renderer.adapter) {
+				ws.frameStarted = true
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // resetLazyState clears per-frame state after frame cycle.
@@ -1012,7 +1046,7 @@ func (r *Renderer) getOrCreateTexBindGroup(tex *Texture) (*wgpu.BindGroup, error
 func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error {
 	ws := r.activeSurface()
 	if !ws.ensureFrameStarted() {
-		return nil // No frame in progress
+		return fmt.Errorf("gogpu: surface frame not available")
 	}
 	ws.hasGPUWork = true
 

--- a/renderer_skip_present_test.go
+++ b/renderer_skip_present_test.go
@@ -70,8 +70,8 @@ func TestEnsureFrameStarted_NoSurface_ReturnsFalse(t *testing.T) {
 	if result {
 		t.Error("ensureFrameStarted should return false when surface not configured")
 	}
-	if !ws.frameStarted {
-		t.Error("frameStarted should be true after ensureFrameStarted (even if failed)")
+	if ws.frameStarted {
+		t.Error("frameStarted should stay false when beginFrame fails")
 	}
 }
 


### PR DESCRIPTION
**Summary:**

The previous live-resize hook called `ws.resize()` on every AppKit
`windowDidResize:` callback. On macOS at 60+ Hz drag rate, each call reached
`setDrawableSize:` in the Metal backend, allocating a new CAMetalLayer
IOSurface pool. Core Animation holds the last-presented drawable for ~16 ms
independently of any GPU idle wait, so pools accumulate faster than they are
released — observed peak: **4.43 GB** footprint during a 10-second drag.

**Changes:**

- **`app.go`**: hook no longer calls `ws.resize()`. Instead, `RequestResize`
  queues the physical dimensions for the render thread; swapchain reconfiguration
  happens once per render tick, not once per geometry event. The main thread
  blocks in `renderFrameMultiThread` until the render thread presents,
  satisfying AppKit's expectation for in-tick frame delivery.

- **`LiveResizePhaser`** (new platform interface): `windowWillStartLiveResize:`
  and `windowDidEndLiveResize:` delegates call registered Go hooks.
  `App.initWindow` uses these to toggle `presentsWithTransaction` on the Metal
  surface. Enabled only during the drag — outside that window the render
  goroutine operates on a non-main thread, so transaction-present would defer
  every frame until the next AppKit event (blank window).

- **`LiveResizeRenderer`** (new platform interface): `windowDidResize:` calls
  the registered hook. Checked via type assertion in `App.initWindow` — no
  impact on non-macOS builds.

- **`renderer.go`**: `setTransactionPresent` uses an interface assertion to
  reach `hal.Surface.SetPresentsWithTransaction(bool)` without Metal imports.

**Known limitation:** Zero-stretch *and* zero-leak simultaneously requires
`[drawable present]` dispatched from the main thread, enabling perpetual
`presentsWithTransaction=true`. The current architecture presents from the
render goroutine. `contentsGravity="topLeft"` (set in wgpu-local) eliminates
stretch artifacts; the small black margin during drag is the accepted trade-off.

**Testing:** `go test ./...` passes. Live-resize stress test (60-second drag):
peak footprint under 150 MB, no observable growth trend.
