### PR TITLE
fix(linux): WindowID stamping + X11 multi-window + docs v0.44.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.10] - 2026-07-20
+
+### Fixed
+
+- **Linux WindowID stamping** (@lkmavi, #381) — all X11/Wayland event types (keyboard, pointer, scroll, char, focus) now carry correct `WindowID`. Previously only Close/Expose were stamped — `getByPlatformID` returned nil for all other events, silently dropping per-window callbacks on Linux.
+- **X11 multi-window** (@lkmavi, #381) — secondary windows use independent X11 connections (mirrors Wayland pattern). Each window gets its own atoms, XKB state, cursor cache, event queue. `WaitEvents` budget-split polling: `100ms / (N+1)` keeps latency constant as window count grows.
+- **Wayland secondary window Close** (@lkmavi, #381) — `Close()` on secondary window now correctly targets its own connection instead of silently closing the primary.
+
 ## [0.44.9] - 2026-07-16
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.44.9
+## Current State: v0.44.10
 
 ✅ **Production-ready** with full feature set:
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.
@@ -80,6 +80,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.44.10** | 2026-07-20 | **Linux WindowID stamping** + X11 multi-window + Wayland secondary Close (@lkmavi, #381). |
 | **v0.44.9** | 2026-07-16 | **deps:** wgpu v0.30.22 — Metal MSAA Intel Mac crash fix (@AnyCPU). |
 | **v0.44.8** | 2026-07-15 | **deps:** wgpu v0.30.21 — software backend row stride, blend state, BGRA readTexel fixes. |
 | **v0.44.7** | 2026-07-14 | **pixelPresented frame lifecycle** (ADR-052) — fixes software backend PRESENT ERROR. deps: wgpu v0.30.20 (DX12 UMA @Zeroes1). |


### PR DESCRIPTION
## Summary

### Fixed

- **Linux WindowID stamping** (@lkmavi, #381) — all X11/Wayland event types (keyboard, pointer, scroll, char, focus) now carry correct `WindowID`. Previously only Close/Expose were stamped — `getByPlatformID` returned nil for all other events, silently dropping per-window callbacks on Linux.
- **X11 multi-window** (@lkmavi, #381) — secondary windows use independent X11 connections (mirrors Wayland pattern). Each window gets its own atoms, XKB state, cursor cache, event queue. `WaitEvents` budget-split polling: `100ms / (N+1)` keeps latency constant as window count grows.
- **Wayland secondary window Close** (@lkmavi, #381) — `Close()` on secondary window now correctly targets its own connection instead of silently closing the primary.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all pass
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [ ] CI all green