### PR TITLE
docs: v0.48.1 — CHANGELOG, ROADMAP, README for idle loop fix (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.1] - 2026-08-02
+
+### Fixed
+
+- **Demand-driven idle loop** (#411, @samyfodil) — `renderFrameGPU` unconditionally called `RequestRedraw` when `!frameStarted`, causing infinite render loop (~27% CPU on idle X11) for demand-driven UIs that correctly draw nothing when nothing changed. New `acquireFailed` flag distinguishes "callback drew nothing" (lazy acquire working as designed) from "callback drew but swapchain unavailable" (genuine failure, retry warranted).
+
 ## [0.48.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Built on [gogpu/wgpu](https://github.com/gogpu/wgpu) — the unified Go WebGPU p
 | **Backends** | Pure Go (default), Rust FFI (`-tags rust`), Browser WASM — via [gogpu/wgpu](https://github.com/gogpu/wgpu) |
 | **Graphics API** | Runtime selection: Vulkan, DX12, Metal, GLES, Software |
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal), Browser/WASM (WebGPU) |
-| **Rendering** | Event-driven three-state model (idle/animating/continuous), zero-copy surface rendering, damage-aware presentation |
+| **Rendering** | Event-driven three-state model (idle/animating/continuous), 0% CPU when idle (lazy acquire), zero-copy surface rendering, damage-aware presentation |
 | **Input Models** | Three coexisting models: callbacks (`EventSource`), state polling (`Input()`, Ebiten-style), SDL-style event queue (`PollInputEvent()`) |
 | **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, runtime window resize (`RequestSize`), mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), OS drag-and-drop (all 4 desktop platforms), GPU adapter power preference, native macOS window tabbing, native system menus (macOS + Windows), native file dialogs (macOS + Windows + Linux D-Bus/zenity/kdialog) |
 | **Scroll** | ScrollPhase + IsMomentum for macOS trackpad momentum detection (ADR-032), pixel/line/page delta modes |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,9 +25,10 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.48.0
+## Current State: v0.48.1
 
 ✅ **Production-ready** with full feature set:
+- **Demand-driven idle loop fix** (#411, @samyfodil) — 0% CPU on idle windows (was ~27% on X11). `acquireFailed` flag for lazy acquire correctness
 - **Runtime DPI/scale change** (#409, ADR-059) — `ScaleChangedEvent` on all 5 platforms. Multi-display HiDPI: window drag between Retina and FullHD. winit/Qt6/SDL3 patterns
 - **SDL-style event queue** (ADR-058) — `App.PollInputEvent()` with sealed `InputEvent` interface. Three coexisting input models: callbacks, polling, event queue. Research: Qt6, SDL3, winit, Flutter, Bevy, Gio, Ebiten
 - **Font smoothing OS detection** (#396, ADR-057) — `App.FontSmoothing()` returns None/Grayscale/Subpixel on all 5 platforms (Qt6 pattern)


### PR DESCRIPTION
## Documentation updates for v0.48.1

### CHANGELOG
- **[0.48.1]** — demand-driven idle loop fix (#411, @samyfodil). `acquireFailed` flag distinguishes lazy acquire from swapchain failure. ~27% → 0% CPU on idle.

### ROADMAP
- Current state updated to v0.48.1 with idle loop fix entry.

### README
- Rendering feature table: added "0% CPU when idle (lazy acquire)".