### PR TITLE
feat: App.RequestSize for runtime window resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`App.RequestSize(width, height)`** (#397) — programmatic window resize at runtime. All 5 platforms: Windows (DPI-aware `SetWindowPos`), macOS (`setContentSize:` + unzoom), X11 (`_NET_WM_STATE` remove-maximize + `ConfigureWindow`), Wayland (advisory min=max trick, SDL3 pattern), Browser (CSS + drawingBuffer). Min/max constraint clamping, fullscreen guard, maximized restore (winit pattern). Requested by @unxed for f4 file manager.
+- **`Context.CommandEncoder()`** (#393, #394, @besmpl) — frame-owned lazy command encoder. External renderers (g3d) record passes into a borrowed encoder; gogpu remains sole owner of finish/submit/present. Single `queue.Submit()` per frame eliminates Intel Vulkan VK_ERROR_DEVICE_LOST on multi-pass compositing.
+- **`ContextRenderTarget.PreserveContent()`** (#390, #391) — exposes `MarkExternalContent` state through the render-target adapter so ggcanvas preserves earlier renderer's surface content.
+
+### Fixed
+
+- **X11 remote keyboard mapping** (#279, #395, @unxed) — X forwarding, XQuartz, XWayland now prefer server-side XKB keymap over client host config. `serverHasXkb()` probe, fallback to `xcb_key_symbols` when XKB unavailable.
+- **macOS `SetSize` content area** — changed from `setFrame:` (outer frame including title bar) to `setContentSize:` (inner content area). Previously, requested size was reduced by the title bar height. winit pattern (window_delegate.rs:1085).
+
 ## [0.45.1] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Built on [gogpu/wgpu](https://github.com/gogpu/wgpu) — the unified Go WebGPU p
 | **Graphics API** | Runtime selection: Vulkan, DX12, Metal, GLES, Software |
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal), Browser/WASM (WebGPU) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), zero-copy surface rendering, damage-aware presentation |
-| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), GPU adapter power preference, native macOS window tabbing, native system menus (macOS + Windows), native file dialogs (macOS + Windows + Linux D-Bus/zenity/kdialog) |
+| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, runtime window resize (`RequestSize`), mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), OS drag-and-drop (all 4 desktop platforms), GPU adapter power preference, native macOS window tabbing, native system menus (macOS + Windows), native file dialogs (macOS + Windows + Linux D-Bus/zenity/kdialog) |
 | **Scroll** | ScrollPhase + IsMomentum for macOS trackpad momentum detection (ADR-032), pixel/line/page delta modes |
 | **Sound** | Platform system sounds for UI feedback (winmm, NSSound, canberra/PulseAudio) |
 | **Compute** | Full compute shader support |
@@ -287,6 +287,7 @@ This eliminates the GPU→CPU→GPU round-trip when integrating with gg/ggcanvas
 w, h := app.Size()              // logical points (DIP)
 fw, fh := app.PhysicalSize()    // physical pixels (framebuffer)
 scale := app.ScaleFactor()      // 1.0 = standard, 2.0 = Retina/HiDPI
+app.RequestSize(1024, 768)      // resize at runtime (all platforms, DPI-aware)
 
 // Clipboard
 text, _ := app.ClipboardRead()

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,9 +25,12 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.45.1
+## Current State: v0.45.x
 
 ✅ **Production-ready** with full feature set:
+- **Runtime window resize** (#397) — `App.RequestSize(width, height)` on all 5 platforms (winit/SDL3 patterns, DPI-aware, maximized restore)
+- **Single-encoder compositing** (#393, @besmpl) — frame-owned `CommandEncoder()` for multi-pass rendering (g3d + gg overlay, single queue submit)
+- **OS drag-and-drop** (#387) — all 4 desktop platforms (Windows WM_DROPFILES, X11 XDND v5, macOS NSDragging, Wayland wl_data_device)
 - **CSD maximize/fullscreen geometry** (#300) — 5 bugs fixed (enterprise research: GTK4, winit/SCTK, SDL3/libdecor). Negative offset geometry model, fullscreen state parsing, decoration lifecycle.
 - **Hidden-then-show window creation** — GLFW/Ebiten/SDL3/Flutter pattern: window created hidden, shown after GPU init. Eliminates black flash and WM_SETFOCUS race on all platforms.
 - **Universal App Lifecycle** — RenderTarget, QuitOnLastWindowClosed, AppLifecycle enum (5 states), surface/lifecycle callbacks (ADR-026, Phases 1-3)

--- a/app.go
+++ b/app.go
@@ -282,6 +282,36 @@ func (a *App) SetMaxSize(width, height int) {
 	}
 }
 
+// RequestSize requests the primary window to resize its content area to the
+// given logical size in DIP (device-independent pixels). Non-positive dimensions
+// are ignored. The size is clamped to any configured min/max constraints.
+// The request is ignored when the window is in fullscreen mode. On Wayland,
+// this is advisory — the compositor may reject the request for tiled windows.
+func (a *App) RequestSize(width, height int) {
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	// Clamp to constraints.
+	if a.config.MinWidth > 0 && width < a.config.MinWidth {
+		width = a.config.MinWidth
+	}
+	if a.config.MinHeight > 0 && height < a.config.MinHeight {
+		height = a.config.MinHeight
+	}
+	if a.config.MaxWidth > 0 && width > a.config.MaxWidth {
+		width = a.config.MaxWidth
+	}
+	if a.config.MaxHeight > 0 && height > a.config.MaxHeight {
+		height = a.config.MaxHeight
+	}
+
+	// Dispatch to primary window.
+	if a.primaryWindow != nil && a.primaryWindow.platWindow != nil {
+		a.primaryWindow.platWindow.RequestSize(width, height)
+	}
+}
+
 // TrackResource registers an io.Closer for automatic cleanup during shutdown.
 // Tracked resources are closed in LIFO (reverse) order after WaitIdle and
 // before the renderer is destroyed, so the GPU device is still alive.

--- a/app_test.go
+++ b/app_test.go
@@ -1134,6 +1134,121 @@ func TestAppSetMinMaxSizeNilPlatform(t *testing.T) {
 	}
 }
 
+func TestRequestSize_ClampsToConstraints(t *testing.T) {
+	mock := &mockWindow{width: 800, height: 600}
+	wm := newWindowManager()
+	id := wm.allocate()
+	pw := &Window{
+		id:         id,
+		platWindow: mock,
+	}
+	wm.add(pw)
+
+	app := &App{
+		config:        Config{MinWidth: 200, MinHeight: 150, MaxWidth: 1920, MaxHeight: 1080},
+		primaryWindow: pw,
+		windowManager: wm,
+	}
+
+	tests := []struct {
+		name       string
+		w, h       int
+		wantW      int
+		wantH      int
+		wantCalled bool
+	}{
+		{"within bounds", 640, 480, 640, 480, true},
+		{"clamp to min width", 100, 480, 200, 480, true},
+		{"clamp to min height", 640, 100, 640, 150, true},
+		{"clamp to max width", 2000, 480, 1920, 480, true},
+		{"clamp to max height", 640, 2000, 640, 1080, true},
+		{"clamp both min", 50, 50, 200, 150, true},
+		{"clamp both max", 3000, 3000, 1920, 1080, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock.width = 800
+			mock.height = 600
+			app.RequestSize(tt.w, tt.h)
+			if mock.width != tt.wantW || mock.height != tt.wantH {
+				t.Errorf("got %dx%d, want %dx%d", mock.width, mock.height, tt.wantW, tt.wantH)
+			}
+		})
+	}
+}
+
+func TestRequestSize_SkipsNegativeAndZero(t *testing.T) {
+	mock := &mockWindow{width: 800, height: 600}
+	wm := newWindowManager()
+	id := wm.allocate()
+	pw := &Window{
+		id:         id,
+		platWindow: mock,
+	}
+	wm.add(pw)
+
+	app := &App{
+		config:        DefaultConfig(),
+		primaryWindow: pw,
+		windowManager: wm,
+	}
+
+	tests := []struct {
+		name string
+		w, h int
+	}{
+		{"zero width", 0, 600},
+		{"zero height", 800, 0},
+		{"negative width", -100, 600},
+		{"negative height", 800, -50},
+		{"both zero", 0, 0},
+		{"both negative", -1, -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock.width = 800
+			mock.height = 600
+			app.RequestSize(tt.w, tt.h)
+			// Size should NOT change — request ignored
+			if mock.width != 800 || mock.height != 600 {
+				t.Errorf("got %dx%d, want 800x600 (unchanged)", mock.width, mock.height)
+			}
+		})
+	}
+}
+
+func TestRequestSize_NilPlatformNoPanic(t *testing.T) {
+	app := NewApp(DefaultConfig())
+
+	// Must not panic when primaryWindow is nil
+	app.RequestSize(800, 600)
+}
+
+func TestRequestSize_NoConstraints(t *testing.T) {
+	mock := &mockWindow{width: 800, height: 600}
+	wm := newWindowManager()
+	id := wm.allocate()
+	pw := &Window{
+		id:         id,
+		platWindow: mock,
+	}
+	wm.add(pw)
+
+	// No min/max constraints (all zero)
+	app := &App{
+		config:        Config{},
+		primaryWindow: pw,
+		windowManager: wm,
+	}
+
+	app.RequestSize(3840, 2160)
+	if mock.width != 3840 || mock.height != 2160 {
+		t.Errorf("got %dx%d, want 3840x2160", mock.width, mock.height)
+	}
+}
+
 // configCapturingManager wraps mockManager and records the Config passed to CreateWindow.
 type configCapturingManager struct {
 	mockManager

--- a/internal/platform/darwin/selectors.go
+++ b/internal/platform/darwin/selectors.go
@@ -215,8 +215,9 @@ var selectors struct {
 	setTabbingIdentifier SEL
 
 	// Window size constraints
-	setMinSize SEL
-	setMaxSize SEL
+	setMinSize     SEL
+	setMaxSize     SEL
+	setContentSize SEL
 
 	// NSDragging protocol (drag-and-drop)
 	draggingLocation        SEL
@@ -467,6 +468,7 @@ func initSelectors() {
 		// Window size constraints
 		selectors.setMinSize = RegisterSelector("setMinSize:")
 		selectors.setMaxSize = RegisterSelector("setMaxSize:")
+		selectors.setContentSize = RegisterSelector("setContentSize:")
 
 		// NSDragging protocol (drag-and-drop)
 		selectors.draggingLocation = RegisterSelector("draggingLocation")

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -265,7 +265,9 @@ func (w *Window) Size() (width, height int) {
 	return w.width, w.height
 }
 
-// SetSize sets the window content size.
+// SetSize sets the window content size using setContentSize: (inner size).
+// This correctly handles the title bar height — unlike setFrame: which sets
+// the outer window frame and would shrink the content area by the title bar.
 func (w *Window) SetSize(width, height int) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -277,19 +279,11 @@ func (w *Window) SetSize(width, height int) {
 	w.width = width
 	w.height = height
 
-	// Get current frame
-	frame := w.nsWindow.GetRect(selectors.frame)
-
-	// Create new frame with updated size
-	newFrame := MakeRect(
-		frame.Origin.X,
-		frame.Origin.Y,
-		CGFloat(width),
-		CGFloat(height),
-	)
-
-	// Set frame with display
-	w.nsWindow.SendRect(selectors.setFrame, newFrame)
+	// Use setContentSize: to set the inner content area.
+	// This is the correct API — setFrame: sets the outer frame including
+	// the title bar, which would make the content area smaller than requested.
+	// winit uses setContentSize: for the same reason (window_delegate.rs:1085-1089).
+	w.nsWindow.SendSize(selectors.setContentSize, MakeSize(CGFloat(width), CGFloat(height)))
 }
 
 // ShouldClose returns true if the window should close.
@@ -923,6 +917,36 @@ func (w *Window) SetOnClose(fn func() bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.onClose = fn
+}
+
+// RequestSize sets the window content size to the given logical dimensions.
+// Skips if fullscreen or zoomed (maximized). Uses setContentSize: which
+// correctly handles the title bar (inner size, not outer frame).
+func (w *Window) RequestSize(width, height int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	// Skip if fullscreen — the compositor owns the size.
+	mask := uintptr(w.nsWindow.Send(selectors.styleMask))
+	if mask&uintptr(NSWindowStyleMaskFullScreen) != 0 {
+		return
+	}
+
+	// Restore from zoomed state before resizing (winit pattern).
+	// macOS "zoom" is analogous to Windows maximize — the caller asked for a
+	// specific size, so zoomed state should yield.
+	if w.nsWindow.Send(selectors.isZoomed) != 0 {
+		w.nsWindow.SendPtr(selectors.zoom, 0)
+	}
+
+	w.width = width
+	w.height = height
+
+	w.nsWindow.SendSize(selectors.setContentSize, MakeSize(CGFloat(width), CGFloat(height)))
 }
 
 // ScreenChangedCh returns a receive-only channel that is signaled when the

--- a/internal/platform/menu_linux_test.go
+++ b/internal/platform/menu_linux_test.go
@@ -570,6 +570,7 @@ func (s *stubWindow) ShouldClose() bool                                         
 func (s *stubWindow) SetTitle(_ string)                                                    {}
 func (s *stubWindow) SetMinSize(_, _ int)                                                  {}
 func (s *stubWindow) SetMaxSize(_, _ int)                                                  {}
+func (s *stubWindow) RequestSize(_, _ int)                                                 {}
 func (s *stubWindow) SetCursor(_ int)                                                      {}
 func (s *stubWindow) SetFrameless(_ bool)                                                  {}
 func (s *stubWindow) IsFrameless() bool                                                    { return false }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -273,6 +273,12 @@ type PlatformWindow interface {
 	// SetModalFrameCallback registers a callback for platform modal operations.
 	SetModalFrameCallback(fn func())
 
+	// RequestSize requests the window to resize its content area to the given
+	// logical size in DIP (device-independent pixels). The request is ignored
+	// when the window is in fullscreen mode. On Wayland, this is advisory —
+	// the compositor may reject the request for tiled/maximized windows.
+	RequestSize(width, height int)
+
 	// Destroy releases native window resources.
 	Destroy()
 }

--- a/internal/platform/platform_browser.go
+++ b/internal/platform/platform_browser.go
@@ -390,6 +390,20 @@ func (w *browserWindow) SetMinSize(_, _ int) {}
 // SetMaxSize is a no-op on browser — window sizing is controlled by the page.
 func (w *browserWindow) SetMaxSize(_, _ int) {}
 
+// RequestSize sets the canvas element dimensions to the given logical size (DIP).
+// Adjusts both the CSS layout size and the canvas drawing buffer for HiDPI.
+func (w *browserWindow) RequestSize(width, height int) {
+	dpr := js.Global().Get("devicePixelRatio").Float()
+	if dpr <= 0 {
+		dpr = 1.0
+	}
+	style := w.canvas.Get("style")
+	style.Set("width", js.ValueOf(fmt.Sprintf("%dpx", width)))
+	style.Set("height", js.ValueOf(fmt.Sprintf("%dpx", height)))
+	w.canvas.Set("width", int(float64(width)*dpr))
+	w.canvas.Set("height", int(float64(height)*dpr))
+}
+
 // SetFrameless is a no-op on browser — there's no OS window chrome.
 func (w *browserWindow) SetFrameless(_ bool) {}
 

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -435,6 +435,15 @@ func (dw *darwinPlatformWindow) SetMaxSize(width, height int) {
 	}
 }
 
+// RequestSize resizes the window's content area to the given logical size.
+// Delegates to darwin.Window.RequestSize which uses setContentSize: and
+// skips fullscreen/zoomed windows.
+func (dw *darwinPlatformWindow) RequestSize(width, height int) {
+	if dw.window != nil {
+		dw.window.RequestSize(width, height)
+	}
+}
+
 func (dw *darwinPlatformWindow) PrepareFrame() PrepareFrameResult {
 	if dw.window == nil {
 		return PrepareFrameResult{ScaleFactor: 1.0}

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -523,6 +523,7 @@ func (w *x11PlatformWindow) InSizeMove() bool               { return false }
 func (w *x11PlatformWindow) SetTitle(title string)          { w.inner().SetTitle(title) }
 func (w *x11PlatformWindow) SetMinSize(width, height int)   { w.inner().SetMinSize(width, height) }
 func (w *x11PlatformWindow) SetMaxSize(width, height int)   { w.inner().SetMaxSize(width, height) }
+func (w *x11PlatformWindow) RequestSize(width, height int)  { w.inner().RequestSize(width, height) }
 func (w *x11PlatformWindow) SetCursor(cursorID int)         { w.inner().SetCursor(cursorID) }
 func (w *x11PlatformWindow) SetCursorMode(mode int)         { w.inner().SetCursorMode(mode) }
 func (w *x11PlatformWindow) CursorMode() int                { return w.inner().GetCursorMode() }
@@ -701,6 +702,45 @@ func (w *waylandPlatformWindow) SetMinSize(width, height int) {
 func (w *waylandPlatformWindow) SetMaxSize(width, height int) {
 	if libwl := w.libwayland(); libwl != nil {
 		libwl.SetMaxSize(int32(width), int32(height))
+		_ = libwl.Flush()
+	}
+}
+
+// RequestSize requests the compositor to resize the window's content area.
+// This is advisory — the compositor may reject it for maximized, fullscreen,
+// or tiled windows. On Wayland the client cannot force a window size; only
+// the compositor decides the final geometry via xdg_toplevel.configure.
+func (w *waylandPlatformWindow) RequestSize(width, height int) {
+	var wp *waylandWindow
+	if w.secondary != nil {
+		wp = &w.secondary.state
+	} else {
+		wp = w.platform.primary
+	}
+
+	wp.eventMu.Lock()
+	isMax := wp.maximized
+	isFS := wp.fullscreen
+	if !isMax && !isFS {
+		wp.width = width
+		wp.height = height
+	}
+	wp.eventMu.Unlock()
+
+	// Compositor owns the size in maximized/fullscreen — skip.
+	if isMax || isFS {
+		return
+	}
+
+	// Temporarily set min==max==desired to signal the compositor. Then
+	// restore 0,0 so the window remains freely resizable after the
+	// compositor applies the requested size.
+	if libwl := w.libwayland(); libwl != nil {
+		libwl.SetMinSize(int32(width), int32(height))
+		libwl.SetMaxSize(int32(width), int32(height))
+		_ = libwl.Flush()
+		libwl.SetMinSize(0, 0)
+		libwl.SetMaxSize(0, 0)
 		_ = libwl.Flush()
 	}
 }

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -134,6 +134,7 @@ func (m *mockPlatformWindow) InSizeMove() bool                 { return false }
 func (m *mockPlatformWindow) SetTitle(string)                  {}
 func (m *mockPlatformWindow) SetMinSize(int, int)              {}
 func (m *mockPlatformWindow) SetMaxSize(int, int)              {}
+func (m *mockPlatformWindow) RequestSize(int, int)             {}
 func (m *mockPlatformWindow) PrepareFrame() PrepareFrameResult { return PrepareFrameResult{} }
 func (m *mockPlatformWindow) SetCursor(int)                    {}
 func (m *mockPlatformWindow) SetCursorMode(int)                {}

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -953,6 +953,58 @@ func (w *win32Window) IsFullscreen() bool {
 	return w.fullscreen
 }
 
+// RequestSize resizes the window's content area to the given logical size in DIP.
+// Ignores the request when fullscreen. If the window is maximized, it is restored
+// first (winit pattern). The window position is preserved (SWP_NOMOVE).
+func (w *win32Window) RequestSize(width, height int) {
+	if w.fullscreen {
+		return
+	}
+
+	// Clamp to constraints.
+	w.sizeMu.RLock()
+	if w.minWidth > 0 && width < w.minWidth {
+		width = w.minWidth
+	}
+	if w.minHeight > 0 && height < w.minHeight {
+		height = w.minHeight
+	}
+	if w.maxWidth > 0 && width > w.maxWidth {
+		width = w.maxWidth
+	}
+	if w.maxHeight > 0 && height > w.maxHeight {
+		height = w.maxHeight
+	}
+	w.sizeMu.RUnlock()
+
+	// Restore from maximized state before resizing (winit pattern).
+	ret, _, _ := procIsZoomed.Call(uintptr(w.hwnd))
+	if ret != 0 {
+		procShowWindow.Call(uintptr(w.hwnd), swRestore)
+	}
+
+	// Scale logical DIP to physical pixels.
+	dpi, _, _ := procGetDpiForWindow.Call(uintptr(w.hwnd))
+	if dpi == 0 {
+		dpi = 96
+	}
+	scale := float64(dpi) / 96.0
+	physW := int32(float64(width) * scale)
+	physH := int32(float64(height) * scale)
+
+	// Add window frame to get outer dimensions.
+	style, _, _ := procGetWindowLongPtrW.Call(uintptr(w.hwnd), gwlStyle)
+	outerRect := rect{left: 0, top: 0, right: physW, bottom: physH}
+	adjustWindowRectForDpi(&outerRect, style, uint32(dpi))
+
+	outerW := uintptr(outerRect.right - outerRect.left)
+	outerH := uintptr(outerRect.bottom - outerRect.top)
+
+	procSetWindowPos.Call(uintptr(w.hwnd), 0, 0, 0,
+		outerW, outerH,
+		swpNoMove|swpNoZOrder|swpNoActivate)
+}
+
 func (w *win32Window) Close() {
 	procPostMessageW.Call(uintptr(w.hwnd), wmClose, 0, 0)
 }

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -1569,6 +1569,36 @@ func (p *Platform) SetMaxSize(width, height int) {
 	_ = p.conn.SetWMSizeHints(p.primary.window, 0, 0, width, height)
 }
 
+// RequestSize resizes the window's content area to the given logical size.
+// Skips if fullscreen. If maximized, sends _NET_WM_STATE remove-maximize
+// so the window manager releases the geometry constraint (winit pattern).
+func (p *Platform) RequestSize(width, height int) {
+	if p.primary == nil || p.conn == nil {
+		return
+	}
+	if p.IsFullscreen() {
+		return
+	}
+
+	// Remove maximize state so the WM allows the resize (winit pattern).
+	// Without this, KDE/GNOME/Sway silently ignore ConfigureWindow.
+	if err := p.conn.Unmaximize(p.primary.window, p.atoms); err != nil {
+		logger().Warn("x11: Unmaximize failed", "err", err)
+	}
+
+	// X11 uses physical pixels; scale logical → physical.
+	scale := p.ScaleFactor()
+	physW := uint16(float64(width) * scale)
+	physH := uint16(float64(height) * scale)
+
+	if err := p.conn.ResizeWindow(p.primary.window, physW, physH); err != nil {
+		logger().Warn("x11: RequestSize failed", "err", err)
+		return
+	}
+
+	_ = p.conn.Flush()
+}
+
 // Destroy closes the window and releases resources.
 func (p *Platform) Destroy() {
 	p.mu.Lock()

--- a/internal/platform/x11/window.go
+++ b/internal/platform/x11/window.go
@@ -366,6 +366,32 @@ func (c *Connection) ConfigureWindow(window ResourceID, x, y int16, width, heigh
 	return nil
 }
 
+// ResizeWindow changes only the width and height of a window without
+// altering its position. Uses ConfigureWindow with Width+Height value mask.
+func (c *Connection) ResizeWindow(window ResourceID, width, height uint16) error {
+	const (
+		ConfigWidth  = 1 << 2
+		ConfigHeight = 1 << 3
+	)
+
+	valueMask := uint16(ConfigWidth | ConfigHeight)
+
+	e := NewEncoder(c.byteOrder)
+	e.PutUint8(OpcodeConfigureWindow)
+	e.PutUint8(0)  // unused
+	e.PutUint16(5) // length: 3 header + 2 values = 5 4-byte units
+	e.PutUint32(uint32(window))
+	e.PutUint16(valueMask)
+	e.PutUint16(0) // unused
+	e.PutUint32(uint32(width))
+	e.PutUint32(uint32(height))
+
+	if _, err := c.sendRequest(e.Bytes()); err != nil {
+		return fmt.Errorf("x11: ResizeWindow failed: %w", err)
+	}
+	return nil
+}
+
 // GetGeometry gets window geometry.
 func (c *Connection) GetGeometry(drawable ResourceID) (x, y int16, width, height uint16, err error) {
 	e := NewEncoder(c.byteOrder)
@@ -548,6 +574,23 @@ func (c *Connection) SetFullscreen(window ResourceID, fullscreen bool, atoms *St
 
 	return c.SendClientMessage(window, c.RootWindow(), atoms.NetWMState,
 		action, uint32(atoms.NetWMStateFullscreen), 0, 0, 0)
+}
+
+// Unmaximize removes _NET_WM_STATE_MAXIMIZED_VERT and _HORZ via a client
+// message so the window manager releases its maximized geometry constraint.
+// Both atoms are sent in one message (data1 + data2) per EWMH spec.
+func (c *Connection) Unmaximize(window ResourceID, atoms *StandardAtoms) error {
+	if atoms.NetWMState == AtomNone {
+		return nil
+	}
+	if atoms.NetWMStateMaximizedVert == AtomNone || atoms.NetWMStateMaximizedHorz == AtomNone {
+		return nil
+	}
+	return c.SendClientMessage(window, c.RootWindow(), atoms.NetWMState,
+		0, // _NET_WM_STATE_REMOVE
+		uint32(atoms.NetWMStateMaximizedVert),
+		uint32(atoms.NetWMStateMaximizedHorz),
+		0, 0)
 }
 
 // SendClientMessage sends a ClientMessage event to a window.

--- a/platform_provider_test.go
+++ b/platform_provider_test.go
@@ -48,6 +48,7 @@ func (m *mockWindow) InSizeMove() bool              { return false }
 func (m *mockWindow) SetTitle(_ string)             {}
 func (m *mockWindow) SetMinSize(w, h int)           { m.minWidth = w; m.minHeight = h }
 func (m *mockWindow) SetMaxSize(w, h int)           { m.maxWidth = w; m.maxHeight = h }
+func (m *mockWindow) RequestSize(w, h int)          { m.width = w; m.height = h }
 func (m *mockWindow) SetModalFrameCallback(func())  {}
 func (m *mockWindow) Destroy()                      {}
 func (m *mockWindow) ScaleFactor() float64          { return m.scaleFactor }


### PR DESCRIPTION
## Summary

Adds `App.RequestSize(width, height int)` for programmatic window resizing at runtime. Closes #397.

Requested by @unxed for [f4 file manager](https://github.com/unxed/f4) — `Alt+F9` toggle between standard and enlarged viewports.

## Platform Coverage

| Platform | Implementation | Maximized behavior | Fullscreen | Reference |
|----------|---------------|-------------------|------------|-----------|
| **Windows** | `SetWindowPos` + DPI-aware `AdjustWindowRectForDpi` | Restore → resize (winit) | Skip | winit |
| **macOS** | `setContentSize:` (inner size, not outer frame) | Unzoom → resize (winit) | Skip | winit |
| **X11** | `_NET_WM_STATE` remove-maximize + `ConfigureWindow` | Remove maximize → resize | Skip | winit |
| **Wayland** | Advisory `min=max=desired`, flush, restore `0,0` | Skip (compositor-owned) | Skip | SDL3 |
| **Browser** | CSS size + canvas `drawingBuffer * dpr` | N/A | N/A | winit |

## Additional fix

macOS `SetSize` corrected from `setFrame:` to `setContentSize:` — the old code set the outer window frame including the title bar, making the content area smaller than requested.

## Changes

- `app.go` — public API with min/max constraint clamping
- `internal/platform/platform.go` — `RequestSize` added to `PlatformWindow` interface
- 5 platform implementations (Windows, macOS, X11, Wayland, Browser)
- `x11/window.go` — `Unmaximize()` and `ResizeWindow()` X11 protocol methods
- `darwin/selectors.go` — `setContentSize:` selector
- 4 test cases (clamping, negative/zero guard, nil safety, unconstrained)
- All mock interfaces updated (3 test files)

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test -count=1 ./...` — all pass
- [x] `golangci-lint run` — 0 issues (Windows, Linux, macOS)
- [x] `gofmt` — clean
- [ ] CI (ubuntu, macos, windows matrix)