### PR TITLE
release: v0.48.4 — Quit wakes idle loop (#406, @lkmavi)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,9 +25,11 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.48.1
+## Current State: v0.48.4
 
 ✅ **Production-ready** with full feature set:
+- **Quit wakes idle loop** (#406, @lkmavi) — `App.Quit()` invokes `WakeUp` so event-driven loop exits without waiting for input (GLFW/winit/SDL pattern)
+- **macOS checkptr safe** (#406, @jbunds) — ObjC associated object replaced with Go-side `sync.Map` (purego pattern)
 - **Demand-driven idle loop fix** (#411, @samyfodil) — 0% CPU on idle windows (was ~27% on X11). `acquireFailed` flag for lazy acquire correctness
 - **Runtime DPI/scale change** (#409, ADR-059) — `ScaleChangedEvent` on all 5 platforms. Multi-display HiDPI: window drag between Retina and FullHD. winit/Qt6/SDL3 patterns
 - **SDL-style event queue** (ADR-058) — `App.PollInputEvent()` with sealed `InputEvent` interface. Three coexisting input models: callbacks, polling, event queue. Research: Qt6, SDL3, winit, Flutter, Bevy, Gio, Ebiten


### PR DESCRIPTION
## [0.48.4] - 2026-08-02

### Fixed

- **`App.Quit()` does not unblock idle WaitEvents** (#406, @lkmavi) — `Quit()` now invokes atomically published `WakeUp` so the event-driven idle loop exits without waiting for mouse/keyboard input. GLFW/winit/SDL pattern.

ROADMAP updated to v0.48.4.