### PR TITLE
docs: CHANGELOG + ROADMAP for v0.44.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.1] - 2026-07-08
+
+### Fixed
+
+- **macOS live resize IOSurface churn** (@lkmavi, #358) — per-frame `NSAutoreleasePool` drain (`RunInFramePool`) prevents multi-GB memory growth during window resize. Transaction-based present (`presentsWithTransaction`) toggled during drag so Core Animation releases superseded drawables immediately. Enterprise-validated: wgpu-rs, Flutter/Impeller, Skia, Gio all use the same patterns.
+- **macOS 0×0 initial surface** — `syncInitialSurfaceSize()` after Show() handles macOS reporting 0×0 PhysicalSize before first layout. Frames no longer skipped at zero size.
+- **`InSizeMove` guard restored** in `processEventsMultiThread` — resize events suppressed during modal resize (Windows), fixing regression from PR #352.
+- **Pre-Run() `RequestRedraw`** — `pendingRedraw atomic.Bool` stores redraw requests before the invalidator is initialized, consumed on `startRunLoop`.
+
+### Changed
+
+- **Run() refactor** — extracted `shutdown()`, `startRunLoop()`, `runFrame()`, `renderFrameGPU()`, `applyPendingMenus()`, `setupLiveResizeHook()`, `setupLiveResizePhaseHooks()`. Inline Run() reduced from 120+ to ~15 lines.
+
 ## [0.44.0] - 2026-07-08
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.44.0
+## Current State: v0.44.1
 
 ✅ **Production-ready** with full feature set:
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.
@@ -80,6 +80,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.44.1** | 2026-07-08 | **macOS live resize fix** (@lkmavi) — IOSurface churn eliminated via NSAutoreleasePool + transaction present. Run() refactor. Enterprise-validated (wgpu-rs, Flutter, Skia). |
 | **v0.44.0** | 2026-07-08 | **Multi-backend auto-selection** (#357) — Auto enumerates DX12+Vulkan+GLES, picks best GPU. Old GPUs without Vulkan get DX12/GLES instead of software. Rust wgpu pattern. |
 | **v0.43.4** | 2026-07-03 | **deps:** wgpu v0.30.9, goffi v0.5.6 — callback stack-move corruption fix (@tie, goffi#59) |
 | **v0.43.3** | 2026-07-01 | **Software backend fixes** — WM_PAINT EventExpose (#354), deps wgpu v0.30.8 (MSAA rejection, BGRA blending, dynamic offsets). Reported by @ChristianG1984 |


### PR DESCRIPTION
Release documentation for v0.44.1 (macOS live resize IOSurface fix, @lkmavi #358).