### PR TITLE
fix: App.Quit wakes WaitEvents so idle loop exits without input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.4] - 2026-08-02
+
+### Fixed
+
+- **`App.Quit()` does not unblock idle WaitEvents** (reported by @jbunds on [wgpu#294](https://github.com/gogpu/wgpu/pull/294)) — `Quit()` set `running=false` but never woke the event loop. In event-driven mode the main loop stayed blocked in `WaitEvents` until mouse/keyboard input. Fixed: `Quit()` invokes an atomically published `WakeUp` (macOS `PostEmptyEvent` / GLFW-winit pattern). Darwin smoke tests use `WithContinuousRender(true)`.
+
 ## [0.48.3] - 2026-08-02
 
 ### Fixed

--- a/app.go
+++ b/app.go
@@ -74,6 +74,9 @@ type App struct {
 	invalidator   *Invalidator
 	pendingRedraw atomic.Bool
 	animations    *AnimationController
+	// wakeupFn unblocks WaitEvents from any goroutine (Quit, timers).
+	// Stored atomically so Quit never races with manager/invalidator publish.
+	wakeupFn atomic.Value // holds func()
 
 	// Event source for gpucontext integration
 	eventSource *eventSourceAdapter
@@ -465,6 +468,7 @@ func (a *App) startRunLoop() {
 	}
 	a.lastFrame = time.Now()
 	a.invalidator = newInvalidator(a.manager.WakeUp)
+	a.wakeupFn.Store(a.manager.WakeUp)
 	a.animations = &AnimationController{}
 	if a.pendingRedraw.Swap(false) {
 		a.invalidator.Invalidate()
@@ -1271,8 +1275,14 @@ func (a *App) SetAppName(name string) {
 
 // Quit requests the application to quit.
 // The main loop will exit after completing the current frame.
+// Safe to call from any goroutine. After startRunLoop, also wakes
+// WaitEvents so the idle (event-driven) loop notices running=false
+// without waiting for a device input event (GLFW/winit/SDL pattern).
 func (a *App) Quit() {
 	a.running.Store(false)
+	if v := a.wakeupFn.Load(); v != nil {
+		v.(func())()
+	}
 }
 
 // frameCallbackReady checks if the platform allows rendering this frame.

--- a/app_test.go
+++ b/app_test.go
@@ -107,6 +107,33 @@ func TestAppQuit(t *testing.T) {
 	}
 }
 
+// TestAppQuitWakesEventLoop verifies Quit unblocks WaitEvents (reported by
+// @jbunds on macOS: App.Run hung until mouse/keyboard input after Quit from
+// a timer because running=false alone does not wake the idle loop).
+func TestAppQuitWakesEventLoop(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	woken := false
+	app.wakeupFn.Store(func() { woken = true })
+	app.running.Store(true)
+
+	app.Quit()
+
+	if app.running.Load() {
+		t.Error("running should be false after Quit()")
+	}
+	if !woken {
+		t.Error("Quit should invoke wakeupFn to unblock WaitEvents")
+	}
+}
+
+func TestAppQuitBeforeStartRunLoopNoWakeup(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	app.Quit()
+	if app.running.Load() {
+		t.Error("running should be false after Quit()")
+	}
+}
+
 func TestAppRequestRedrawNilInvalidator(t *testing.T) {
 	app := NewApp(DefaultConfig())
 

--- a/internal/platform/darwin/app_run_test.go
+++ b/internal/platform/darwin/app_run_test.go
@@ -5,6 +5,7 @@ package darwin_test
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,10 +44,13 @@ func runAppOnce(t *testing.T, cfg gogpu.Config, setup func(app *gogpu.App), expe
 // This mirrors the production call stack without invoking DrawTriangle (to avoid
 // shader compilation failures) while still exercising BeginFrame/EndFrame.
 func TestDarwinAppRunSmoke(t *testing.T) {
+	// ContinuousRender so OnUpdate advances without waiting for input —
+	// default event-driven mode idles in WaitEvents after the first frame.
 	cfg := gogpu.DefaultConfig().
 		WithTitle("gogpu").
 		WithSize(640, 480).
-		WithBackend(gogpu.BackendGo)
+		WithBackend(gogpu.BackendGo).
+		WithContinuousRender(true)
 
 	frames := 0
 	runAppOnce(t, cfg,
@@ -74,7 +78,8 @@ func TestDarwinAppRunNoDraw(t *testing.T) {
 	cfg := gogpu.DefaultConfig().
 		WithTitle("gogpu").
 		WithSize(640, 480).
-		WithBackend(gogpu.BackendGo)
+		WithBackend(gogpu.BackendGo).
+		WithContinuousRender(true)
 
 	frames := 0
 	runAppOnce(t, cfg,
@@ -99,7 +104,8 @@ func TestDarwinAppRunPanicOnUpdate(t *testing.T) {
 	cfg := gogpu.DefaultConfig().
 		WithTitle("gogpu").
 		WithSize(640, 480).
-		WithBackend(gogpu.BackendGo)
+		WithBackend(gogpu.BackendGo).
+		WithContinuousRender(true)
 
 	runAppOnce(t, cfg,
 		func(app *gogpu.App) {
@@ -118,7 +124,8 @@ func TestDarwinAppRunPanicOnDrawNoTriangle(t *testing.T) {
 	cfg := gogpu.DefaultConfig().
 		WithTitle("gogpu").
 		WithSize(640, 480).
-		WithBackend(gogpu.BackendGo)
+		WithBackend(gogpu.BackendGo).
+		WithContinuousRender(true)
 
 	runAppOnce(t, cfg,
 		func(app *gogpu.App) {
@@ -139,7 +146,8 @@ func TestDarwinAppRunPanicPath(t *testing.T) {
 	cfg := gogpu.DefaultConfig().
 		WithTitle("gogpu").
 		WithSize(640, 480).
-		WithBackend(gogpu.BackendGo)
+		WithBackend(gogpu.BackendGo).
+		WithContinuousRender(true)
 
 	const iterations = 20
 	for i := 0; i < iterations; i++ {
@@ -156,5 +164,42 @@ func TestDarwinAppRunPanicPath(t *testing.T) {
 			},
 			true,
 		)
+	}
+}
+
+// TestDarwinAppQuitUnblocksIdle verifies Quit from a background timer exits
+// App.Run while the event-driven loop is blocked in WaitEvents — without
+// requiring a mouse/keyboard event (jbunds report on wgpu#294 / gogpu macOS).
+func TestDarwinAppQuitUnblocksIdle(t *testing.T) {
+	cfg := gogpu.DefaultConfig().
+		WithTitle("gogpu").
+		WithSize(640, 480).
+		WithBackend(gogpu.BackendGo)
+	// ContinuousRender left false: after the first frame the loop idles.
+
+	done := make(chan struct{})
+	runOnMainThread(t, func() {
+		defer close(done)
+		app := gogpu.NewApp(cfg)
+		var quitOnce sync.Once
+		app.OnDraw(func(ctx *gogpu.Context) {
+			ctx.Clear(0, 0, 0, 1)
+			// Schedule Quit after the first frame so wakeupFn is published
+			// and the loop is about to block in WaitEvents.
+			quitOnce.Do(func() {
+				time.AfterFunc(200*time.Millisecond, func() {
+					app.Quit()
+				})
+			})
+		})
+		if err := app.Run(); err != nil {
+			t.Fatalf("App.Run failed: %v", err)
+		}
+	})
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("App.Run did not exit after Quit — WaitEvents was not woken")
 	}
 }


### PR DESCRIPTION
## Summary

- **`App.Quit()`** now invokes an atomically published `WakeUp` so the event-driven idle loop unblocks without waiting for mouse/keyboard input (reported by @jbunds on [wgpu#294](https://github.com/gogpu/wgpu/pull/294)).
- Darwin app-run smoke tests use `WithContinuousRender(true)`; added idle-Quit regression test.
- Window-delegate checkptr fix already landed on main as v0.48.3 (#406) — this PR only covers Quit wakeup.

## Test plan

- [x] `go test -run 'TestAppQuit|TestAppQuitWakes' .`
- [x] `go test -timeout 60s -run 'TestDarwinAppQuitUnblocksIdle|TestDarwinAppRunSmoke' ./internal/platform/darwin/`
- [x] `go test -race -timeout 180s ./internal/platform/darwin/` on Apple Silicon
- [x] Confirm on M1 with Go 1.25 — @jbunds

Refs: [wgpu#294 comment](https://github.com/gogpu/wgpu/pull/294#issuecomment-5156633395), #406