### PR TITLE
feat(render): add frame-owned command encoder

### DIFF
--- a/context.go
+++ b/context.go
@@ -206,6 +206,32 @@ func (c *Context) SurfaceView() *wgpu.TextureView {
 	return ws.currentView
 }
 
+// CommandEncoder returns the framework-owned command encoder for the active
+// surface frame. External renderers can record additional passes into it so all
+// work targeting the swapchain image is submitted once at frame end.
+//
+// The returned encoder is borrowed and valid only during the current draw
+// callback. Callers must not call Finish, Submit, or DiscardEncoding on it.
+// Returns nil when the surface frame or encoder cannot be created.
+func (c *Context) CommandEncoder() *wgpu.CommandEncoder {
+	ws := c.activeSurface()
+	if ws == nil {
+		return nil
+	}
+	encoder, err := ws.ensureFrameEncoder()
+	if err != nil {
+		slog.Error("gogpu: shared frame encoder unavailable", "err", err)
+		return nil
+	}
+	// Deferred clears must precede every externally recorded pass. Flushing
+	// here preserves call order; waiting until EndFrame would clear overlays.
+	if !ws.flushClear(ws.renderer.device, ws.renderer) {
+		return nil
+	}
+	ws.hasGPUWork = true
+	return encoder
+}
+
 // PresentTexture draws a texture filling the entire surface.
 // This is the universal path for presenting pre-rendered content (e.g., from
 // ggcanvas.Flush) on any backend including software.
@@ -243,6 +269,17 @@ func (c *Context) RenderTarget() *ContextRenderTarget {
 
 // ContextRenderTarget adapts *Context to ggcanvas.RenderTarget interface.
 type ContextRenderTarget struct{ ctx *Context }
+
+// CommandEncoder returns the active framework-owned encoder as an opaque
+// handle. This optional capability lets compositors record into the same
+// command buffer without depending directly on gogpu or wgpu.
+func (r *ContextRenderTarget) CommandEncoder() gpucontext.CommandEncoder {
+	encoder := r.ctx.CommandEncoder()
+	if encoder == nil {
+		return gpucontext.CommandEncoder{}
+	}
+	return gpucontext.NewCommandEncoder(unsafe.Pointer(encoder)) //nolint:gosec // Go spec Rule 1: *T -> unsafe.Pointer
+}
 
 // PreserveContent reports whether the active surface already contains content
 // that subsequent render passes must load. This exposes MarkExternalContent's
@@ -287,6 +324,7 @@ func (r *ContextRenderTarget) WriteSurfacePixels(data []byte, width, height uint
 		return err
 	}
 	ws.pixelPresented = true
+	ws.discardFrameEncoder()
 	if ws.currentView != nil {
 		ws.currentView.Release()
 		ws.currentView = nil

--- a/context_command_encoder_test.go
+++ b/context_command_encoder_test.go
@@ -1,6 +1,7 @@
 package gogpu
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gogpu/gputypes"
@@ -14,6 +15,14 @@ type countingSubmitQueue struct {
 	submits int
 }
 
+type commandEncoderFailDevice struct{ noop.Device }
+
+func (d *commandEncoderFailDevice) CreateCommandEncoder(
+	_ *hal.CommandEncoderDescriptor,
+) (hal.CommandEncoder, error) {
+	return nil, errors.New("injected command encoder failure")
+}
+
 func (q *countingSubmitQueue) Submit(_ []hal.CommandBuffer) (uint64, error) {
 	q.submits++
 	return uint64(q.submits), nil
@@ -21,9 +30,17 @@ func (q *countingSubmitQueue) Submit(_ []hal.CommandBuffer) (uint64, error) {
 
 func newSharedEncoderTestContext(t *testing.T) (*Context, *RenderTarget, *countingSubmitQueue) {
 	t.Helper()
+	return newSharedEncoderTestContextWithDevice(t, &noop.Device{})
+}
+
+func newSharedEncoderTestContextWithDevice(
+	t *testing.T,
+	halDevice hal.Device,
+) (*Context, *RenderTarget, *countingSubmitQueue) {
+	t.Helper()
 	queue := &countingSubmitQueue{}
 	device, err := wgpu.NewDeviceFromHAL(
-		&noop.Device{}, queue, 0, gputypes.DefaultLimits(), "shared-encoder-test",
+		halDevice, queue, 0, gputypes.DefaultLimits(), "shared-encoder-test",
 	)
 	if err != nil {
 		t.Fatalf("NewDeviceFromHAL: %v", err)
@@ -56,7 +73,9 @@ func newSharedEncoderTestContext(t *testing.T) (*Context, *RenderTarget, *counti
 	renderer.primary = target
 	t.Cleanup(func() {
 		target.discardFrameEncoder()
-		view.Release()
+		if target.currentView != nil {
+			target.currentView.Release()
+		}
 		texture.Release()
 		device.Release()
 	})
@@ -121,5 +140,108 @@ func TestContextCommandEncoderWithoutSurfaceReturnsNil(t *testing.T) {
 	ctx := newContext(&Renderer{}, 1)
 	if got := ctx.CommandEncoder(); got != nil {
 		t.Fatalf("CommandEncoder() = %v, want nil", got)
+	}
+}
+
+func TestContextRenderTargetCommandEncoderWithoutSurfaceReturnsNil(t *testing.T) {
+	ctx := newContext(&Renderer{}, 1)
+	if got := ctx.RenderTarget().CommandEncoder(); !got.IsNil() {
+		t.Fatal("opaque CommandEncoder is non-nil without an active surface")
+	}
+}
+
+func TestEnsureFrameEncoderWithoutFrameFails(t *testing.T) {
+	target := &RenderTarget{renderer: &Renderer{}}
+	if _, err := target.ensureFrameEncoder(); err == nil {
+		t.Fatal("ensureFrameEncoder succeeded without an active frame")
+	}
+}
+
+func TestContextCommandEncoderReturnsNilWhenCreationFails(t *testing.T) {
+	ctx, _, _ := newSharedEncoderTestContextWithDevice(t, &commandEncoderFailDevice{})
+	if got := ctx.CommandEncoder(); got != nil {
+		t.Fatalf("CommandEncoder() = %v after creation failure, want nil", got)
+	}
+}
+
+func TestFlushClearStandaloneSubmitsOnce(t *testing.T) {
+	_, target, queue := newSharedEncoderTestContext(t)
+	target.clear(0.1, 0.2, 0.3, 1)
+
+	if !target.flushClear(target.renderer.device, target.renderer) {
+		t.Fatal("flushClear failed")
+	}
+	if queue.submits != 1 {
+		t.Fatalf("standalone clear submissions = %d, want 1", queue.submits)
+	}
+	if target.hasPendingClear || !target.frameCleared {
+		t.Fatal("standalone clear did not update frame state")
+	}
+}
+
+func TestFlushClearDiscardsStandaloneEncoderOnInvalidView(t *testing.T) {
+	_, target, queue := newSharedEncoderTestContext(t)
+	target.currentView.Release()
+	target.clear(0.1, 0.2, 0.3, 1)
+
+	if target.flushClear(target.renderer.device, target.renderer) {
+		t.Fatal("flushClear succeeded with a released view")
+	}
+	if queue.submits != 0 {
+		t.Fatalf("invalid clear submissions = %d, want 0", queue.submits)
+	}
+}
+
+func TestContextCommandEncoderDiscardsSharedEncoderWhenClearFails(t *testing.T) {
+	ctx, target, queue := newSharedEncoderTestContext(t)
+	if encoder := ctx.CommandEncoder(); encoder == nil {
+		t.Fatal("CommandEncoder returned nil")
+	}
+	target.currentView.Release()
+	target.clear(0.1, 0.2, 0.3, 1)
+
+	if encoder := ctx.CommandEncoder(); encoder != nil {
+		t.Fatal("CommandEncoder returned encoder after clear failure")
+	}
+	if target.frameEncoder != nil {
+		t.Fatal("failed shared encoder was retained")
+	}
+	if queue.submits != 0 {
+		t.Fatalf("failed shared encoder submissions = %d, want 0", queue.submits)
+	}
+}
+
+func TestSubmitFrameEncoderDropsFinishFailure(t *testing.T) {
+	ctx, target, queue := newSharedEncoderTestContext(t)
+	encoder := ctx.CommandEncoder()
+	if encoder == nil {
+		t.Fatal("CommandEncoder returned nil")
+	}
+	encoder.CopyBufferToBuffer(nil, 0, nil, 0, 1)
+
+	target.submitFrameEncoder(target.renderer)
+	if target.frameEncoder != nil {
+		t.Fatal("failed frame encoder was retained")
+	}
+	if queue.submits != 0 {
+		t.Fatalf("invalid frame submissions = %d, want 0", queue.submits)
+	}
+}
+
+func TestEndFrameDiscardsEncoderAfterPixelPresent(t *testing.T) {
+	ctx, target, queue := newSharedEncoderTestContext(t)
+	if encoder := ctx.CommandEncoder(); encoder == nil {
+		t.Fatal("CommandEncoder returned nil")
+	}
+	target.pixelPresented = true
+
+	if target.renderer.endFrameForSurface(target) {
+		t.Fatal("pixel-presented frame unexpectedly reconfigured")
+	}
+	if target.frameEncoder != nil {
+		t.Fatal("pixel-presented frame retained its encoder")
+	}
+	if queue.submits != 0 {
+		t.Fatalf("pixel-presented frame submissions = %d, want 0", queue.submits)
 	}
 }

--- a/context_command_encoder_test.go
+++ b/context_command_encoder_test.go
@@ -1,0 +1,125 @@
+package gogpu
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+	"github.com/gogpu/wgpu/hal"
+	"github.com/gogpu/wgpu/hal/noop"
+)
+
+type countingSubmitQueue struct {
+	noop.Queue
+	submits int
+}
+
+func (q *countingSubmitQueue) Submit(_ []hal.CommandBuffer) (uint64, error) {
+	q.submits++
+	return uint64(q.submits), nil
+}
+
+func newSharedEncoderTestContext(t *testing.T) (*Context, *RenderTarget, *countingSubmitQueue) {
+	t.Helper()
+	queue := &countingSubmitQueue{}
+	device, err := wgpu.NewDeviceFromHAL(
+		&noop.Device{}, queue, 0, gputypes.DefaultLimits(), "shared-encoder-test",
+	)
+	if err != nil {
+		t.Fatalf("NewDeviceFromHAL: %v", err)
+	}
+	renderer := &Renderer{device: device}
+	texture, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "shared-encoder-test-target",
+		Size:          wgpu.Extent3D{Width: 1, Height: 1, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     gputypes.TextureDimension2D,
+		Format:        gputypes.TextureFormatBGRA8Unorm,
+		Usage:         gputypes.TextureUsageRenderAttachment,
+	})
+	if err != nil {
+		device.Release()
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	view, err := device.CreateTextureView(texture, nil)
+	if err != nil {
+		texture.Release()
+		device.Release()
+		t.Fatalf("CreateTextureView: %v", err)
+	}
+	target := &RenderTarget{
+		renderer:     renderer,
+		frameStarted: true,
+		currentView:  view,
+	}
+	renderer.primary = target
+	t.Cleanup(func() {
+		target.discardFrameEncoder()
+		view.Release()
+		texture.Release()
+		device.Release()
+	})
+	return newContext(renderer, 1), target, queue
+}
+
+func TestContextCommandEncoderReusesAndSubmitsFrameEncoderOnce(t *testing.T) {
+	ctx, target, queue := newSharedEncoderTestContext(t)
+
+	first := ctx.CommandEncoder()
+	if first == nil {
+		t.Fatal("CommandEncoder returned nil")
+	}
+	if second := ctx.CommandEncoder(); second != first {
+		t.Fatal("CommandEncoder did not reuse the active frame encoder")
+	}
+	if queue.submits != 0 {
+		t.Fatalf("encoder submitted before frame end: %d", queue.submits)
+	}
+
+	target.submitFrameEncoder(target.renderer)
+	if queue.submits != 1 {
+		t.Fatalf("frame submissions = %d, want 1", queue.submits)
+	}
+	if target.frameEncoder != nil {
+		t.Fatal("frame encoder retained after submission")
+	}
+}
+
+func TestContextRenderTargetCommandEncoderForwardsActiveEncoder(t *testing.T) {
+	ctx, _, _ := newSharedEncoderTestContext(t)
+
+	encoder := ctx.CommandEncoder()
+	opaque := ctx.RenderTarget().CommandEncoder()
+	if opaque.IsNil() {
+		t.Fatal("opaque CommandEncoder is nil")
+	}
+	if got := (*wgpu.CommandEncoder)(opaque.Pointer()); got != encoder {
+		t.Fatal("RenderTarget returned a different command encoder")
+	}
+}
+
+func TestContextCommandEncoderFlushesPendingClearFirst(t *testing.T) {
+	ctx, target, queue := newSharedEncoderTestContext(t)
+	target.clear(0.1, 0.2, 0.3, 1)
+
+	if encoder := ctx.CommandEncoder(); encoder == nil {
+		t.Fatal("CommandEncoder returned nil")
+	}
+	if target.hasPendingClear {
+		t.Fatal("pending clear was not recorded before returning the shared encoder")
+	}
+	if !target.frameCleared {
+		t.Fatal("frame was not marked cleared")
+	}
+	if queue.submits != 0 {
+		t.Fatalf("clear submitted before frame end: %d", queue.submits)
+	}
+}
+
+func TestContextCommandEncoderWithoutSurfaceReturnsNil(t *testing.T) {
+	ctx := newContext(&Renderer{}, 1)
+	if got := ctx.CommandEncoder(); got != nil {
+		t.Fatalf("CommandEncoder() = %v, want nil", got)
+	}
+}

--- a/renderer.go
+++ b/renderer.go
@@ -489,8 +489,7 @@ func (ws *RenderTarget) beginFrame(platWin platform.PlatformWindow, device *wgpu
 	}
 	ws.currentView = view
 
-	// Reset frame state for new frame.
-	ws.discardFrameEncoder()
+	// Reset frame state for new frame
 	ws.frameCleared = false
 	ws.hasPendingClear = false
 	ws.hasGPUWork = false
@@ -636,6 +635,7 @@ func (ws *RenderTarget) setTransactionPresent(enabled bool) {
 // The actual swapchain acquire happens on first draw call via ensureFrameStarted.
 // Uses ws.platWindow and ws.renderer.{device,adapter} — no parameters needed.
 func (ws *RenderTarget) prepareLazyAcquire() {
+	ws.discardFrameEncoder()
 	ws.frameStarted = false
 	ws.hasGPUWork = false
 	ws.pixelPresented = false

--- a/renderer.go
+++ b/renderer.go
@@ -55,6 +55,9 @@ type RenderTarget struct {
 	currentSurfaceTexture *wgpu.SurfaceTexture
 	currentView           *wgpu.TextureView
 	frameCleared          bool // Whether the frame has been cleared (for LoadOp selection)
+	// frameEncoder is borrowed by external renderers and owned by this surface.
+	// It is finished and submitted exactly once at frame end.
+	frameEncoder *wgpu.CommandEncoder
 
 	// Deferred clear -- eliminates separate Clear render pass.
 	// ClearColor stores the color and sets hasPendingClear=true.
@@ -486,7 +489,8 @@ func (ws *RenderTarget) beginFrame(platWin platform.PlatformWindow, device *wgpu
 	}
 	ws.currentView = view
 
-	// Reset frame state for new frame
+	// Reset frame state for new frame.
+	ws.discardFrameEncoder()
 	ws.frameCleared = false
 	ws.hasPendingClear = false
 	ws.hasGPUWork = false
@@ -538,6 +542,7 @@ func (r *Renderer) EndFrame() {
 func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	// PresentPixels already presented — skip normal present path (ADR-052).
 	if ws.pixelPresented {
+		ws.discardFrameEncoder()
 		ws.pixelPresented = false
 		ws.hasPendingClear = false
 		if ws.platWindow != nil {
@@ -548,6 +553,7 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	}
 
 	ws.flushClear(r.device, r)
+	ws.submitFrameEncoder(r)
 	// Request frame callback BEFORE present (winit pre_present_notify pattern).
 	// Wayland spec: "The frame request will take effect on the next commit."
 	// The present's internal wl_surface.commit activates it atomically.
@@ -666,8 +672,52 @@ func (ws *RenderTarget) resetLazyState() {
 	ws.pixelPresented = false
 }
 
+// ensureFrameEncoder returns the framework-owned encoder for this surface
+// frame, creating it lazily. Ownership remains with RenderTarget.
+func (ws *RenderTarget) ensureFrameEncoder() (*wgpu.CommandEncoder, error) {
+	if !ws.ensureFrameStarted() {
+		return nil, fmt.Errorf("gogpu: surface frame not available")
+	}
+	if ws.frameEncoder != nil {
+		return ws.frameEncoder, nil
+	}
+	encoder, err := ws.renderer.device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{
+		Label: "gogpu_shared_frame",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gogpu: create shared frame encoder: %w", err)
+	}
+	ws.frameEncoder = encoder
+	return encoder, nil
+}
+
+// submitFrameEncoder finishes and submits the framework-owned shared encoder.
+func (ws *RenderTarget) submitFrameEncoder(r *Renderer) {
+	encoder := ws.frameEncoder
+	ws.frameEncoder = nil
+	if encoder == nil {
+		return
+	}
+	commands, err := encoder.Finish()
+	if err != nil {
+		slog.Error("finish shared frame encoder failed", "err", err)
+		return
+	}
+	r.submitTracked(commands)
+}
+
+// discardFrameEncoder abandons an unsubmitted shared encoder on cancellation.
+func (ws *RenderTarget) discardFrameEncoder() {
+	if ws.frameEncoder == nil {
+		return
+	}
+	ws.frameEncoder.DiscardEncoding()
+	ws.frameEncoder = nil
+}
+
 // releaseFrame releases per-frame resources after presentation.
 func (ws *RenderTarget) releaseFrame() {
+	ws.discardFrameEncoder()
 	if ws.currentView != nil {
 		ws.currentView.Release()
 		ws.currentView = nil
@@ -696,16 +746,20 @@ func (ws *RenderTarget) clear(red, green, blue, alpha float64) {
 
 // flushClear applies any pending clear immediately as a standalone render pass.
 // Called by EndFrame if no draw calls consumed the pending clear.
-func (ws *RenderTarget) flushClear(device *wgpu.Device, r *Renderer) {
+func (ws *RenderTarget) flushClear(device *wgpu.Device, r *Renderer) bool {
 	if !ws.hasPendingClear || ws.currentView == nil {
-		return
+		return true
 	}
 
-	encoder, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{
-		Label: "Clear",
-	})
-	if err != nil {
-		return
+	encoder := ws.frameEncoder
+	shared := encoder != nil
+	if !shared {
+		var err error
+		encoder, err = device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{Label: "Clear"})
+		if err != nil {
+			slog.Error("create clear command encoder failed", "err", err)
+			return false
+		}
 	}
 
 	renderPass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
@@ -719,21 +773,38 @@ func (ws *RenderTarget) flushClear(device *wgpu.Device, r *Renderer) {
 		},
 	})
 	if err != nil {
-		return
+		if shared {
+			ws.discardFrameEncoder()
+		} else {
+			encoder.DiscardEncoding()
+		}
+		slog.Error("begin clear render pass failed", "err", err)
+		return false
 	}
 
 	if err := renderPass.End(); err != nil {
-		return
+		if shared {
+			ws.discardFrameEncoder()
+		} else {
+			encoder.DiscardEncoding()
+		}
+		slog.Error("end clear render pass failed", "err", err)
+		return false
+	}
+	ws.hasPendingClear = false
+	ws.frameCleared = true
+	if shared {
+		return true
 	}
 
 	commands, err := encoder.Finish()
 	if err != nil {
-		return
+		slog.Error("finish clear command encoder failed", "err", err)
+		return false
 	}
 
 	r.submitTracked(commands)
-	ws.hasPendingClear = false
-	ws.frameCleared = true
+	return true
 }
 
 // submitTracked submits commands with non-blocking tracking.
@@ -1463,6 +1534,7 @@ func (r *Renderer) ReleaseInstance() {
 
 // destroy releases all resources owned by this window surface.
 func (ws *RenderTarget) destroy() {
+	ws.discardFrameEncoder()
 	if ws.currentView != nil {
 		ws.currentView.Release()
 		ws.currentView = nil


### PR DESCRIPTION
## Summary

Implements the frame-encoder ownership seam proposed by @kolkov for #393.

`Context.CommandEncoder()` now returns a borrowed, framework-owned encoder for the active surface frame. External renderers can append passes to it, while gogpu remains the sole owner of finish/submit/present.

## Changes

- lazily creates one command encoder per active surface frame
- reuses it across external renderers and submits it exactly once in `EndFrame`
- exposes the encoder through `ContextRenderTarget` as an optional opaque `gpucontext.CommandEncoder` capability
- records a deferred clear before returning the encoder, preserving draw-call order
- discards unsubmitted encoders on pixel-present, cancelled-frame, surface-destroy, and teardown paths
- adds noop-HAL tests for reuse, ordering, capability forwarding, and one-submit ownership

## Coordinated stack

- **frame owner:** this PR
- **g3d recording API:** [gogpu/g3d#12](https://github.com/gogpu/g3d/pull/12)
- **ggcanvas borrowed encoder:** [gogpu/gg#454](https://github.com/gogpu/gg/pull/454)

The g3d and gg PRs add optional APIs with no dependency on this unreleased gogpu API, so they can merge independently. This PR activates the whole path automatically through `ContextRenderTarget`.

## Testing

- `CGO_ENABLED=0 go test -count=1 ./...`
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go test -race -count=1 .`
- local compile-only integration module combining gogpu + g3d `RenderTo` + ggcanvas in one encoder

Refs #393