### PR TITLE
Fix Wayland fractional scaling

### DIFF
--- a/app.go
+++ b/app.go
@@ -19,6 +19,17 @@ type appRenderLoop interface {
 	ConsumePendingResize() (uint32, uint32, bool)
 }
 
+func physicalSizeUint32(width, height int) (uint32, uint32, bool) {
+	if width <= 0 || height <= 0 {
+		return 0, 0, false
+	}
+	maxUint32 := uint64(^uint32(0))
+	if uint64(width) > maxUint32 || uint64(height) > maxUint32 {
+		return 0, 0, false
+	}
+	return uint32(width), uint32(height), true
+}
+
 // App is the main application type.
 // It manages the window, rendering, and application lifecycle.
 //
@@ -612,8 +623,8 @@ func (a *App) setupLiveResizeHook(platWindow platform.PlatformWindow) {
 		// on every Resized event). onResize (user layout callback) still
 		// fires once after the drag via the normal event path.
 		physW, physH := platWindow.PhysicalSize()
-		if physW > 0 && physH > 0 {
-			a.renderLoop.RequestResize(uint32(physW), uint32(physH)) //nolint:gosec // G115: validated positive
+		if w, h, ok := physicalSizeUint32(physW, physH); ok {
+			a.renderLoop.RequestResize(w, h)
 		}
 		a.renderFrameMultiThread()
 	})
@@ -696,8 +707,8 @@ func (a *App) processEventsMultiThread() {
 	if lastResize != nil && a.platWindow != nil && !a.platWindow.InSizeMove() {
 		// Queue PHYSICAL size for render thread (GPU surface reconfiguration)
 		physW, physH := lastResize.PhysicalWidth, lastResize.PhysicalHeight
-		if physW > 0 && physH > 0 {
-			a.renderLoop.RequestResize(uint32(physW), uint32(physH)) //nolint:gosec // G115: validated positive
+		if w, h, ok := physicalSizeUint32(physW, physH); ok {
+			a.renderLoop.RequestResize(w, h)
 		}
 
 		// Call user callback with LOGICAL size (what user expects for layout)
@@ -1002,17 +1013,7 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 		if ws == nil {
 			continue
 		}
-
-		// initRenderer may leave the surface unconfigured when PhysicalSize was 0.
-		if !ws.CanRender() && ws.platWindow != nil {
-			pw, ph := ws.platWindow.PhysicalSize()
-			if pw > 0 && ph > 0 {
-				ws.resize(pw, ph, a.renderer.device, a.renderer.adapter)
-			}
-		}
-		if ws.width != uint32(frame.physW) || ws.height != uint32(frame.physH) {
-			a.renderer.ResizeSurface(ws, frame.physW, frame.physH)
-		}
+		a.syncFrameSurfaceSize(ws, frame.physW, frame.physH)
 
 		// Lazy acquire: reset per-frame state for deferred beginFrame.
 		// beginFrame is called on first draw call, not upfront.
@@ -1054,6 +1055,26 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 	a.renderer.pollSubmissions()
 }
 
+func (a *App) syncFrameSurfaceSize(ws *RenderTarget, physW, physH int) {
+	// initRenderer may leave the surface unconfigured when PhysicalSize was 0.
+	if !ws.CanRender() && ws.platWindow != nil {
+		pw, ph := ws.platWindow.PhysicalSize()
+		if pw > 0 && ph > 0 {
+			ws.resize(pw, ph, a.renderer.device, a.renderer.adapter)
+		}
+	}
+	if physW <= 0 || physH <= 0 {
+		return
+	}
+	width, height, ok := physicalSizeUint32(physW, physH)
+	if !ok {
+		return
+	}
+	if ws.width != width || ws.height != height {
+		a.renderer.ResizeSurface(ws, physW, physH)
+	}
+}
+
 // modalFrameTick executes one update+render cycle during the Win32 modal
 // drag/resize loop. Called from the WM_TIMER handler on the main thread.
 //
@@ -1092,8 +1113,8 @@ func (a *App) modalFrameTick() {
 		return
 	}
 	width, height := a.platWindow.PhysicalSize()
-	if width > 0 && height > 0 {
-		a.renderLoop.RequestResize(uint32(width), uint32(height)) //nolint:gosec // G115: validated positive
+	if w, h, ok := physicalSizeUint32(width, height); ok {
+		a.renderLoop.RequestResize(w, h)
 	}
 
 	// Resize secondary window swapchains to match their current physical size.

--- a/app.go
+++ b/app.go
@@ -1010,6 +1010,9 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 				ws.resize(pw, ph, a.renderer.device, a.renderer.adapter)
 			}
 		}
+		if ws.width != uint32(frame.physW) || ws.height != uint32(frame.physH) {
+			a.renderer.ResizeSurface(ws, frame.physW, frame.physH)
+		}
 
 		// Lazy acquire: reset per-frame state for deferred beginFrame.
 		// beginFrame is called on first draw call, not upfront.

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -459,13 +459,17 @@ type waylandPlatformWindow struct {
 func (w *waylandPlatformWindow) ID() WindowID { return w.id }
 
 func (w *waylandPlatformWindow) GetHandle() (uintptr, uintptr) {
-	if w.secondary != nil && w.secondary.libwl != nil {
-		return w.secondary.libwl.Display(), w.secondary.libwl.Surface()
-	}
-	if w.platform.libwl != nil {
-		return w.platform.libwl.Display(), w.platform.libwl.Surface()
+	if libwl := w.libwayland(); libwl != nil {
+		return libwl.Display(), libwl.Surface()
 	}
 	return 0, 0
+}
+
+func (w *waylandPlatformWindow) libwayland() *wayland.LibwaylandHandle {
+	if w.secondary != nil && w.secondary.libwl != nil {
+		return w.secondary.libwl
+	}
+	return w.platform.libwl
 }
 
 func (w *waylandPlatformWindow) LogicalSize() (int, int) {
@@ -492,7 +496,23 @@ func (w *waylandPlatformWindow) PhysicalSize() (int, int) {
 }
 
 func (w *waylandPlatformWindow) ScaleFactor() float64 {
-	return w.platform.ScaleFactor()
+	w.platform.mu.Lock()
+	envScale := w.platform.envScaleFactor
+	outputScale := w.platform.outputScale
+	w.platform.mu.Unlock()
+
+	if envScale > 0 {
+		return envScale
+	}
+	if libwl := w.libwayland(); libwl != nil {
+		if scale := libwl.FractionalScale(); scale > 0 {
+			return scale
+		}
+	}
+	if outputScale > 0 {
+		return outputScale
+	}
+	return 1.0
 }
 
 func (w *waylandPlatformWindow) ShouldClose() bool {
@@ -509,34 +529,35 @@ func (w *waylandPlatformWindow) ShouldClose() bool {
 
 func (w *waylandPlatformWindow) InSizeMove() bool { return false }
 func (w *waylandPlatformWindow) SetTitle(title string) {
-	if w.platform.libwl != nil {
-		w.platform.libwl.SetTitle(title)
-		_ = w.platform.libwl.Flush()
+	if libwl := w.libwayland(); libwl != nil {
+		libwl.SetTitle(title)
+		_ = libwl.Flush()
 	}
 }
 
 func (w *waylandPlatformWindow) SetMinSize(width, height int) {
-	if w.platform.libwl != nil {
-		w.platform.libwl.SetMinSize(int32(width), int32(height))
-		_ = w.platform.libwl.Flush()
+	if libwl := w.libwayland(); libwl != nil {
+		libwl.SetMinSize(int32(width), int32(height))
+		_ = libwl.Flush()
 	}
 }
 
 func (w *waylandPlatformWindow) SetMaxSize(width, height int) {
-	if w.platform.libwl != nil {
-		w.platform.libwl.SetMaxSize(int32(width), int32(height))
-		_ = w.platform.libwl.Flush()
+	if libwl := w.libwayland(); libwl != nil {
+		libwl.SetMaxSize(int32(width), int32(height))
+		_ = libwl.Flush()
 	}
 }
 
 func (w *waylandPlatformWindow) PrepareFrame() PrepareFrameResult {
-	if w.platform.libwl != nil && w.ScaleFactor() > 1.0 {
+	scale := w.ScaleFactor()
+	if libwl := w.libwayland(); libwl != nil && scale > 1.0 {
 		lw, lh := w.LogicalSize()
-		w.platform.libwl.SetViewportDestination(int32(lw), int32(lh))
+		libwl.SetViewportDestination(int32(lw), int32(lh))
 	}
 	pw, ph := w.PhysicalSize()
 	return PrepareFrameResult{
-		ScaleFactor:    w.ScaleFactor(),
+		ScaleFactor:    scale,
 		PhysicalWidth:  uint32(pw),
 		PhysicalHeight: uint32(ph),
 	}
@@ -559,8 +580,8 @@ func (w *waylandPlatformWindow) CursorMode() int {
 // next render: FrameCallbackReady() returns false until the compositor fires
 // the done event (FRAME-001 / BUG-WL-006, winit pattern).
 func (w *waylandPlatformWindow) SyncFrame() {
-	if w.platform.libwl != nil && wayland.FrameCallbackEnabled() {
-		w.platform.libwl.RequestFrameCallback()
+	if libwl := w.libwayland(); libwl != nil && wayland.FrameCallbackEnabled() {
+		libwl.RequestFrameCallback()
 	}
 }
 
@@ -598,15 +619,15 @@ func (w *waylandPlatformWindow) SetModalFrameCallback(_ func()) {}
 // wl_display between the main thread (event dispatch) and the render thread
 // (Vulkan WSI present/acquire). ADR-041 Phase 2.
 func (w *waylandPlatformWindow) DisplayLock() {
-	if w.platform.libwl != nil {
-		w.platform.libwl.DisplayLock()
+	if libwl := w.libwayland(); libwl != nil {
+		libwl.DisplayLock()
 	}
 }
 
 // DisplayUnlock releases the Wayland display mutex.
 func (w *waylandPlatformWindow) DisplayUnlock() {
-	if w.platform.libwl != nil {
-		w.platform.libwl.DisplayUnlock()
+	if libwl := w.libwayland(); libwl != nil {
+		libwl.DisplayUnlock()
 	}
 }
 
@@ -615,10 +636,11 @@ func (w *waylandPlatformWindow) DisplayUnlock() {
 // callback is pending). Returns false while waiting for the compositor's done
 // event (FRAME-001 / BUG-WL-006, winit 3-state pattern).
 func (w *waylandPlatformWindow) FrameCallbackReady() bool {
-	if w.platform.libwl == nil || !wayland.FrameCallbackEnabled() {
+	libwl := w.libwayland()
+	if libwl == nil || !wayland.FrameCallbackEnabled() {
 		return true // Not initialized or gating disabled
 	}
-	return w.platform.libwl.FrameCallbackReady()
+	return libwl.FrameCallbackReady()
 }
 
 func (w *waylandPlatformWindow) SetHeaderAlignment(alignment int) {
@@ -1020,6 +1042,16 @@ func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandC
 		decorName = dg.Name
 		decorVersion = dg.Version
 	}
+	var fractionalName, fractionalVersion uint32
+	if fractionalGlobal := registry.GetGlobalByInterface(wayland.InterfaceWpFractionalScaleManagerV1); fractionalGlobal != nil {
+		fractionalName = fractionalGlobal.Name
+		fractionalVersion = fractionalGlobal.Version
+	}
+	var viewporterName, viewporterVersion uint32
+	if viewporterGlobal := registry.GetGlobalByInterface(wayland.InterfaceWpViewporter); viewporterGlobal != nil {
+		viewporterName = viewporterGlobal.Name
+		viewporterVersion = viewporterGlobal.Version
+	}
 	// decorName/decorVersion enable SSD on the secondary window.
 	// CSD is attempted below when SSD is unavailable.
 
@@ -1031,6 +1063,9 @@ func (p *waylandPlatform) createSecondaryConn(config Config) (*secondaryWaylandC
 	if err != nil {
 		_ = display.Close()
 		return nil, fmt.Errorf("OpenLibwayland: %w", err)
+	}
+	if err := libwl.SetupFractionalScale(fractionalName, fractionalVersion, viewporterName, viewporterVersion); err != nil {
+		logger().Warn("secondary fractional scale setup failed", "err", err)
 	}
 
 	libwl.SetTitle(config.Title)

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -126,8 +126,9 @@ type waylandPlatform struct {
 	display  *wayland.Display
 	registry *wayland.Registry
 
-	// Scale factor from environment variables (fallback)
+	// Scale factor from environment variables (explicit override).
 	envScaleFactor float64
+	outputScale    float64
 
 	// Subpixel layout from wl_output.geometry event (ADR-047)
 	outputSubpixel    int32
@@ -529,6 +530,10 @@ func (w *waylandPlatformWindow) SetMaxSize(width, height int) {
 }
 
 func (w *waylandPlatformWindow) PrepareFrame() PrepareFrameResult {
+	if w.platform.libwl != nil && w.ScaleFactor() > 1.0 {
+		lw, lh := w.LogicalSize()
+		w.platform.libwl.SetViewportDestination(int32(lw), int32(lh))
+	}
 	pw, ph := w.PhysicalSize()
 	return PrepareFrameResult{
 		ScaleFactor:    w.ScaleFactor(),
@@ -773,6 +778,9 @@ func (p *waylandPlatform) initSingleConnection(config Config) error { //nolint:g
 		if err == nil {
 			output := wayland.NewWlOutput(display, outputID)
 			if rtErr := display.Roundtrip(); rtErr == nil {
+				if scale := output.Scale(); scale > 0 {
+					p.outputScale = float64(scale)
+				}
 				p.outputSubpixel = output.Subpixel()
 				p.hasOutputSubpixel = true
 			}
@@ -793,6 +801,16 @@ func (p *waylandPlatform) initSingleConnection(config Config) error { //nolint:g
 		decorName = decorGlobal.Name
 		decorVersion = decorGlobal.Version
 	}
+	var fractionalName, fractionalVersion uint32
+	if fractionalGlobal := registry.GetGlobalByInterface(wayland.InterfaceWpFractionalScaleManagerV1); fractionalGlobal != nil {
+		fractionalName = fractionalGlobal.Name
+		fractionalVersion = fractionalGlobal.Version
+	}
+	var viewporterName, viewporterVersion uint32
+	if viewporterGlobal := registry.GetGlobalByInterface(wayland.InterfaceWpViewporter); viewporterGlobal != nil {
+		viewporterName = viewporterGlobal.Name
+		viewporterVersion = viewporterGlobal.Version
+	}
 
 	// Step 2: Open C libwayland connection — this is the SINGLE connection
 	// that owns everything: surface, xdg-shell, input, Vulkan.
@@ -806,6 +824,9 @@ func (p *waylandPlatform) initSingleConnection(config Config) error { //nolint:g
 		return fmt.Errorf("wayland: failed to open libwayland: %w", err)
 	}
 	p.libwl = libwl
+	if err := libwl.SetupFractionalScale(fractionalName, fractionalVersion, viewporterName, viewporterVersion); err != nil {
+		logger().Warn("fractional scale setup failed", "err", err)
+	}
 
 	// Set initial size on the primary window
 	p.primary.width = config.Width
@@ -2866,15 +2887,23 @@ func detectEnvScaleFactor() float64 {
 	return 0
 }
 
-// ScaleFactor returns the DPI scale factor.
-// Falls back to environment variables (GDK_SCALE, QT_SCALE_FACTOR) or 1.0.
-// TODO: Add wl_output scale tracking on C display for proper HiDPI support.
+// ScaleFactor returns the Wayland DPI scale factor.
+// Uses explicit environment overrides first, then compositor-provided fractional
+// scale, wl_output integer scale, and finally 1.0.
 func (p *waylandPlatform) ScaleFactor() float64 {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	if p.envScaleFactor > 0 {
 		return p.envScaleFactor
+	}
+	if p.libwl != nil {
+		if scale := p.libwl.FractionalScale(); scale > 0 {
+			return scale
+		}
+	}
+	if p.outputScale > 0 {
+		return p.outputScale
 	}
 	return 1.0
 }

--- a/internal/platform/wayland/libwayland.go
+++ b/internal/platform/wayland/libwayland.go
@@ -49,6 +49,14 @@ type LibwaylandHandle struct {
 	decorManager  uintptr // zxdg_decoration_manager_v1* proxy
 	toplevelDecor uintptr // zxdg_toplevel_decoration_v1* proxy
 
+	// Fractional scale and viewporter objects (optional).
+	fractionalScaleMgr uintptr
+	fractionalScaleObj uintptr
+	viewporter         uintptr
+	viewport           uintptr
+	scaleMu            sync.Mutex
+	fractionalScale    float64
+
 	// Function symbols
 	fnDisplayConnect   unsafe.Pointer
 	fnDisplayDisconn   unsafe.Pointer
@@ -415,6 +423,26 @@ func (h *LibwaylandHandle) Close() {
 	if h.decorManager != 0 {
 		h.proxyDestroy(h.decorManager)
 		h.decorManager = 0
+	}
+
+	if h.viewport != 0 {
+		h.proxyDestroy(h.viewport)
+		h.viewport = 0
+	}
+	if h.viewporter != 0 {
+		h.proxyDestroy(h.viewporter)
+		h.viewporter = 0
+	}
+	if h.fractionalScaleObj != 0 {
+		fractionalHandlesMu.Lock()
+		delete(fractionalHandles, h.fractionalScaleObj)
+		fractionalHandlesMu.Unlock()
+		h.proxyDestroy(h.fractionalScaleObj)
+		h.fractionalScaleObj = 0
+	}
+	if h.fractionalScaleMgr != 0 {
+		h.proxyDestroy(h.fractionalScaleMgr)
+		h.fractionalScaleMgr = 0
 	}
 
 	// Destroy xdg objects (reverse order: toplevel → surface → wm_base)

--- a/internal/platform/wayland/libwayland.go
+++ b/internal/platform/wayland/libwayland.go
@@ -54,6 +54,8 @@ type LibwaylandHandle struct {
 	fractionalScaleObj uintptr
 	viewporter         uintptr
 	viewport           uintptr
+	viewportDestW      int32
+	viewportDestH      int32
 	scaleMu            sync.Mutex
 	fractionalScale    float64
 
@@ -426,14 +428,19 @@ func (h *LibwaylandHandle) Close() {
 	}
 
 	if h.viewport != 0 {
+		h.marshalVoid(h.viewport, 0) // wp_viewport::destroy (opcode 0)
 		h.proxyDestroy(h.viewport)
 		h.viewport = 0
+		h.viewportDestW = 0
+		h.viewportDestH = 0
 	}
 	if h.viewporter != 0 {
+		h.marshalVoid(h.viewporter, 0) // wp_viewporter::destroy (opcode 0)
 		h.proxyDestroy(h.viewporter)
 		h.viewporter = 0
 	}
 	if h.fractionalScaleObj != 0 {
+		h.marshalVoid(h.fractionalScaleObj, 0) // wp_fractional_scale_v1::destroy (opcode 0)
 		fractionalHandlesMu.Lock()
 		delete(fractionalHandles, h.fractionalScaleObj)
 		fractionalHandlesMu.Unlock()
@@ -441,6 +448,7 @@ func (h *LibwaylandHandle) Close() {
 		h.fractionalScaleObj = 0
 	}
 	if h.fractionalScaleMgr != 0 {
+		h.marshalVoid(h.fractionalScaleMgr, 0) // wp_fractional_scale_manager_v1::destroy (opcode 0)
 		h.proxyDestroy(h.fractionalScaleMgr)
 		h.fractionalScaleMgr = 0
 	}

--- a/internal/platform/wayland/libwayland_fractional_scale.go
+++ b/internal/platform/wayland/libwayland_fractional_scale.go
@@ -148,5 +148,10 @@ func (h *LibwaylandHandle) SetViewportDestination(width, height int32) {
 	if h.viewport == 0 || width <= 0 || height <= 0 {
 		return
 	}
+	if h.viewportDestW == width && h.viewportDestH == height {
+		return
+	}
+	h.viewportDestW = width
+	h.viewportDestH = height
 	h.marshalVoid(h.viewport, 2, uintptr(width), uintptr(height))
 }

--- a/internal/platform/wayland/libwayland_fractional_scale.go
+++ b/internal/platform/wayland/libwayland_fractional_scale.go
@@ -1,0 +1,152 @@
+//go:build linux
+
+package wayland
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/go-webgpu/goffi/ffi"
+)
+
+var fractionalIfaces struct {
+	once sync.Once
+
+	scaleMgr   cWlInterface
+	scale      cWlInterface
+	viewporter cWlInterface
+	viewport   cWlInterface
+
+	scaleMgrMethods   [2]cWlMessage
+	scaleMethods      [1]cWlMessage
+	scaleEvents       [1]cWlMessage
+	viewporterMethods [2]cWlMessage
+	viewportMethods   [3]cWlMessage
+	nullTypes         [4]uintptr
+}
+
+var (
+	fractionalScaleListener [1]uintptr
+	fractionalHandlesMu     sync.Mutex
+	fractionalHandles       = map[uintptr]*LibwaylandHandle{}
+)
+
+func initFractionalScaleInterfaces() {
+	fractionalIfaces.once.Do(func() {
+		nt := uintptr(unsafe.Pointer(&fractionalIfaces.nullTypes[0]))
+
+		fractionalIfaces.scaleMgrMethods[0] = cWlMessage{cstr("destroy\x00"), cstr("\x00"), nt}
+		fractionalIfaces.scaleMgrMethods[1] = cWlMessage{cstr("get_fractional_scale\x00"), cstr("no\x00"), nt}
+		fractionalIfaces.scaleMgr = cWlInterface{
+			Name:        cstr("wp_fractional_scale_manager_v1\x00"),
+			Version:     1,
+			MethodCount: 2,
+			Methods:     uintptr(unsafe.Pointer(&fractionalIfaces.scaleMgrMethods[0])),
+		}
+
+		fractionalIfaces.scaleMethods[0] = cWlMessage{cstr("destroy\x00"), cstr("\x00"), nt}
+		fractionalIfaces.scaleEvents[0] = cWlMessage{cstr("preferred_scale\x00"), cstr("u\x00"), nt}
+		fractionalIfaces.scale = cWlInterface{
+			Name:        cstr("wp_fractional_scale_v1\x00"),
+			Version:     1,
+			MethodCount: 1,
+			Methods:     uintptr(unsafe.Pointer(&fractionalIfaces.scaleMethods[0])),
+			EventCount:  1,
+			Events:      uintptr(unsafe.Pointer(&fractionalIfaces.scaleEvents[0])),
+		}
+
+		fractionalIfaces.viewporterMethods[0] = cWlMessage{cstr("destroy\x00"), cstr("\x00"), nt}
+		fractionalIfaces.viewporterMethods[1] = cWlMessage{cstr("get_viewport\x00"), cstr("no\x00"), nt}
+		fractionalIfaces.viewporter = cWlInterface{
+			Name:        cstr("wp_viewporter\x00"),
+			Version:     1,
+			MethodCount: 2,
+			Methods:     uintptr(unsafe.Pointer(&fractionalIfaces.viewporterMethods[0])),
+		}
+
+		fractionalIfaces.viewportMethods[0] = cWlMessage{cstr("destroy\x00"), cstr("\x00"), nt}
+		fractionalIfaces.viewportMethods[1] = cWlMessage{cstr("set_source\x00"), cstr("ffff\x00"), nt}
+		fractionalIfaces.viewportMethods[2] = cWlMessage{cstr("set_destination\x00"), cstr("ii\x00"), nt}
+		fractionalIfaces.viewport = cWlInterface{
+			Name:        cstr("wp_viewport\x00"),
+			Version:     1,
+			MethodCount: 3,
+			Methods:     uintptr(unsafe.Pointer(&fractionalIfaces.viewportMethods[0])),
+		}
+
+		fractionalScaleListener[0] = ffi.NewCallback(fractionalPreferredScaleCb)
+	})
+}
+
+func fractionalPreferredScaleCb(_, scaleObj, scale uintptr) {
+	fractionalHandlesMu.Lock()
+	h := fractionalHandles[scaleObj]
+	fractionalHandlesMu.Unlock()
+	if h == nil {
+		return
+	}
+	h.scaleMu.Lock()
+	h.fractionalScale = float64(scale) / 120.0
+	h.scaleMu.Unlock()
+}
+
+func (h *LibwaylandHandle) SetupFractionalScale(scaleName, scaleVersion, viewporterName, viewporterVersion uint32) error {
+	if scaleName == 0 || viewporterName == 0 {
+		return nil
+	}
+	initFractionalScaleInterfaces()
+
+	if scaleVersion > 1 {
+		scaleVersion = 1
+	}
+	scaleMgr, err := h.registryBind(scaleName, unsafe.Pointer(&fractionalIfaces.scaleMgr), scaleVersion)
+	if err != nil {
+		return fmt.Errorf("wayland: bind fractional scale manager: %w", err)
+	}
+	h.fractionalScaleMgr = scaleMgr
+
+	scaleObj, err := h.marshalConstructorObj(scaleMgr, 1, unsafe.Pointer(&fractionalIfaces.scale), h.surface)
+	if err != nil {
+		return fmt.Errorf("wayland: create fractional scale: %w", err)
+	}
+	h.fractionalScaleObj = scaleObj
+	if err := h.addListener(scaleObj, uintptr(unsafe.Pointer(&fractionalScaleListener[0]))); err != nil {
+		return fmt.Errorf("wayland: add fractional scale listener: %w", err)
+	}
+	fractionalHandlesMu.Lock()
+	fractionalHandles[scaleObj] = h
+	fractionalHandlesMu.Unlock()
+
+	if viewporterVersion > 1 {
+		viewporterVersion = 1
+	}
+	viewporter, err := h.registryBind(viewporterName, unsafe.Pointer(&fractionalIfaces.viewporter), viewporterVersion)
+	if err != nil {
+		return fmt.Errorf("wayland: bind viewporter: %w", err)
+	}
+	h.viewporter = viewporter
+	viewport, err := h.marshalConstructorObj(viewporter, 1, unsafe.Pointer(&fractionalIfaces.viewport), h.surface)
+	if err != nil {
+		return fmt.Errorf("wayland: create viewport: %w", err)
+	}
+	h.viewport = viewport
+
+	if err := h.flush(); err != nil {
+		return err
+	}
+	return h.roundtrip()
+}
+
+func (h *LibwaylandHandle) FractionalScale() float64 {
+	h.scaleMu.Lock()
+	defer h.scaleMu.Unlock()
+	return h.fractionalScale
+}
+
+func (h *LibwaylandHandle) SetViewportDestination(width, height int32) {
+	if h.viewport == 0 || width <= 0 || height <= 0 {
+		return
+	}
+	h.marshalVoid(h.viewport, 2, uintptr(width), uintptr(height))
+}

--- a/internal/platform/wayland/registry.go
+++ b/internal/platform/wayland/registry.go
@@ -37,7 +37,9 @@ const (
 
 	// Cursor shape protocol (wp_cursor_shape_manager_v1).
 	// Modern protocol for setting cursor shapes without loading xcursor themes.
-	InterfaceWpCursorShapeManagerV1 = "wp_cursor_shape_manager_v1"
+	InterfaceWpCursorShapeManagerV1     = "wp_cursor_shape_manager_v1"
+	InterfaceWpFractionalScaleManagerV1 = "wp_fractional_scale_manager_v1"
+	InterfaceWpViewporter               = "wp_viewporter"
 
 	// KDE-specific app menu protocol. Wayland clients use this to tell KWin
 	// which D-Bus service/path exposes their dbusmenu. Required for global


### PR DESCRIPTION
## Summary

Adds native Wayland fractional-scale support using:

- `wp_fractional_scale_manager_v1` to read the compositor preferred scale
- `wp_viewporter` to keep the surface destination in logical coordinates
- per-frame surface resizing when the physical framebuffer size changes
- `wl_output` integer scale as a fallback when fractional scale is unavailable

## Why

On KDE Wayland at 150% scaling, gogpu was rendering the framebuffer at the logical window size and the compositor scaled it up, making apps visibly blurry.

Observed before this fix:

```text
ctx=1504x1003 framebuffer=1504x1003 app=1504x1003 scale_factor=1.000
```

With the fix, the app renders to the physical framebuffer while keeping logical coordinates stable:

```text
ctx=1504x1003 framebuffer=2256x1505 app=1504x1003 scale_factor=1.500 framebuffer_scale=1.500x1.500
```

This matches the behavior observed through XWayland on the same KDE setup, where the framebuffer is already scaled correctly.

## Notes

Runtime validation against current `main` is currently affected by #368 (`wl_display_flush failed: -1` closes native Wayland apps). The fractional-scale path was validated in the same app on the v0.42.7 baseline, then rebased onto current `main` and reviewed to keep the patch scoped to Wayland scale handling.

## Tests

```sh
go test ./...
```

Fixes https://github.com/gogpu/ui/issues/166