### PR TITLE
fix(x11): convert pointer coordinates to logical DIP on HiDPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **X11 HiDPI mouse coordinates** (#398) — X11 pointer events delivered physical pixels instead of logical DIP, causing offset clicks on HiDPI displays. Added `physicalToLogical` conversion in all 5 pointer handlers (MotionNotify, ButtonPress, ButtonRelease, EnterNotify, LeaveNotify). All platforms now consistently deliver logical DIP matching `App.Size()`.
 - **X11 remote keyboard mapping** (#279, #395, @unxed) — X forwarding, XQuartz, XWayland now prefer server-side XKB keymap over client host config. `serverHasXkb()` probe, fallback to `xcb_key_symbols` when XKB unavailable.
 - **macOS `SetSize` content area** — changed from `setFrame:` (outer frame including title bar) to `setContentSize:` (inner content area). Previously, requested size was reduced by the title bar height. winit pattern (window_delegate.rs:1085).
 

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -1127,6 +1127,9 @@ func buttonsFromNumber(buttonNumber int64) gpucontext.Buttons {
 }
 
 // createPointerEvent creates a PointerEvent with common fields filled in.
+// createPointerEvent builds a PointerEvent from macOS NSEvent data.
+// Coordinates are already in logical points (NSEvent.locationInWindow) —
+// no DPI scaling needed. Consistent with App.Size() on all platforms.
 // Detects pen/tablet input from NSEvent subtype and sets PointerType,
 // Pressure, TiltX, TiltY, and Twist accordingly.
 func (w *darwinWindow) createPointerEvent(

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -530,6 +530,17 @@ func (p *Platform) ScaleFactor() float64 {
 	return p.scaleFactor
 }
 
+// physicalToLogical converts X11 physical pixel coordinates to logical DIP.
+// X11 events report physical pixels; all other platforms (Windows, macOS,
+// Wayland, Browser) deliver logical DIP coordinates. This conversion ensures
+// pointer events are consistent with App.Size() across all platforms.
+func (p *Platform) physicalToLogical(x, y float64) (float64, float64) {
+	if scale := p.ScaleFactor(); scale > 1.0 {
+		return x / scale, y / scale
+	}
+	return x, y
+}
+
 // queryScaleFactor determines the DPI scale factor using two methods:
 //  1. Xft.dpi from RESOURCE_MANAGER property on root window (most reliable, matches GLFW/Qt/GTK)
 //  2. Screen physical dimensions as fallback (pixels / mm * 25.4 / 96)
@@ -1013,8 +1024,9 @@ func (p *Platform) handleEvent(event Event) PlatformEvent {
 
 // handleMotionNotify processes mouse movement events.
 func (p *Platform) handleMotionNotify(w *x11Window, e *MotionNotifyEvent) {
-	x := float64(e.EventX)
-	y := float64(e.EventY)
+	// X11 reports physical pixels; convert to logical DIP to match
+	// App.Size() and all other platforms (Windows, macOS, Wayland, Browser).
+	x, y := p.physicalToLogical(float64(e.EventX), float64(e.EventY))
 
 	w.eventMu.Lock()
 	cursorMode := w.cursorMode
@@ -1054,8 +1066,7 @@ func (p *Platform) handleMotionNotify(w *x11Window, e *MotionNotifyEvent) {
 
 // handleButtonPress processes mouse button press events.
 func (p *Platform) handleButtonPress(w *x11Window, e *ButtonPressEvent) {
-	x := float64(e.EventX)
-	y := float64(e.EventY)
+	x, y := p.physicalToLogical(float64(e.EventX), float64(e.EventY))
 
 	// Scroll buttons (4-7) are emulated as button presses in X11
 	if isScrollButton(e.Detail) {
@@ -1128,8 +1139,7 @@ func (p *Platform) handleButtonPress(w *x11Window, e *ButtonPressEvent) {
 
 // handleButtonRelease processes mouse button release events.
 func (p *Platform) handleButtonRelease(w *x11Window, e *ButtonReleaseEvent) {
-	x := float64(e.EventX)
-	y := float64(e.EventY)
+	x, y := p.physicalToLogical(float64(e.EventX), float64(e.EventY))
 
 	// Scroll button releases are ignored (scroll is handled on press)
 	if isScrollButton(e.Detail) {
@@ -1196,8 +1206,7 @@ func (p *Platform) handleScrollButton(w *x11Window, detail uint8, x, y float64, 
 
 // handleEnterNotify processes pointer enter events.
 func (p *Platform) handleEnterNotify(w *x11Window, e *EnterNotifyEvent) {
-	x := float64(e.EventX)
-	y := float64(e.EventY)
+	x, y := p.physicalToLogical(float64(e.EventX), float64(e.EventY))
 
 	w.eventMu.Lock()
 	w.mouseX = x
@@ -1213,8 +1222,7 @@ func (p *Platform) handleEnterNotify(w *x11Window, e *EnterNotifyEvent) {
 
 // handleLeaveNotify processes pointer leave events.
 func (p *Platform) handleLeaveNotify(w *x11Window, e *LeaveNotifyEvent) {
-	x := float64(e.EventX)
-	y := float64(e.EventY)
+	x, y := p.physicalToLogical(float64(e.EventX), float64(e.EventY))
 
 	w.eventMu.Lock()
 	w.mouseX = x
@@ -2178,6 +2186,8 @@ func isScrollButton(detail uint8) bool {
 }
 
 // createPointerEvent creates a PointerEvent with common fields filled in.
+// Coordinates must be in logical DIP — callers convert from X11 physical
+// pixels via Platform.physicalToLogical before passing x/y here.
 func (w *x11Window) createPointerEvent(
 	eventType gpucontext.PointerEventType,
 	button gpucontext.Button,


### PR DESCRIPTION
## Summary

X11 pointer events delivered physical pixels while all other platforms deliver logical DIP. On HiDPI X11 displays (e.g., Mint Cinnamon 125%) this caused mouse click offset. Fixes #398.

## Root Cause

`handleMotionNotify`, `handleButtonPress`, `handleButtonRelease`, `handleEnterNotify`, `handleLeaveNotify` all extracted `float64(e.EventX)` directly without dividing by `ScaleFactor()`. Windows has this conversion at `createPointerEvent:2186-2190`, but X11 was missing it.

## Fix

Added `physicalToLogical(x, y)` helper that divides by `ScaleFactor()` (matching Windows pattern). Applied to all 5 pointer handlers at the point of coordinate extraction.

## Platform consistency after this fix

| Platform | Source | Conversion | Result |
|----------|--------|-----------|--------|
| Windows | `lParam` (physical) | ÷ `scaleFactor()` | Logical DIP |
| macOS | `locationInWindow` (logical) | None | Logical DIP |
| X11 | `EventX/EventY` (physical) | **÷ `ScaleFactor()`** (NEW) | Logical DIP |
| Wayland | `wl_pointer` (logical) | None | Logical DIP |
| Browser | `offsetX/offsetY` (CSS) | None | Logical DIP |

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `golangci-lint run` — 0 issues (3 platforms)
- [ ] CI matrix