### PR TITLE
fix(x11): prefer server keyboard mapping when remote

### DIFF
--- a/internal/platform/x11/keyboard_source_test.go
+++ b/internal/platform/x11/keyboard_source_test.go
@@ -1,0 +1,76 @@
+//go:build linux
+
+package x11
+
+import (
+	"testing"
+
+	"github.com/gogpu/gogpu/internal/platform/eventqueue"
+	"github.com/gogpu/gpucontext"
+)
+
+func TestShouldPreferServerKeymap(t *testing.T) {
+	tests := []struct {
+		name     string
+		display  string
+		vendor   string
+		xwayland bool
+		want     bool
+	}{
+		{name: "local Xorg", display: ":0", vendor: "The X.Org Foundation"},
+		{name: "explicit local unix", display: "unix:0", vendor: "The X.Org Foundation"},
+		{name: "SSH forwarding", display: "localhost:10.0", vendor: "The X.Org Foundation", want: true},
+		{name: "remote TCP", display: "workstation.example:0", vendor: "The X.Org Foundation", want: true},
+		{name: "XQuartz vendor", display: ":0", vendor: "The XQuartz Project", want: true},
+		{name: "legacy Apple vendor", display: ":0", vendor: "Apple Computer, Inc.", want: true},
+		{name: "XWayland", display: ":1", vendor: "The X.Org Foundation", xwayland: true, want: true},
+		{name: "invalid display", display: "not-a-display", vendor: "The X.Org Foundation"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldPreferServerKeymap(tt.display, tt.vendor, tt.xwayland); got != tt.want {
+				t.Fatalf("shouldPreferServerKeymap(%q, %q, %v) = %v, want %v",
+					tt.display, tt.vendor, tt.xwayland, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDispatchServerKeymapText(t *testing.T) {
+	keymap := &KeyboardMapping{
+		MinKeycode:     38,
+		MaxKeycode:     38,
+		KeysymsPerCode: 2,
+		Keysyms:        []Keysym{'a', 'A'},
+	}
+	w := &x11Window{events: eventqueue.New[PlatformEvent](eventqueue.DefaultCapacity)}
+
+	if !dispatchServerKeymapText(w, keymap, 38, gpucontext.ModShift, 0) {
+		t.Fatal("dispatchServerKeymapText did not dispatch a printable keysym")
+	}
+	event, ok := w.events.Pop()
+	if !ok {
+		t.Fatal("character event was not queued")
+	}
+	if event.Type != EventTypeChar || event.Char != 'A' {
+		t.Fatalf("event = {Type: %v, Char: %q}, want EventTypeChar 'A'", event.Type, event.Char)
+	}
+}
+
+func TestDispatchServerKeymapTextRejectsNonPrintable(t *testing.T) {
+	keymap := &KeyboardMapping{
+		MinKeycode:     67,
+		MaxKeycode:     67,
+		KeysymsPerCode: 1,
+		Keysyms:        []Keysym{KeysymF1},
+	}
+	w := &x11Window{events: eventqueue.New[PlatformEvent](eventqueue.DefaultCapacity)}
+
+	if dispatchServerKeymapText(w, keymap, 67, 0, 0) {
+		t.Fatal("dispatchServerKeymapText dispatched a non-printable keysym")
+	}
+	if _, ok := w.events.Pop(); ok {
+		t.Fatal("non-printable keysym queued an event")
+	}
+}

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -191,6 +191,12 @@ type Platform struct {
 	// _XKB_RULES_NAMES is unreliable under XWayland (freedesktop#612).
 	isXWayland bool
 
+	// preferServerKeymap selects the mapping advertised by the connected X
+	// server before host-local xkbcommon. This is required when the server and
+	// client hosts can have different keyboard configuration (X forwarding,
+	// XQuartz, and XWayland).
+	preferServerKeymap bool
+
 	// DPI scale factor (from Xft.dpi or screen physical size) — process-level
 	scaleFactor float64
 
@@ -386,11 +392,20 @@ func (p *Platform) Init(config Config) error {
 	if p.isXWayland {
 		logger().Info("XWayland detected — _XKB_RULES_NAMES may be unreliable")
 	}
+	vendor := ""
+	if setup := conn.Setup(); setup != nil {
+		vendor = setup.Vendor
+	}
+	p.preferServerKeymap = shouldPreferServerKeymap(os.Getenv("DISPLAY"), vendor, p.isXWayland)
 
 	// Load libxkbcommon for proper text input (AltGr, dead keys, multi-layout).
 	// First try RMLVO from _XKB_RULES_NAMES, then system defaults.
 	// Non-fatal: falls back to manual KeycodeToKeysymGroup (no AltGr support).
-	p.initXkbcommon()
+	if p.preferServerKeymap {
+		logger().Info("using X server keyboard mapping", "DISPLAY", os.Getenv("DISPLAY"), "vendor", vendor)
+	} else {
+		p.initXkbcommon()
+	}
 
 	// Initialize XInput2 for touch support (non-fatal)
 	xi, err := conn.InitXInput2()
@@ -1320,6 +1335,7 @@ func (p *Platform) handleUnknownEvent(e *UnknownEvent) {
 // SDL3 uses the same fallback pattern.
 // BUG-INPUT-005: Now uses full state sync (modifiers + group) instead of group-only.
 func (p *Platform) handleMappingNotify() {
+	p.reloadServerKeymap()
 	if p.xkb == nil {
 		return
 	}
@@ -1351,6 +1367,8 @@ func (p *Platform) handleMappingNotify() {
 // Called on XkbNewKeyboardNotify (keyboard hot-plug) and XkbMapNotify (keymap changed).
 // BUG-INPUT-005: Handles layout reconfiguration without restart.
 func (p *Platform) reloadXkbKeymap() {
+	p.reloadServerKeymap()
+
 	p.mu.Lock()
 	xkbState := p.xkbState
 	p.mu.Unlock()
@@ -1386,14 +1404,23 @@ func (p *Platform) reloadXkbKeymap() {
 			p.mu.Unlock()
 		}
 	}
+}
 
-	// Also re-read keyboard mapping for the fallback path.
-	keymap, _ := p.conn.GetKeyboardMapping()
-	if keymap != nil {
-		p.mu.Lock()
-		p.keymap = keymap
-		p.mu.Unlock()
+// reloadServerKeymap refreshes the pure-Go core mapping after the X server
+// reports a keyboard configuration change. XQuartz rewrites this mapping when
+// the macOS input source changes, so it must be refreshed independently of XKB.
+func (p *Platform) reloadServerKeymap() {
+	if p.conn == nil {
+		return
 	}
+	keymap, err := p.conn.GetKeyboardMapping()
+	if err != nil {
+		logger().Warn("failed to refresh X server keyboard mapping", "err", err)
+		return
+	}
+	p.mu.Lock()
+	p.keymap = keymap
+	p.mu.Unlock()
 }
 
 // handleXITouchEvent processes an XI2 touch event and dispatches it as a PointerEvent.
@@ -1708,20 +1735,29 @@ func (p *Platform) handleKeyEvent(w *x11Window, keycode uint8, state uint16, pre
 	// Evdev keycode for xkbcommon: X11 keycode - 8
 	evdevKey := uint32(keycode) - 8
 
-	// Text input: use xkbcommon if available (handles AltGr/Level3 correctly).
-	// Fallback to manual KeycodeToKeysymGroup (no AltGr support).
+	// Text input uses the connected server's mapping for remote/compatibility
+	// servers, otherwise xkbcommon with the server mapping as fallback.
 	p.mu.Lock()
 	xkbState := p.xkbState
 	keymap := p.keymap
+	group := p.xkbGroup
+	preferServerKeymap := p.preferServerKeymap
 	p.mu.Unlock()
 
 	if pressed {
 		dispatched := false
 
+		// Remote and compatibility X servers own the effective keymap. Consulting
+		// their wire-protocol mapping first avoids translating with an unrelated
+		// client-host layout.
+		if preferServerKeymap {
+			dispatched = dispatchServerKeymapText(w, keymap, keycode, mods, group)
+		}
+
 		// Primary: xkbcommon (handles AltGr/Level3 and all layouts correctly).
 		// State is synced via UpdateMask from XkbStateNotify events (winit pattern).
 		// Do NOT call UpdateKey here — winit never does on X11.
-		if xkbState != nil && xkbState.Ready() {
+		if !dispatched && xkbState != nil && xkbState.Ready() {
 			s := xkbState.KeyGetUtf8(evdevKey)
 			if s != "" {
 				for _, r := range s {
@@ -1736,18 +1772,45 @@ func (p *Platform) handleKeyEvent(w *x11Window, keycode uint8, state uint16, pre
 		// Fallback: manual lookup with group-aware keysym resolution.
 		// Covers cases where xkb_keymap_new_from_names(NULL) doesn't include
 		// the user's configured layouts (e.g., Russian via desktop settings).
-		if !dispatched && keymap != nil {
-			p.mu.Lock()
-			group := p.xkbGroup
-			p.mu.Unlock()
-			shift := mods&gpucontext.ModShift != 0
-			capsLock := mods&gpucontext.ModCapsLock != 0
-			keysym := keymap.KeycodeToKeysymGroup(keycode, shift, capsLock, group)
-			if r, ok := KeysymToRune(keysym); ok && r >= 32 {
-				w.queueEvent(PlatformEvent{Type: EventTypeChar, Char: r})
-			}
+		if !dispatched {
+			dispatchServerKeymapText(w, keymap, keycode, mods, group)
 		}
 	}
+}
+
+func dispatchServerKeymapText(
+	w *x11Window,
+	keymap *KeyboardMapping,
+	keycode uint8,
+	mods gpucontext.Modifiers,
+	group int,
+) bool {
+	if keymap == nil {
+		return false
+	}
+	shift := mods&gpucontext.ModShift != 0
+	capsLock := mods&gpucontext.ModCapsLock != 0
+	keysym := keymap.KeycodeToKeysymGroup(keycode, shift, capsLock, group)
+	r, ok := KeysymToRune(keysym)
+	if !ok || r < 32 {
+		return false
+	}
+	w.queueEvent(PlatformEvent{Type: EventTypeChar, Char: r})
+	return true
+}
+
+// shouldPreferServerKeymap reports whether host-local keyboard configuration
+// can differ from the connected X server's effective mapping.
+func shouldPreferServerKeymap(display, vendor string, xwayland bool) bool {
+	if xwayland {
+		return true
+	}
+	vendor = strings.ToLower(vendor)
+	if strings.Contains(vendor, "xquartz") || strings.Contains(vendor, "apple") {
+		return true
+	}
+	host, _, _, err := parseDisplay(display)
+	return err == nil && host != "" && !strings.EqualFold(host, "unix")
 }
 
 // x11KeycodeToKey converts an X11 keycode to a gpucontext.Key.


### PR DESCRIPTION
## Summary

Fixes X11 text translation when the client host's keyboard configuration is not authoritative: X forwarding, XQuartz, and XWayland.

Thanks @unxed for pointing to keytrans and its fallback-first design. I evaluated direct integration, but keytrans currently requires a `*xgb.Conn`; gogpu owns a separate pure-Go X11 wire connection, so adopting it directly would add a second X connection/event owner plus overlapping protocol dependencies.

This PR applies the same core principle at gogpu's existing ownership seam instead:

- prefer the connected X server's `GetKeyboardMapping` data for remote `DISPLAY` hosts, XQuartz vendors, and XWayland
- keep xkbcommon as the richer primary translator on native local Xorg
- refresh the server mapping on both core `MappingNotify` and XKB keymap notifications
- refresh the pure-Go mapping even when XKB/xkbcommon is unavailable
- add no dependency and preserve `CGO_ENABLED=0`

This matters for XQuartz in particular because its effective core keymap can be rewritten when the macOS input source changes; a client-host xkbcommon keymap can be valid but wrong.

## Testing

- table tests for local Xorg, remote TCP/SSH `DISPLAY`, XQuartz/Apple vendors, XWayland, and malformed displays
- server-keymap printable/non-printable dispatch tests
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -c -o /dev/null ./internal/platform/x11`
- `CGO_ENABLED=0 go test -count=1 ./...`
- `CGO_ENABLED=0 go build ./...`

Physical XQuartz and SSH-forwarding validation remains valuable after CI, but the selection and refresh policy is deterministic and covered.

Closes #279
