### PR TITLE
release: v0.48.0 — runtime DPI scale change + atomic.Bool Quit (ADR-059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.0] - 2026-08-01
+
+### Added
+
+- **Runtime DPI/Scale Factor Change** (#409, ADR-059) — `EventScaleChanged` emitted on all 5 platforms when window moves between monitors with different DPI. Windows: `WM_DPICHANGED`. macOS: `lastScale` comparison in PollEvents. Wayland: `lastScale` tracking in PrepareFrame. X11/Browser: `lastScale` tracking. Event ordering: `ScaleChangedEvent` before `ResizeEvent` (winit pattern). Enterprise research: winit, Qt6, SDL3, Flutter.
+
+### Fixed
+
+- **`App.Quit()` thread safety** (#406, @jbunds) — `running` field changed from `bool` to `atomic.Bool` for safe cross-goroutine shutdown.
+
+### Changed
+
+- **deps:** gpucontext v0.23.0 → v0.24.0 (ScaleChangedEvent), wgpu v0.30.31 → v0.30.32
+
+## [0.48.0] - 2026-08-01
+
+### Added
+
+- **Runtime DPI/scale factor change** (#409, ADR-059) — `ScaleChangedEvent` emitted on all 5 platforms when window moves between monitors with different DPI or OS DPI settings change. Windows: `WM_DPICHANGED` → `EventScaleChanged` before `EventResize`. macOS: `lastScale` tracking in PollEvents. Wayland: `lastScale` in PrepareFrame with event queue emission. X11: `lastScale` tracking in PrepareFrame. Browser: `lastScale` for DPR-only changes (zoom). Enterprise research: winit, Qt6, SDL3, Flutter.
+
+### Fixed
+
+- **`App.Quit()` thread safety** (#406, @jbunds) — `running` field changed from `bool` to `atomic.Bool`. Safe to call `Quit()` from any goroutine (timer, signal handler, network callback).
+
+### Changed
+
+- **deps:** gpucontext v0.23.0 → v0.24.0 (ScaleChangedEvent), wgpu v0.30.31 → v0.30.32 (deps)
+
 ## [0.47.3] - 2026-08-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Built on [gogpu/wgpu](https://github.com/gogpu/wgpu) — the unified Go WebGPU p
 | **Sound** | Platform system sounds for UI feedback (winmm, NSSound, canberra/PulseAudio) |
 | **Compute** | Full compute shader support |
 | **Window Chrome** | Frameless windows with custom title bars, DWM shadow, hit-test regions |
-| **HiDPI** | Per-monitor DPI, WM_DPICHANGED, logical/physical coordinate split, WithSize in logical DIP (ADR-030) |
+| **HiDPI** | Per-monitor DPI, runtime DPI change (`ScaleChangedEvent` on all platforms), WM_DPICHANGED, logical/physical coordinate split, WithSize in logical DIP (ADR-030, ADR-059) |
 | **Integration** | DeviceProvider, WindowProvider, PlatformProvider, WindowChrome, SurfaceView |
 | **Logging** | Structured logging via `log/slog`, silent by default |
 | **Build** | Zero CGO with Pure Go backend |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,9 +25,10 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.47.0
+## Current State: v0.48.0
 
 ✅ **Production-ready** with full feature set:
+- **Runtime DPI/scale change** (#409, ADR-059) — `ScaleChangedEvent` on all 5 platforms. Multi-display HiDPI: window drag between Retina and FullHD. winit/Qt6/SDL3 patterns
 - **SDL-style event queue** (ADR-058) — `App.PollInputEvent()` with sealed `InputEvent` interface. Three coexisting input models: callbacks, polling, event queue. Research: Qt6, SDL3, winit, Flutter, Bevy, Gio, Ebiten
 - **Font smoothing OS detection** (#396, ADR-057) — `App.FontSmoothing()` returns None/Grayscale/Subpixel on all 5 platforms (Qt6 pattern)
 - **Runtime window resize** (#397) — `App.RequestSize(width, height)` on all 5 platforms (winit/SDL3 patterns, DPI-aware, maximized restore)

--- a/app.go
+++ b/app.go
@@ -855,6 +855,13 @@ func (a *App) classifyEvent(event *platform.Event, lastResize *platform.Event, s
 	case platform.EventScroll:
 		a.dispatchScrollEvent(event)
 		a.inputEvents = append(a.inputEvents, event.Scroll)
+	case platform.EventScaleChanged:
+		a.inputEvents = append(a.inputEvents, gpucontext.ScaleChangedEvent{
+			ScaleFactor: event.ScaleFactor,
+			Width:       event.Width,
+			Height:      event.Height,
+		})
+		a.RequestRedraw()
 	case platform.EventDragDrop:
 		if a.onFileDrop != nil {
 			a.onFileDrop(event.DragPaths, event.DragX, event.DragY)

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/go-webgpu/goffi v0.6.2
-	github.com/gogpu/gpucontext v0.23.0
+	github.com/gogpu/gpucontext v0.24.0
 	github.com/gogpu/gputypes v0.5.1
-	github.com/gogpu/wgpu v0.30.31
+	github.com/gogpu/wgpu v0.30.32
 	golang.org/x/sys v0.47.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,13 +2,13 @@ github.com/go-webgpu/goffi v0.6.2 h1:xuMaUbqsNQ/xiyy5UwAKZb5vQZUDg9QRCrJIpHJaXSE
 github.com/go-webgpu/goffi v0.6.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V4=
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
-github.com/gogpu/gpucontext v0.23.0 h1:DiqZfXk2x5mql76zLUToB6a352J6NoAuE25VZbT/D5g=
-github.com/gogpu/gpucontext v0.23.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
+github.com/gogpu/gpucontext v0.24.0 h1:YQ0FxGqXEO8LQB+6/TOqZOV1fn0mO9UDYR0obSU3R6o=
+github.com/gogpu/gpucontext v0.24.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
 github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.16 h1:SaDkx2laBNg1+nM25X91F7vopLalbI+MGn8diM9YB9Y=
 github.com/gogpu/naga v0.17.16/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.30.31 h1:B0dgqIt0LQuaqehsN2yqtzdyz+OppXWYAFl6ImtcprA=
-github.com/gogpu/wgpu v0.30.31/go.mod h1:j9Wk/jpiv17f7qykyOYqBwrakB4JszlalqKHN+/DMFM=
+github.com/gogpu/wgpu v0.30.32 h1:8TMX42EaVVEn4TN4OnbyVp9S4g7a+oMZBgeFFcSeRrY=
+github.com/gogpu/wgpu v0.30.32/go.mod h1:8EAEFC6oX/hx78+PwTSt20vKEQ+MpINdr4Xr3uEL/J4=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -62,6 +62,9 @@ type Event struct {
 	DragPaths []string // file paths (set on DragEnter and DragDrop)
 	DragX     float64  // drop/hover position in physical pixels
 	DragY     float64  // drop/hover position in physical pixels
+
+	// Scale factor (EventScaleChanged)
+	ScaleFactor float64
 }
 
 // EventType represents the type of platform event.
@@ -82,10 +85,11 @@ const (
 	EventPointerLeave
 	EventScroll
 	EventExpose
-	EventDragEnter // Files entered window area (OS file drag-and-drop)
-	EventDragMove  // Files moving over window
-	EventDragDrop  // Files dropped on window
-	EventDragLeave // Files left window area
+	EventDragEnter    // Files entered window area (OS file drag-and-drop)
+	EventDragMove     // Files moving over window
+	EventDragDrop     // Files dropped on window
+	EventDragLeave    // Files left window area
+	EventScaleChanged // DPI scale factor changed (ADR-059)
 )
 
 // PrepareFrameResult contains per-frame surface state from the platform layer.

--- a/internal/platform/platform_browser.go
+++ b/internal/platform/platform_browser.go
@@ -179,6 +179,7 @@ type browserWindow struct {
 	id          WindowID
 	canvas      js.Value
 	shouldClose bool
+	lastScale   float64 // DPI scale change detection (ADR-059)
 
 	// JS callbacks stored for cleanup.
 	jsCallbacks []js.Func
@@ -365,8 +366,11 @@ func (w *browserWindow) PrepareFrame() PrepareFrameResult {
 		w.canvas.Set("height", physH)
 	}
 
+	scaleChanged := w.lastScale != 0 && w.lastScale != dpr
+	w.lastScale = dpr
+
 	return PrepareFrameResult{
-		ScaleChanged:   changed,
+		ScaleChanged:   changed || scaleChanged,
 		ScaleFactor:    dpr,
 		PhysicalWidth:  uint32(physW),
 		PhysicalHeight: uint32(physH),

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -652,6 +652,20 @@ func (w *darwinWindow) pollEvents(app *darwin.Application) Event {
 			w.config.Height = newHeight
 			w.physW = newPhysW
 			w.physH = newPhysH
+
+			// Detect scale change — emit ScaleChanged before Resize (ADR-059).
+			newScale := w.window.BackingScaleFactor()
+			if w.lastScale != 0 && w.lastScale != newScale {
+				w.events.Push(Event{
+					WindowID:    w.id,
+					Type:        EventScaleChanged,
+					ScaleFactor: newScale,
+					Width:       newWidth,
+					Height:      newHeight,
+				})
+			}
+			w.lastScale = newScale
+
 			w.events.Push(Event{
 				WindowID:       w.id,
 				Type:           EventResize,

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -43,7 +43,8 @@ type waylandWindow struct {
 	height      int
 	shouldClose bool
 	configured  bool
-	activated   bool // xdg_toplevel Activated state (window manager focus)
+	activated   bool    // xdg_toplevel Activated state (window manager focus)
+	lastScale   float64 // DPI scale change detection (ADR-059)
 
 	// eventMu guards window state fields (shouldClose, maximized, fullscreen,
 	// width, height, savedWidth, savedHeight). The event queue has its own
@@ -501,6 +502,7 @@ type x11PlatformWindow struct {
 	platform  *x11Platform
 	id        WindowID
 	secondary *secondaryX11Conn // non-nil for secondary windows
+	lastScale float64           // DPI scale change detection (ADR-059)
 }
 
 // inner returns the *x11.Platform connection backing this window: the
@@ -542,8 +544,12 @@ func (w *x11PlatformWindow) SetModalFrameCallback(_ func()) {}
 
 func (w *x11PlatformWindow) PrepareFrame() PrepareFrameResult {
 	pw, ph := w.inner().GetSize()
+	scale := w.inner().ScaleFactor()
+	scaleChanged := w.lastScale != 0 && w.lastScale != scale
+	w.lastScale = scale
 	return PrepareFrameResult{
-		ScaleFactor:    w.inner().ScaleFactor(),
+		ScaleChanged:   scaleChanged,
+		ScaleFactor:    scale,
 		PhysicalWidth:  uint32(pw),
 		PhysicalHeight: uint32(ph),
 	}
@@ -761,8 +767,32 @@ func (w *waylandPlatformWindow) PrepareFrame() PrepareFrameResult {
 		lw, lh := w.LogicalSize()
 		libwl.SetViewportDestination(int32(lw), int32(lh))
 	}
+
+	// Detect scale change (ADR-059).
+	var wp *waylandWindow
+	if w.secondary != nil {
+		wp = &w.secondary.state
+	} else {
+		wp = w.platform.primary
+	}
+	wp.eventMu.Lock()
+	scaleChanged := wp.lastScale != 0 && wp.lastScale != scale
+	if scaleChanged {
+		lw, lh := w.LogicalSize()
+		wp.events.Push(Event{
+			WindowID:    wp.winID,
+			Type:        EventScaleChanged,
+			ScaleFactor: scale,
+			Width:       lw,
+			Height:      lh,
+		})
+	}
+	wp.lastScale = scale
+	wp.eventMu.Unlock()
+
 	pw, ph := w.PhysicalSize()
 	return PrepareFrameResult{
+		ScaleChanged:   scaleChanged,
 		ScaleFactor:    scale,
 		PhysicalWidth:  uint32(pw),
 		PhysicalHeight: uint32(ph),

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -2650,9 +2650,18 @@ func wndProc(hwnd windows.HWND, message uint32, wParam, lParam uintptr) uintptr 
 		// Update cached client size after DPI-driven resize.
 		w.updateSize()
 
+		// Emit ScaleChanged BEFORE Resize (cause before effect, ADR-059).
+		logW, logH := w.LogicalSize()
+		p.queueEvent(Event{
+			Type:        EventScaleChanged,
+			WindowID:    w.id,
+			ScaleFactor: w.scaleFactor(),
+			Width:       logW,
+			Height:      logH,
+		})
+
 		// Queue resize event with new DPI-adjusted dimensions.
 		physW, physH := w.PhysicalSize()
-		logW, logH := w.LogicalSize()
 		p.queueEvent(Event{
 			Type:           EventResize,
 			WindowID:       w.id,


### PR DESCRIPTION
## [0.48.0] - 2026-08-01

### Added

- **Runtime DPI/scale factor change** (#409, ADR-059) — `ScaleChangedEvent` emitted on all 5 platforms when window moves between monitors with different DPI. Windows: `WM_DPICHANGED`. macOS: `lastScale` tracking. Wayland/X11/Browser: `lastScale` in PrepareFrame. Enterprise research: winit, Qt6, SDL3, Flutter.

### Fixed

- **`App.Quit()` thread safety** (#406, @jbunds) — `running` field changed from `bool` to `atomic.Bool`.

### Changed

- **deps:** gpucontext v0.23.0 → v0.24.0 (ScaleChangedEvent), wgpu v0.30.31 → v0.30.32