### PR TITLE
fix: PreserveContent bridge + docs v0.45.2 (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.2] - 2026-07-27
+
+### Fixed
+
+- **ContextRenderTarget.PreserveContent()** (#390, @besmpl PR #391) — bridges `MarkExternalContent()` frame state to gg's render session. Without this, gg always used `LoadOp::Clear` after external 3D rendering, wiping the content. Part of the g3d+gg overlay chain (gg#451, gg#453).
+
 ## [0.45.1] - 2026-07-27
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.45.1
+## Current State: v0.45.2
 
 ✅ **Production-ready** with full feature set:
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.
@@ -80,6 +80,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.45.2** | 2026-07-27 | **PreserveContent bridge** (#390, @besmpl) — completes g3d+gg overlay chain. |
 | **v0.45.1** | 2026-07-27 | **DnD complete** — macOS NSDragging + Wayland wl_data_device. All 4 platforms. |
 | **v0.45.0** | 2026-07-27 | **OS file drag-and-drop** (#387, Windows+X11). fix: Wayland 60fps (#379), macOS title double-render (#384), macOS tabbing (#383). |
 | **v0.44.11** | 2026-07-26 | **MarkExternalContent** (#341) — multi-pass frame compositing for g3d+ui. deps: wgpu v0.30.23, goffi v0.6.2 (@besmpl). |


### PR DESCRIPTION
## Summary

- **ContextRenderTarget.PreserveContent()** (#390, @besmpl PR #391) — bridges MarkExternalContent() frame state to gg render session. Completes g3d+gg overlay chain.

## Test plan
- [x] Build/test/lint all pass
- [ ] CI green