### PR TITLE
fix: expose render target content preservation

### DIFF
--- a/context.go
+++ b/context.go
@@ -244,6 +244,14 @@ func (c *Context) RenderTarget() *ContextRenderTarget {
 // ContextRenderTarget adapts *Context to ggcanvas.RenderTarget interface.
 type ContextRenderTarget struct{ ctx *Context }
 
+// PreserveContent reports whether the active surface already contains content
+// that subsequent render passes must load. This exposes MarkExternalContent's
+// frame state to ggcanvas without introducing a dependency on gg.
+func (r *ContextRenderTarget) PreserveContent() bool {
+	ws := r.ctx.activeSurface()
+	return ws != nil && ws.frameCleared
+}
+
 // SurfaceView returns the surface texture view as a type-safe opaque handle.
 func (r *ContextRenderTarget) SurfaceView() gpucontext.TextureView {
 	tv := r.ctx.SurfaceView()

--- a/context_external_content_test.go
+++ b/context_external_content_test.go
@@ -140,3 +140,35 @@ func TestMarkExternalContent_MultiWindow(t *testing.T) {
 		t.Error("Context with explicit surface must target it, not primary")
 	}
 }
+
+// TestContextRenderTarget_PreserveContent verifies that the ggcanvas adapter
+// exposes the external-content state for the surface targeted by its Context.
+func TestContextRenderTarget_PreserveContent(t *testing.T) {
+	if newContext(&Renderer{}, 1.0).RenderTarget().PreserveContent() {
+		t.Error("PreserveContent() = true without an active surface")
+	}
+
+	primary := newTestWindowSurface()
+	ctx := newContext(primary.renderer, 1.0)
+	rt := ctx.RenderTarget()
+
+	if rt.PreserveContent() {
+		t.Error("PreserveContent() = true before external content is marked")
+	}
+
+	primary.frameCleared = true
+	if !rt.PreserveContent() {
+		t.Error("PreserveContent() = false with frameCleared=true")
+	}
+
+	secondary := &RenderTarget{
+		renderer:     primary.renderer,
+		format:       gputypes.TextureFormatBGRA8Unorm,
+		frameCleared: true,
+	}
+	primary.frameCleared = false
+	secondaryRT := newContextForSurface(primary.renderer, secondary, 1.0).RenderTarget()
+	if !secondaryRT.PreserveContent() {
+		t.Error("PreserveContent() did not read the Context's secondary surface")
+	}
+}


### PR DESCRIPTION
## Summary

Expose `Context.MarkExternalContent()` state through the render-target adapter so ggcanvas can preserve an earlier renderer's surface content.

- add `ContextRenderTarget.PreserveContent()` backed by the active surface's `frameCleared` state
- preserve correct primary and secondary-window targeting
- return `false` when no surface is active
- add focused regression coverage

This completes gogpu's side of the external-content path:

1. merged [gogpu/gg#451](https://github.com/gogpu/gg/pull/451) forwards the optional `ContentPreserver` state to `GPURenderTarget.PreserveContent`
2. [gogpu/gg#453](https://github.com/gogpu/gg/pull/453) makes preserved surface content the compositor base, resolving [gogpu/gg#452](https://github.com/gogpu/gg/issues/452)
3. this PR supplies that state from the active gogpu surface

**Merge order:** land gogpu/gg#453 first, then merge this PR to complete the validated g3d + gg overlay bridge.

## Testing

- `CGO_ENABLED=0 go test -count=1 . -run '^(TestContextRenderTarget_PreserveContent|TestMarkExternalContent_)'`
- all packages except `github.com/gogpu/gogpu/internal/platform/darwin`
- `golangci-lint v2.12.2 run --timeout=5m` (0 issues)
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go build ./examples/...`
- cross-repo compile assertion that `*gogpu.ContextRenderTarget` satisfies `ggcanvas.ContentPreserver`

The complete local test command reached the existing `internal/platform/darwin` package and did not complete; every other package passed. Local `go vet ./...` also reports the existing Darwin `unsafe.Pointer` diagnostics outside this change.

Closes #390
