### PR TITLE
feat(config): WithTransparent + premultiplied swapchain alpha (#361)

### DIFF
--- a/app.go
+++ b/app.go
@@ -716,6 +716,7 @@ func (a *App) initRenderer(platWindow platform.PlatformWindow) error {
 	a.renderLoop.RunOnRenderThreadVoid(func() {
 		a.renderer, initErr = newRenderer(
 			platWindow, a.config.GraphicsAPI, a.config.VSync, a.config.PowerPreference,
+			a.config.Transparent,
 		)
 	})
 	if initErr != nil {

--- a/config.go
+++ b/config.go
@@ -77,6 +77,15 @@ type Config struct {
 	// WindowChrome.SetHitTestCallback for drag, resize, and button regions.
 	Frameless bool
 
+	// Transparent enables a per-pixel-alpha window (rounded corners, tray
+	// popups, overlays). When true, the swapchain uses
+	// CompositeAlphaModePremultiplied when the surface supports it and the
+	// platform window is created with the native transparency style
+	// (DwmBlurBehind on Windows, NSWindow.isOpaque=false on macOS, ARGB
+	// visual on X11, no opaque region on Wayland). The application must
+	// clear with alpha=0 for transparent regions.
+	Transparent bool
+
 	// PowerPreference specifies GPU power consumption preference for adapter selection.
 	// On systems with both integrated and discrete GPUs (e.g. laptops),
 	// this controls which GPU is selected.
@@ -275,6 +284,16 @@ func (c Config) WithFullscreen() Config {
 // Use WindowChrome.SetHitTestCallback to define drag, resize, and button regions.
 func (c Config) WithFrameless(frameless bool) Config {
 	c.Frameless = frameless
+	return c
+}
+
+// WithTransparent enables or disables per-pixel-alpha window transparency.
+// When true, the surface selects CompositeAlphaModePremultiplied when
+// supported and the platform window is created with its native transparency
+// style. Falls back to an opaque surface when the backend does not support
+// premultiplied alpha.
+func (c Config) WithTransparent(transparent bool) Config {
+	c.Transparent = transparent
 	return c
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -177,6 +177,25 @@ func TestConfigWithFramelessBuilder(t *testing.T) {
 	}
 }
 
+func TestConfigWithTransparent(t *testing.T) {
+	tests := []struct {
+		name        string
+		transparent bool
+	}{
+		{"enabled", true},
+		{"disabled", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig().WithTransparent(tt.transparent)
+			if cfg.Transparent != tt.transparent {
+				t.Errorf("Transparent = %v, want %v", cfg.Transparent, tt.transparent)
+			}
+		})
+	}
+}
+
 func TestConfigBuilderChaining(t *testing.T) {
 	t.Setenv("GOGPU_GRAPHICS_API", "")
 
@@ -186,7 +205,8 @@ func TestConfigBuilderChaining(t *testing.T) {
 		WithBackend(types.BackendNative).
 		WithGraphicsAPI(types.GraphicsAPIVulkan).
 		WithContinuousRender(false).
-		WithFrameless(true)
+		WithFrameless(true).
+		WithTransparent(true)
 
 	if cfg.Title != "Test App" {
 		t.Errorf("Title = %q, want %q", cfg.Title, "Test App")
@@ -208,6 +228,9 @@ func TestConfigBuilderChaining(t *testing.T) {
 	}
 	if !cfg.Frameless {
 		t.Error("Frameless = false, want true")
+	}
+	if !cfg.Transparent {
+		t.Error("Transparent = false, want true")
 	}
 	// Verify defaults not overridden remain intact.
 	if !cfg.Resizable {

--- a/renderer.go
+++ b/renderer.go
@@ -70,6 +70,10 @@ type RenderTarget struct {
 	// VSync preference for this window
 	vsync bool
 
+	// transparent requests CompositeAlphaModePremultiplied for this surface
+	// when the adapter advertises support (ADR-060, gogpu#361).
+	transparent bool
+
 	// damageRects holds the dirty regions for the current frame (physical pixels,
 	// top-left origin). Set by Context.SetDamageRects(), consumed and cleared by
 	// present(). When nil, the full surface is presented (backward compatible).
@@ -180,14 +184,15 @@ type Renderer struct {
 }
 
 // newRenderer creates and initializes a new renderer.
-func newRenderer(platWin platform.PlatformWindow, graphicsAPI types.GraphicsAPI, vsync bool, powerPref gputypes.PowerPreference) (*Renderer, error) {
+func newRenderer(platWin platform.PlatformWindow, graphicsAPI types.GraphicsAPI, vsync bool, powerPref gputypes.PowerPreference, transparent bool) (*Renderer, error) {
 	r := &Renderer{
 		powerPreference: powerPref,
 	}
 	r.primary = &RenderTarget{
-		renderer:   r,
-		platWindow: platWin,
-		vsync:      vsync,
+		renderer:    r,
+		platWindow:  platWin,
+		vsync:       vsync,
+		transparent: transparent,
 	}
 
 	// Phase 1: Create GPU instance with backend mask (may include multiple backends).
@@ -299,14 +304,16 @@ func (r *Renderer) configureSurface(ws *RenderTarget) error {
 
 // configure configures the wgpu surface with current dimensions and format.
 func (ws *RenderTarget) configure(device *wgpu.Device, adapter *wgpu.Adapter) error {
-	presentMode := ws.resolvePresentMode(adapter)
+	caps := adapter.GetSurfaceCapabilities(ws.surface)
+	presentMode := resolvePresentMode(caps, ws.vsync)
+	alphaMode := resolveAlphaMode(caps, ws.transparent)
 
 	return ws.surface.Configure(device, &wgpu.SurfaceConfiguration{
 		Format:      ws.format,
 		Usage:       gputypes.TextureUsageRenderAttachment,
 		Width:       ws.width,
 		Height:      ws.height,
-		AlphaMode:   gputypes.CompositeAlphaModeOpaque,
+		AlphaMode:   alphaMode,
 		PresentMode: presentMode,
 	})
 }
@@ -315,23 +322,22 @@ func (ws *RenderTarget) configure(device *wgpu.Device, adapter *wgpu.Adapter) er
 // Rust wgpu fallback pattern. For VSync on (AutoVsync): FifoRelaxed -> Fifo.
 // For VSync off (AutoNoVsync): Immediate -> Mailbox -> Fifo.
 // Falls back to Fifo which is guaranteed by the Vulkan spec.
-func (ws *RenderTarget) resolvePresentMode(adapter *wgpu.Adapter) gputypes.PresentMode {
-	caps := adapter.GetSurfaceCapabilities(ws.surface)
+func resolvePresentMode(caps *wgpu.SurfaceCapabilities, vsync bool) gputypes.PresentMode {
 	if caps == nil {
 		// No capabilities available — use safe default.
 		mode := gputypes.PresentModeFifo
-		if !ws.vsync {
+		if !vsync {
 			mode = gputypes.PresentModeImmediate
 		}
 		slog.Debug("gogpu: no surface capabilities, using default present mode",
-			"mode", mode, "vsync", ws.vsync)
+			"mode", mode, "vsync", vsync)
 		return mode
 	}
 
 	supported := caps.PresentModes
 	var mode gputypes.PresentMode
 
-	if ws.vsync {
+	if vsync {
 		// VSync on: FifoRelaxed -> Fifo (like Rust AutoVsync).
 		mode = pickPresentMode(supported,
 			gputypes.PresentModeFifoRelaxed,
@@ -347,8 +353,30 @@ func (ws *RenderTarget) resolvePresentMode(adapter *wgpu.Adapter) gputypes.Prese
 	}
 
 	slog.Debug("gogpu: resolved present mode",
-		"mode", mode, "vsync", ws.vsync, "supported", supported)
+		"mode", mode, "vsync", vsync, "supported", supported)
 	return mode
+}
+
+// resolveAlphaMode selects the surface alpha compositing mode.
+// Transparent windows request CompositeAlphaModePremultiplied; if the
+// adapter does not advertise it (or capabilities are unavailable) the
+// surface falls back to Opaque, preserving pre-ADR-060 behavior.
+func resolveAlphaMode(caps *wgpu.SurfaceCapabilities, transparent bool) gputypes.CompositeAlphaMode {
+	if !transparent {
+		return gputypes.CompositeAlphaModeOpaque
+	}
+	if caps == nil {
+		slog.Debug("gogpu: no surface capabilities, using opaque alpha mode")
+		return gputypes.CompositeAlphaModeOpaque
+	}
+	for _, mode := range caps.AlphaModes {
+		if mode == gputypes.CompositeAlphaModePremultiplied {
+			return mode
+		}
+	}
+	slog.Debug("gogpu: premultiplied alpha unsupported, using opaque alpha mode",
+		"supported", caps.AlphaModes)
+	return gputypes.CompositeAlphaModeOpaque
 }
 
 // pickPresentMode returns the first mode from preferred that is in supported.

--- a/renderer_init_test.go
+++ b/renderer_init_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gogpu/gogpu/gpu/types"
 	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
 )
 
 // TestConfigureSurface_ZeroDimensionsSkips verifies that configureSurface
@@ -154,6 +155,67 @@ func TestPickPresentMode_EmptySupportedReturnsFifo(t *testing.T) {
 	got := pickPresentMode(nil, gputypes.PresentModeImmediate)
 	if got != gputypes.PresentModeFifo {
 		t.Errorf("pickPresentMode(nil) = %v, want Fifo", got)
+	}
+}
+
+// TestResolvePresentMode_NilCapsUsesVsyncDefault verifies the nil-capabilities
+// fallback keeps the previous default-mode behavior after the refactor.
+func TestResolvePresentMode_NilCapsUsesVsyncDefault(t *testing.T) {
+	if got := resolvePresentMode(nil, true); got != gputypes.PresentModeFifo {
+		t.Errorf("resolvePresentMode(nil, vsync=true) = %v, want Fifo", got)
+	}
+	if got := resolvePresentMode(nil, false); got != gputypes.PresentModeImmediate {
+		t.Errorf("resolvePresentMode(nil, vsync=false) = %v, want Immediate", got)
+	}
+}
+
+// TestResolvePresentMode_PicksFromCapabilities verifies present-mode selection
+// honors the supported list from surface capabilities.
+func TestResolvePresentMode_PicksFromCapabilities(t *testing.T) {
+	caps := &wgpu.SurfaceCapabilities{
+		PresentModes: []gputypes.PresentMode{gputypes.PresentModeFifo},
+	}
+	if got := resolvePresentMode(caps, false); got != gputypes.PresentModeFifo {
+		t.Errorf("resolvePresentMode(caps, vsync=false) = %v, want Fifo (only supported)", got)
+	}
+}
+
+// TestResolveAlphaMode_OpaqueWhenNotTransparent verifies the default surface
+// configuration stays CompositeAlphaModeOpaque (backward compatible).
+func TestResolveAlphaMode_OpaqueWhenNotTransparent(t *testing.T) {
+	caps := &wgpu.SurfaceCapabilities{
+		AlphaModes: []gputypes.CompositeAlphaMode{gputypes.CompositeAlphaModePremultiplied},
+	}
+	if got := resolveAlphaMode(caps, false); got != gputypes.CompositeAlphaModeOpaque {
+		t.Errorf("resolveAlphaMode(caps, false) = %v, want Opaque", got)
+	}
+}
+
+// TestResolveAlphaMode_PremultipliedWhenSupported verifies transparent windows
+// select CompositeAlphaModePremultiplied when the adapter advertises it.
+func TestResolveAlphaMode_PremultipliedWhenSupported(t *testing.T) {
+	caps := &wgpu.SurfaceCapabilities{
+		AlphaModes: []gputypes.CompositeAlphaMode{
+			gputypes.CompositeAlphaModeOpaque,
+			gputypes.CompositeAlphaModePremultiplied,
+		},
+	}
+	if got := resolveAlphaMode(caps, true); got != gputypes.CompositeAlphaModePremultiplied {
+		t.Errorf("resolveAlphaMode(caps, true) = %v, want Premultiplied", got)
+	}
+}
+
+// TestResolveAlphaMode_FallsBackToOpaque verifies transparent windows degrade
+// to Opaque when premultiplied alpha is unsupported or capabilities are nil.
+func TestResolveAlphaMode_FallsBackToOpaque(t *testing.T) {
+	opaqueOnly := &wgpu.SurfaceCapabilities{
+		AlphaModes: []gputypes.CompositeAlphaMode{gputypes.CompositeAlphaModeOpaque},
+	}
+	if got := resolveAlphaMode(opaqueOnly, true); got != gputypes.CompositeAlphaModeOpaque {
+		t.Errorf("resolveAlphaMode(opaqueOnly, true) = %v, want Opaque fallback", got)
+	}
+	if got := resolveAlphaMode(nil, true); got != gputypes.CompositeAlphaModeOpaque {
+		t.Errorf("resolveAlphaMode(nil, true) = %v, want Opaque fallback", got)
 	}
 }
 

--- a/window_manager.go
+++ b/window_manager.go
@@ -332,12 +332,13 @@ func (a *App) NewWindow(config Config) (*Window, error) {
 
 	// Create RenderTarget for this window.
 	ws := &RenderTarget{
-		renderer:   a.renderer,
-		platWindow: platWindow,
-		surface:    surface,
-		format:     a.renderer.surfaceFormat,
-		vsync:      false, // Secondary windows: Immediate (ADR-010 VSync strategy)
-		state:      SurfaceReady,
+		renderer:    a.renderer,
+		platWindow:  platWindow,
+		surface:     surface,
+		format:      a.renderer.surfaceFormat,
+		vsync:       false, // Secondary windows: Immediate (ADR-010 VSync strategy)
+		transparent: config.Transparent,
+		state:       SurfaceReady,
 	}
 
 	// Configure surface with initial dimensions on the render thread.


### PR DESCRIPTION
Part of #361 (ADR-060). Implements the swapchain side of per-pixel-alpha transparency.

**Changes**
- \Config.Transparent\ field + \Config.WithTransparent(bool)\
- \RenderTarget\ resolves \CompositeAlphaModePremultiplied\ from surface capabilities, falling back to \Opaque\ when unsupported or when not requested
- Applies to primary windows (\
ewRenderer\) and secondary windows (\App.NewWindow\)
- Default clear stays transparent black (already the case since BUG-RENDERER-001)

**Tests**
- Config builder tests (\WithTransparent\, chaining)
- \esolveAlphaMode\ unit tests (supported / unsupported / nil capabilities / opaque default)
- \esolvePresentMode\ refactor covered by existing + new tests

Platform window transparency (DwmBlurBehind / NSWindow.isOpaque / X11 ARGB visual) lands in the follow-up PR.