### PR TITLE
fix(darwin): replace ObjC associated object with Go map — checkptr safe (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.3] - 2026-08-02
+
+### Fixed
+
+- **macOS `GetAssociatedObject` checkptr crash under `-race`** (#406) — replaced ObjC associated object round-trip with Go-side `sync.Map` lookup for delegate → `*Window` mapping. Eliminates `uintptr → unsafe.Pointer` conversion that checkptr rejects. Same purego pattern as wgpu block callbacks fix ([wgpu#293](https://github.com/gogpu/wgpu/issues/293)). Third and final checkptr source discovered by @jbunds.
+
 ## [0.48.2] - 2026-08-02
 
 ### Changed

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 )
 
 // Errors returned by Window operations.
@@ -354,7 +353,7 @@ func (w *Window) Destroy() {
 	// Remove delegate properly
 	if w.delegate != 0 {
 		w.nsWindow.SendPtr(selectors.setDelegate, 0) // setDelegate:nil
-		SetAssociatedObject(w.delegate, unsafe.Pointer(&delegateAssociatedKey), nil, 0)
+		delegateWindows.Delete(uintptr(w.delegate))
 		w.delegate.Send(selectors.release)
 		w.delegate = 0
 	}

--- a/internal/platform/darwin/windowdelegate.go
+++ b/internal/platform/darwin/windowdelegate.go
@@ -4,7 +4,6 @@ package darwin
 
 import (
 	"sync"
-	"unsafe"
 
 	"github.com/go-webgpu/goffi/ffi"
 )
@@ -138,17 +137,20 @@ func CreateWindowDelegate(win *Window) (ID, error) {
 	if delegate.IsNil() {
 		return 0, ErrWindowCreationFailed
 	}
-	SetAssociatedObject(delegate, unsafe.Pointer(&delegateAssociatedKey), unsafe.Pointer(win), 0)
+	delegateWindows.Store(uintptr(delegate), win)
 
 	return delegate, nil
 }
 
-var delegateAssociatedKey = "com.gpu.gowindow.delegate"
+// delegateWindows maps ObjC delegate ID → *Window. Replaces ObjC associated
+// objects to avoid uintptr→unsafe.Pointer round-trip that checkptr rejects
+// under -race. Same pattern as purego block callbacks (wgpu#293).
+var delegateWindows sync.Map
 
 func getWindowFromDelegate(delegate ID) *Window {
-	ptr := GetAssociatedObject(delegate, unsafe.Pointer(&delegateAssociatedKey))
-	if ptr == nil {
+	val, ok := delegateWindows.Load(uintptr(delegate))
+	if !ok {
 		return nil
 	}
-	return (*Window)(ptr)
+	return val.(*Window)
 }


### PR DESCRIPTION
## [0.48.3] - 2026-08-02

### Fixed

- **macOS `GetAssociatedObject` checkptr crash under `-race`** (#406) — replaced ObjC associated object round-trip with Go-side `sync.Map` lookup for delegate → `*Window` mapping. Eliminates `uintptr → unsafe.Pointer` conversion that checkptr rejects (objc.go:1391).

Same purego pattern as wgpu block callbacks fix ([wgpu#293](https://github.com/gogpu/wgpu/issues/293)).

Third checkptr source discovered by @jbunds:
1. ~~wgpu block callbacks~~ → fixed wgpu v0.30.31
2. ~~goffi HFA return~~ → fixed goffi v0.6.3
3. **gogpu GetAssociatedObject** → this PR