### PR TITLE
app: don't reschedule a frame that drew nothing

### DIFF
--- a/app.go
+++ b/app.go
@@ -1101,10 +1101,23 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 		ctx := newContextForSurface(a.renderer, ws, frame.scale)
 		frame.onDraw(ctx)
 
-		// beginFrame can fail (outdated / not yet configured). Demand-driven mode
-		// already consumed the invalidation — schedule another frame.
+		// No frame started. Two very different reasons:
+		//
+		// The callback issued no draw calls, so lazy acquire never acquired
+		// anything. That is what lazy acquire is for, not a failure — there is
+		// nothing to present and nothing to retry. Asking for another frame
+		// here is a loop with no exit: a demand-driven UI draws nothing when
+		// nothing changed, so the next frame draws nothing either, and the app
+		// spins at whatever rate the platform allows, burning CPU on an idle
+		// window (~27% of a core on X11, with no visible frames at all).
+		//
+		// Or a draw call did ask for the swapchain and could not have it
+		// (surface outdated, not yet configured). Demand-driven mode already
+		// consumed the invalidation, so that one does need another frame.
 		if !ws.frameStarted {
-			a.RequestRedraw()
+			if ws.acquireFailed {
+				a.RequestRedraw()
+			}
 			ws.resetLazyState()
 			a.renderer.currentSurface = nil
 			continue

--- a/app_coverage_test.go
+++ b/app_coverage_test.go
@@ -212,9 +212,37 @@ func TestRenderFrameGPU_NilSurfaces(t *testing.T) {
 }
 
 // TestRenderFrameGPU_UnconfiguredSurface exercises ws!=nil but CanRender()==false
-// with no platWindow set on the RenderTarget.
+// with no platWindow set on the RenderTarget: the callback DOES draw, and the
+// surface cannot be acquired, so the frame is owed another attempt.
 func TestRenderFrameGPU_UnconfiguredSurface(t *testing.T) {
-	ws := &RenderTarget{} // CanRender()==false, platWindow==nil
+	// renderer set so the draw call can reach beginFrame and be refused there.
+	ws := &RenderTarget{renderer: &Renderer{}} // CanRender()==false, platWindow==nil
+
+	app := &App{
+		renderLoop: &mockRenderLoop{},
+		renderer:   &Renderer{},
+		platWindow: nil,
+	}
+	frames := []windowFrame{
+		{window: &Window{surface: ws}, onDraw: func(c *Context) { c.MarkExternalContent() }, scale: 1.0},
+	}
+	app.renderFrameGPU(frames)
+
+	// A draw call asked for the swapchain and could not have it, so the frame
+	// was lost and RequestRedraw must have been queued.
+	if !app.pendingRedraw.Load() {
+		t.Error("renderFrameGPU should queue a redraw when a draw call could not acquire the surface")
+	}
+}
+
+// A callback that issues no draw calls is lazy acquire working as intended, not
+// a lost frame. Queueing a redraw for it is a loop with no exit: the next frame
+// draws nothing either, so the app renders as fast as the platform allows for as
+// long as it is open — ~27% of a core on an idle X11 window, with nothing on
+// screen changing. Demand-driven UIs draw nothing whenever nothing changed, so
+// this is the common case, not a corner.
+func TestRenderFrameGPU_NoDrawCallsDoesNotRescheduleForever(t *testing.T) {
+	ws := &RenderTarget{}
 
 	app := &App{
 		renderLoop: &mockRenderLoop{},
@@ -226,9 +254,8 @@ func TestRenderFrameGPU_UnconfiguredSurface(t *testing.T) {
 	}
 	app.renderFrameGPU(frames)
 
-	// The frame had no GPU work, so RequestRedraw must have been queued.
-	if !app.pendingRedraw.Load() {
-		t.Error("renderFrameGPU should queue a redraw when frameStarted==false")
+	if app.pendingRedraw.Load() {
+		t.Error("a frame that drew nothing queued another frame, which will also draw nothing")
 	}
 }
 

--- a/renderer.go
+++ b/renderer.go
@@ -97,6 +97,14 @@ type RenderTarget struct {
 	// If OnDraw produces no GPU work, beginFrame is never called → no
 	// swapchain acquire/present → zero GPU overhead.
 	frameStarted bool
+
+	// acquireFailed records that a draw call asked for the swapchain this
+	// frame and could not have it. It is what separates "the callback drew
+	// nothing", which is what lazy acquire is FOR, from "the callback drew and
+	// the surface was unavailable", which is worth another frame. Without the
+	// distinction the demand-driven loop reschedules itself forever against a
+	// UI that correctly draws nothing when nothing changed.
+	acquireFailed bool
 }
 
 // lockDisplay acquires the platform display lock if the window supports it.
@@ -639,6 +647,7 @@ func (ws *RenderTarget) prepareLazyAcquire() {
 	ws.frameStarted = false
 	ws.hasGPUWork = false
 	ws.pixelPresented = false
+	ws.acquireFailed = false
 }
 
 // ensureFrameStarted calls beginFrame on first draw call (lazy acquire pattern).
@@ -662,6 +671,7 @@ func (ws *RenderTarget) ensureFrameStarted() bool {
 			}
 		}
 	}
+	ws.acquireFailed = true
 	return false
 }
 
@@ -670,6 +680,7 @@ func (ws *RenderTarget) resetLazyState() {
 	ws.frameStarted = false
 	ws.hasGPUWork = false
 	ws.pixelPresented = false
+	ws.acquireFailed = false
 }
 
 // ensureFrameEncoder returns the framework-owned encoder for this surface


### PR DESCRIPTION
Lazy acquire defers `beginFrame` to the first draw call, so that a callback which issues no draw calls costs nothing — no swapchain acquire, no present. `renderFrameGPU` then treats that same condition, `!ws.frameStarted`, as a **failed** `beginFrame` and calls `RequestRedraw`:

```go
// beginFrame can fail (outdated / not yet configured). Demand-driven mode
// already consumed the invalidation — schedule another frame.
if !ws.frameStarted {
    a.RequestRedraw()
```

For a demand-driven UI those are not the same thing. Such a UI draws nothing whenever nothing changed, which is most frames, so the retry produces another empty frame, which retries again. The loop never blocks and the app renders as fast as the platform allows for as long as it is open.

### What it costs

Found on a terminal emulator built on gogpu/ui. An **idle** window — nothing printing, nothing animating — sat at **27% of a core** and made ~1400 event-loop turns a second, each one an X11 round trip. The widget tree rendered **zero** frames in fourteen seconds, counted in the app's own draw callback, so nothing above the platform layer was asking for any of it. CPU was identical with the window minimised.

Once any redraw happens the app is stuck in that state for the rest of its life, which is why it showed up as a constant idle cost rather than a spike.

This is the same shape as the Wayland frame-callback loop fixed in #379: a readiness signal used as a trigger.

### The fix

`acquireFailed` records that a draw call reached `ensureFrameStarted` and could not have the swapchain. Only that case is owed another frame; a callback that never drew is left alone.

Idle CPU on the terminal that found it: **27% → 0.75%**. Syscalls while idle: **1361/s → 26/s**. Frames still arrive normally on output, input and cursor blink.

### Tests

`TestRenderFrameGPU_NoDrawCallsDoesNotRescheduleForever` is the regression: a callback that draws nothing must not queue another frame.

`TestRenderFrameGPU_UnconfiguredSurface` asserted the old behaviour using a callback that drew nothing, which is exactly the case being fixed. Its name and intent are about an *unconfigured surface*, so it now makes a real draw call that cannot acquire, and still asserts the redraw is queued — the case that genuinely needs a retry.

