### PR TITLE
feat(platform): per-pixel-alpha window styles (DwmBlurBehind / isOpaque / X11 ARGB) (#361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`Config.WithTransparent(bool)`** (#361, @shaolei) — per-pixel-alpha window transparency. When enabled, the swapchain selects `CompositeAlphaModePremultiplied` when the surface supports it (falling back to `Opaque`), and the platform window is created with its native transparency style.
+
 ## [0.48.5] - 2026-08-02
 
 ### Changed

--- a/app.go
+++ b/app.go
@@ -716,6 +716,7 @@ func (a *App) initRenderer(platWindow platform.PlatformWindow) error {
 	a.renderLoop.RunOnRenderThreadVoid(func() {
 		a.renderer, initErr = newRenderer(
 			platWindow, a.config.GraphicsAPI, a.config.VSync, a.config.PowerPreference,
+			a.config.Transparent,
 		)
 	})
 	if initErr != nil {

--- a/app.go
+++ b/app.go
@@ -559,17 +559,18 @@ func (a *App) initPlatform() (platform.PlatformWindow, error) {
 
 	// Create primary platform window.
 	platWindow, err := a.manager.CreateWindow(platform.Config{
-		Title:      a.config.Title,
-		Width:      a.config.Width,
-		Height:     a.config.Height,
-		Resizable:  a.config.Resizable,
-		Fullscreen: a.config.Fullscreen,
-		Frameless:  a.config.Frameless,
-		MinWidth:   a.config.MinWidth,
-		MinHeight:  a.config.MinHeight,
-		MaxWidth:   a.config.MaxWidth,
-		MaxHeight:  a.config.MaxHeight,
-		Icon:       a.config.Icon,
+		Title:       a.config.Title,
+		Width:       a.config.Width,
+		Height:      a.config.Height,
+		Resizable:   a.config.Resizable,
+		Fullscreen:  a.config.Fullscreen,
+		Frameless:   a.config.Frameless,
+		Transparent: a.config.Transparent,
+		MinWidth:    a.config.MinWidth,
+		MinHeight:   a.config.MinHeight,
+		MaxWidth:    a.config.MaxWidth,
+		MaxHeight:   a.config.MaxHeight,
+		Icon:        a.config.Icon,
 	})
 	if err != nil {
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -77,6 +77,15 @@ type Config struct {
 	// WindowChrome.SetHitTestCallback for drag, resize, and button regions.
 	Frameless bool
 
+	// Transparent enables a per-pixel-alpha window (rounded corners, tray
+	// popups, overlays). When true, the swapchain uses
+	// CompositeAlphaModePremultiplied when the surface supports it and the
+	// platform window is created with the native transparency style
+	// (DwmBlurBehind on Windows, NSWindow.isOpaque=false on macOS, ARGB
+	// visual on X11, no opaque region on Wayland). The application must
+	// clear with alpha=0 for transparent regions.
+	Transparent bool
+
 	// PowerPreference specifies GPU power consumption preference for adapter selection.
 	// On systems with both integrated and discrete GPUs (e.g. laptops),
 	// this controls which GPU is selected.
@@ -275,6 +284,16 @@ func (c Config) WithFullscreen() Config {
 // Use WindowChrome.SetHitTestCallback to define drag, resize, and button regions.
 func (c Config) WithFrameless(frameless bool) Config {
 	c.Frameless = frameless
+	return c
+}
+
+// WithTransparent enables or disables per-pixel-alpha window transparency.
+// When true, the surface selects CompositeAlphaModePremultiplied when
+// supported and the platform window is created with its native transparency
+// style. Falls back to an opaque surface when the backend does not support
+// premultiplied alpha.
+func (c Config) WithTransparent(transparent bool) Config {
+	c.Transparent = transparent
 	return c
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -177,6 +177,25 @@ func TestConfigWithFramelessBuilder(t *testing.T) {
 	}
 }
 
+func TestConfigWithTransparent(t *testing.T) {
+	tests := []struct {
+		name        string
+		transparent bool
+	}{
+		{"enabled", true},
+		{"disabled", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig().WithTransparent(tt.transparent)
+			if cfg.Transparent != tt.transparent {
+				t.Errorf("Transparent = %v, want %v", cfg.Transparent, tt.transparent)
+			}
+		})
+	}
+}
+
 func TestConfigBuilderChaining(t *testing.T) {
 	t.Setenv("GOGPU_GRAPHICS_API", "")
 
@@ -186,7 +205,8 @@ func TestConfigBuilderChaining(t *testing.T) {
 		WithBackend(types.BackendNative).
 		WithGraphicsAPI(types.GraphicsAPIVulkan).
 		WithContinuousRender(false).
-		WithFrameless(true)
+		WithFrameless(true).
+		WithTransparent(true)
 
 	if cfg.Title != "Test App" {
 		t.Errorf("Title = %q, want %q", cfg.Title, "Test App")
@@ -208,6 +228,9 @@ func TestConfigBuilderChaining(t *testing.T) {
 	}
 	if !cfg.Frameless {
 		t.Error("Frameless = false, want true")
+	}
+	if !cfg.Transparent {
+		t.Error("Transparent = false, want true")
 	}
 	// Verify defaults not overridden remain intact.
 	if !cfg.Resizable {

--- a/internal/platform/darwin/darwin_objc_test.go
+++ b/internal/platform/darwin/darwin_objc_test.go
@@ -991,7 +991,7 @@ func TestDarwinGogpuWindowSurfaceStress(t *testing.T) {
 				_ = w.IsVisible()
 				w.UpdateSize()
 
-				s, err := platformdarwin.NewSurface(w)
+				s, err := platformdarwin.NewSurface(w, false)
 				s = must(t, "NewSurface", s, err)
 				s.Configure(platformdarwin.DefaultSurfaceConfig())
 				s.UpdateSize()

--- a/internal/platform/darwin/selectors.go
+++ b/internal/platform/darwin/selectors.go
@@ -68,6 +68,7 @@ var selectors struct {
 	// NSWindow titlebar transparency / title visibility
 	setTitlebarAppearsTransparent SEL
 	setTitleVisibility            SEL
+	setOpaque                     SEL // NSWindow.setOpaque: / CALayer.setOpaque:
 
 	// NSView - View management
 	setWantsLayer   SEL
@@ -315,6 +316,7 @@ func initSelectors() {
 		selectors.windowDidResize = RegisterSelector("windowDidResize:")
 		selectors.setTitlebarAppearsTransparent = RegisterSelector("setTitlebarAppearsTransparent:")
 		selectors.setTitleVisibility = RegisterSelector("setTitleVisibility:")
+		selectors.setOpaque = RegisterSelector("setOpaque:")
 
 		// NSView
 		selectors.setWantsLayer = RegisterSelector("setWantsLayer:")

--- a/internal/platform/darwin/selectors.go
+++ b/internal/platform/darwin/selectors.go
@@ -69,6 +69,8 @@ var selectors struct {
 	setTitlebarAppearsTransparent SEL
 	setTitleVisibility            SEL
 	setOpaque                     SEL // NSWindow.setOpaque: / CALayer.setOpaque:
+	setHasShadow                  SEL // NSWindow.setHasShadow:
+	setBackgroundColor            SEL // NSWindow.setBackgroundColor:
 
 	// NSView - View management
 	setWantsLayer   SEL
@@ -103,6 +105,7 @@ var selectors struct {
 
 	// NSColor class methods
 	labelColor SEL
+	clearColor SEL
 
 	// CALayer - Contents (for software blitting)
 	setContents SEL
@@ -317,6 +320,8 @@ func initSelectors() {
 		selectors.setTitlebarAppearsTransparent = RegisterSelector("setTitlebarAppearsTransparent:")
 		selectors.setTitleVisibility = RegisterSelector("setTitleVisibility:")
 		selectors.setOpaque = RegisterSelector("setOpaque:")
+		selectors.setHasShadow = RegisterSelector("setHasShadow:")
+		selectors.setBackgroundColor = RegisterSelector("setBackgroundColor:")
 
 		// NSView
 		selectors.setWantsLayer = RegisterSelector("setWantsLayer:")
@@ -351,6 +356,7 @@ func initSelectors() {
 
 		// NSColor class methods
 		selectors.labelColor = RegisterSelector("labelColor")
+		selectors.clearColor = RegisterSelector("clearColor")
 
 		// CALayer - Contents
 		selectors.setContents = RegisterSelector("setContents:")

--- a/internal/platform/darwin/surface.go
+++ b/internal/platform/darwin/surface.go
@@ -107,6 +107,16 @@ func (l *MetalLayer) PixelFormat() MetalPixelFormat {
 	return MetalPixelFormat(result)
 }
 
+// SetOpaque controls whether the layer is composited as fully opaque.
+// Transparent windows must set this to false or Core Animation ignores the
+// layer alpha and composites black (ADR-060, gogpu#361).
+func (l *MetalLayer) SetOpaque(opaque bool) {
+	if l == nil || l.id.IsNil() {
+		return
+	}
+	l.id.SendBool(selectors.setOpaque, opaque)
+}
+
 // SetDrawableSize sets the size of the layer's drawable textures.
 func (l *MetalLayer) SetDrawableSize(width, height int) {
 	if l == nil || l.id.IsNil() {
@@ -303,7 +313,7 @@ type Surface struct {
 // The surface is created with default configuration but drawable size
 // is deferred until the window is visible and has valid dimensions.
 // Call UpdateSize() after the window is shown to set the correct size.
-func NewSurface(window *Window) (*Surface, error) {
+func NewSurface(window *Window, transparent bool) (*Surface, error) {
 	if window == nil {
 		return nil, errors.New("darwin: window is nil")
 	}
@@ -318,6 +328,7 @@ func NewSurface(window *Window) (*Surface, error) {
 	layer.SetPixelFormat(MetalPixelFormatBGRA8UNorm)
 	layer.SetFramebufferOnly(true)
 	layer.SetMaximumDrawableCount(3) // Triple buffering
+	layer.SetOpaque(!transparent)
 
 	// Set autoresizingMask so the layer auto-resizes with the view.
 	// Without this, the layer's bounds stay at CGRectZero in layer-hosting mode,

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -23,6 +23,7 @@ type WindowConfig struct {
 	Resizable         bool
 	Fullscreen        bool
 	Frameless         bool
+	Transparent       bool
 	TabbingMode       int
 	TabbingIdentifier string
 }
@@ -128,6 +129,12 @@ func NewWindow(config WindowConfig) (*Window, error) {
 			nsWindow.SendPtr(selectors.setTitle, title.ID().Ptr())
 			title.Release()
 		}
+	}
+
+	// Per-pixel alpha: the window must not be opaque or AppKit fills the
+	// background black and the compositor ignores the surface alpha.
+	if config.Transparent {
+		nsWindow.SendBool(selectors.setOpaque, false)
 	}
 
 	// Create custom GoGPUView (ADR-015: prevents macOS system beep on key press).

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -133,8 +133,16 @@ func NewWindow(config WindowConfig) (*Window, error) {
 
 	// Per-pixel alpha: the window must not be opaque or AppKit fills the
 	// background black and the compositor ignores the surface alpha.
+	// SDL3 sets all three (opaque=NO, hasShadow=NO, backgroundColor=clearColor):
+	// without clearColor AppKit composites the swapchain alpha over an opaque
+	// background; without hasShadow=NO the system shadow renders incorrectly
+	// for overlay/popup windows.
 	if config.Transparent {
 		nsWindow.SendBool(selectors.setOpaque, false)
+		nsWindow.SendBool(selectors.setHasShadow, false)
+		if color := classes.NSColor.Send(selectors.clearColor); !color.IsNil() {
+			nsWindow.SendPtr(selectors.setBackgroundColor, color.Ptr())
+		}
 	}
 
 	// Create custom GoGPUView (ADR-015: prevents macOS system beep on key press).

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -26,6 +26,7 @@ type Config struct {
 	Resizable         bool
 	Fullscreen        bool
 	Frameless         bool
+	Transparent       bool
 	TabbingMode       int
 	TabbingIdentifier string
 	MinWidth          int // 0 = no minimum constraint

--- a/internal/platform/platform_browser.go
+++ b/internal/platform/platform_browser.go
@@ -32,6 +32,9 @@ func (p *browserPlatform) Init() error {
 // CreateWindow creates a browserWindow backed by a <canvas> element.
 // If no <canvas> exists in the DOM, one is created and appended to the body.
 func (p *browserPlatform) CreateWindow(config Config) (PlatformWindow, error) {
+	// TODO(#361, ADR-060): Browser transparency — CSS transparency (e.g.
+	// canvas background) is not implemented yet; Config.Transparent is
+	// silently ignored.
 	doc := js.Global().Get("document")
 
 	// Find or create a <canvas> element.

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -129,6 +129,7 @@ func (p *darwinPlatform) CreateWindow(config Config) (PlatformWindow, error) {
 		Resizable:         config.Resizable,
 		Fullscreen:        config.Fullscreen,
 		Frameless:         config.Frameless,
+		Transparent:       config.Transparent,
 		TabbingMode:       config.TabbingMode,
 		TabbingIdentifier: config.TabbingIdentifier,
 	}
@@ -142,7 +143,7 @@ func (p *darwinPlatform) CreateWindow(config Config) (PlatformWindow, error) {
 	// Create Metal surface for GPU rendering.
 	// Note: Surface is created before window is shown, but drawable size
 	// is set after Show() when window has valid dimensions.
-	surface, err := darwin.NewSurface(window)
+	surface, err := darwin.NewSurface(window, config.Transparent)
 	if err != nil {
 		// Non-fatal: window works without Metal surface
 		// This allows the window to still be used with software rendering

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -962,6 +962,10 @@ func (p *waylandPlatform) Init() error {
 // The first call initializes the primary connection. Subsequent calls create
 // secondary windows each with their own independent Wayland connection and surface.
 func (p *waylandPlatform) CreateWindow(config Config) (PlatformWindow, error) {
+	// TODO(#361, ADR-060): Wayland transparency — explicitly call
+	// wl_surface_set_opaque_region(NULL) when config.Transparent is set.
+	// For now Config.Transparent is silently ignored: Wayland surfaces have
+	// no opaque region by default, so surface alpha already composites.
 	if p.libwl != nil {
 		// Secondary window: open a new independent Wayland connection.
 		sec, err := p.createSecondaryConn(config)

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -237,17 +237,18 @@ func (p *x11Platform) Init() error {
 // CreateWindow creates an X11 window.
 func (p *x11Platform) CreateWindow(config Config) (PlatformWindow, error) {
 	x11Config := x11.Config{
-		Title:      config.Title,
-		Width:      config.Width,
-		Height:     config.Height,
-		Resizable:  config.Resizable,
-		Fullscreen: config.Fullscreen,
-		Frameless:  config.Frameless,
-		MinWidth:   config.MinWidth,
-		MinHeight:  config.MinHeight,
-		MaxWidth:   config.MaxWidth,
-		MaxHeight:  config.MaxHeight,
-		Icon:       config.Icon,
+		Title:       config.Title,
+		Width:       config.Width,
+		Height:      config.Height,
+		Resizable:   config.Resizable,
+		Fullscreen:  config.Fullscreen,
+		Frameless:   config.Frameless,
+		Transparent: config.Transparent,
+		MinWidth:    config.MinWidth,
+		MinHeight:   config.MinHeight,
+		MaxWidth:    config.MaxWidth,
+		MaxHeight:   config.MaxHeight,
+		Icon:        config.Icon,
 	}
 
 	if p.primaryWindowID != 0 {

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -193,6 +193,10 @@ const (
 	swpNoZOrder     = 0x0004
 	swpFrameChanged = 0x0020
 
+	// DwmEnableBlurBehindWindow flags (DWM_BLURBEHIND)
+	dwmBBEnable     = 0x00000001 // DWM_BB_ENABLE
+	dwmBBBlurRegion = 0x00000002 // DWM_BB_BLURREGION
+
 	// GetWindowLongPtr index
 	gwlStyle = ^uintptr(15) // GWL_STYLE = -16 as unsigned uintptr
 
@@ -283,9 +287,10 @@ var (
 	procGetMonitorInfoW    = user32.NewProc("GetMonitorInfoW")
 
 	// DWM (Desktop Window Manager) for frameless window shadow
-	dwmapi                       = windows.NewLazyDLL("dwmapi.dll")
-	procDwmExtendFrameIntoClient = dwmapi.NewProc("DwmExtendFrameIntoClientArea")
-	procDwmFlush                 = dwmapi.NewProc("DwmFlush")
+	dwmapi                        = windows.NewLazyDLL("dwmapi.dll")
+	procDwmExtendFrameIntoClient  = dwmapi.NewProc("DwmExtendFrameIntoClientArea")
+	procDwmEnableBlurBehindWindow = dwmapi.NewProc("DwmEnableBlurBehindWindow")
+	procDwmFlush                  = dwmapi.NewProc("DwmFlush")
 
 	// WaitEvents / WakeUp
 	procMsgWaitForMultipleObjectsEx = user32.NewProc("MsgWaitForMultipleObjectsEx")
@@ -348,6 +353,8 @@ var (
 	procReleaseDC         = user32.NewProc("ReleaseDC")
 	procSetDIBitsToDevice = gdi32.NewProc("SetDIBitsToDevice")
 	procGetStockObject    = gdi32.NewProc("GetStockObject")
+	procCreateRectRgn     = gdi32.NewProc("CreateRectRgn")
+	procDeleteObject      = gdi32.NewProc("DeleteObject")
 
 	// Shell32 (file drag-and-drop)
 	shell32DnD          = windows.NewLazyDLL("shell32.dll")
@@ -673,6 +680,37 @@ func adjustWindowRectForDpi(r *rect, style uintptr, dpi uint32) {
 	}
 }
 
+// dwmBlurBehind mirrors the native DWM_BLURBEHIND structure.
+type dwmBlurBehind struct {
+	dwFlags                uint32
+	fEnable                uint32
+	hRgnBlur               uintptr
+	fTransitionOnMaximized uint32
+}
+
+// enableDwmBlurBehind enables per-pixel-alpha compositing for the window
+// using DwmEnableBlurBehindWindow with an empty blur region — the winit/SDL3
+// pattern documented in ADR-060. WS_EX_LAYERED is intentionally NOT used:
+// it is GDI whole-window opacity, not per-pixel alpha with GPU rendering.
+func enableDwmBlurBehind(hwnd windows.HWND) {
+	if hwnd == 0 {
+		return
+	}
+	// CreateRectRgn(0, 0, -1, -1) creates an empty region.
+	rgn, _, _ := procCreateRectRgn.Call(0, 0, ^uintptr(0), ^uintptr(0))
+	if rgn == 0 {
+		return
+	}
+	defer procDeleteObject.Call(rgn)
+
+	bb := dwmBlurBehind{
+		dwFlags:  dwmBBEnable | dwmBBBlurRegion,
+		fEnable:  1, // TRUE
+		hRgnBlur: rgn,
+	}
+	procDwmEnableBlurBehindWindow.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&bb)))
+}
+
 // createWindowWin32 creates a new Win32 HWND window from the given config.
 // Shared between PlatformManager.CreateWindow and the legacy Init(config).
 func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error) {
@@ -767,6 +805,13 @@ func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error)
 		procSetWindowPos.Call(uintptr(w.hwnd), 0, 0, 0, 0, 0,
 			swpNoMove|swpNoSize|swpNoZOrder|swpFrameChanged)
 		w.updateSize()
+	}
+
+	// Enable DWM blur-behind for per-pixel-alpha transparency (ADR-060).
+	// Independent of frameless mode — a transparent window keeps its chrome
+	// unless the application also opts into WithFrameless.
+	if config.Transparent {
+		enableDwmBlurBehind(w.hwnd)
 	}
 
 	w.updateSize()

--- a/internal/platform/x11/icon_test.go
+++ b/internal/platform/x11/icon_test.go
@@ -49,7 +49,7 @@ func TestSetNetWMIcon_E2E(t *testing.T) {
 		t.Skip("_NET_WM_ICON atom not supported by this X server")
 	}
 
-	window, err := conn.CreateWindow(WindowConfig{Width: 1, Height: 1})
+	window, _, err := conn.CreateWindow(WindowConfig{Width: 1, Height: 1})
 	if err != nil {
 		t.Fatalf("CreateWindow: %v", err)
 	}

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -107,6 +107,10 @@ type x11Window struct {
 	// X11 window ID
 	window ResourceID
 
+	// colormap is the ARGB colormap created for a transparent window
+	// (0 when the window uses the root visual). Freed on Destroy.
+	colormap ResourceID
+
 	// Window state (guarded by eventMu for thread-safe access from multiple goroutines).
 	width       int
 	height      int
@@ -348,7 +352,7 @@ func (p *Platform) Init(config Config) error {
 		Transparent: config.Transparent,
 	}
 
-	window, err := conn.CreateWindow(windowConfig)
+	window, colormap, err := conn.CreateWindow(windowConfig)
 	if err != nil {
 		_ = conn.Close()
 		return fmt.Errorf("x11: failed to create window: %w", err)
@@ -358,6 +362,7 @@ func (p *Platform) Init(config Config) error {
 	// Store physical pixel dimensions (what the X server sees).
 	w := &x11Window{
 		window:        window,
+		colormap:      colormap,
 		width:         physWidth,
 		height:        physHeight,
 		startTime:     time.Now(),
@@ -1720,6 +1725,11 @@ func (p *Platform) Destroy() {
 
 			_ = p.conn.DestroyWindow(w.window)
 			w.window = 0
+		}
+		// Free the ARGB colormap created for transparent windows.
+		if w != nil && w.colormap != 0 {
+			_ = p.conn.FreeColormap(w.colormap)
+			w.colormap = 0
 		}
 		_ = p.conn.Close()
 		p.conn = nil

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -23,17 +23,18 @@ import (
 // Config holds configuration for creating a platform window.
 // This mirrors platform.Config to avoid import cycles.
 type Config struct {
-	Title      string
-	Width      int
-	Height     int
-	Resizable  bool
-	Fullscreen bool
-	Frameless  bool
-	MinWidth   int // 0 = no minimum constraint
-	MinHeight  int // 0 = no minimum constraint
-	MaxWidth   int // 0 = no maximum constraint
-	MaxHeight  int // 0 = no maximum constraint
-	Icon       image.Image
+	Title       string
+	Width       int
+	Height      int
+	Resizable   bool
+	Fullscreen  bool
+	Frameless   bool
+	Transparent bool
+	MinWidth    int // 0 = no minimum constraint
+	MinHeight   int // 0 = no minimum constraint
+	MaxWidth    int // 0 = no maximum constraint
+	MaxHeight   int // 0 = no maximum constraint
+	Icon        image.Image
 }
 
 // EventType represents the type of platform event.
@@ -337,13 +338,14 @@ func (p *Platform) Init(config Config) error {
 
 	// Create window with physical pixel dimensions
 	windowConfig := WindowConfig{
-		Title:      config.Title,
-		Width:      uint16(physWidth),
-		Height:     uint16(physHeight),
-		X:          0,
-		Y:          0,
-		Resizable:  config.Resizable,
-		Fullscreen: config.Fullscreen,
+		Title:       config.Title,
+		Width:       uint16(physWidth),
+		Height:      uint16(physHeight),
+		X:           0,
+		Y:           0,
+		Resizable:   config.Resizable,
+		Fullscreen:  config.Fullscreen,
+		Transparent: config.Transparent,
 	}
 
 	window, err := conn.CreateWindow(windowConfig)

--- a/internal/platform/x11/transparent_test.go
+++ b/internal/platform/x11/transparent_test.go
@@ -117,3 +117,65 @@ func TestFreeColormapRequest(t *testing.T) {
 		t.Errorf("FreeColormap request = %v, want %v", got, want)
 	}
 }
+
+// TestEncodeCreateWindowRequest_TransparentValueOrder verifies the value mask
+// and value list for a transparent 32-bit ARGB window: CWBorderPixel must be
+// present and values must be in ascending bit order
+// (BackPixmap, BorderPixel, EventMask, Colormap).
+func TestEncodeCreateWindowRequest_TransparentValueOrder(t *testing.T) {
+	const eventMask = 0x00000002
+	valueMask := uint32(CWBackPixmap | CWBorderPixel | CWEventMask | CWColormap)
+	valueList := []uint32{0, 0, eventMask, 0x40} // backpixmap, border_pixel, eventmask, colormap
+
+	got := encodeCreateWindowRequest(
+		LSBFirst, 0x10, 0x20,
+		0, 0, 640, 480,
+		32, 0x30, valueMask, valueList,
+	)
+	want := []byte{
+		1, 32, 12, 0, // opcode, depth, length (8 + 4 values)
+		0x10, 0x00, 0x00, 0x00, // window
+		0x20, 0x00, 0x00, 0x00, // parent
+		0x00, 0x00, 0x00, 0x00, // x, y
+		0x80, 0x02, 0xE0, 0x01, // width=640, height=480
+		0x00, 0x00, 0x01, 0x00, // border width, class=InputOutput
+		0x30, 0x00, 0x00, 0x00, // visual
+		0x09, 0x28, 0x00, 0x00, // value mask: 1|8|0x800|0x2000 = 0x2809
+		0x00, 0x00, 0x00, 0x00, // backpixmap = None
+		0x00, 0x00, 0x00, 0x00, // border_pixel = 0
+		0x02, 0x00, 0x00, 0x00, // event mask
+		0x40, 0x00, 0x00, 0x00, // colormap
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("transparent CreateWindow request = %v, want %v", got, want)
+	}
+}
+
+// TestEncodeCreateWindowRequest_OpaqueValueOrder verifies the default window
+// keeps the original two-value encoding (BackPixmap, EventMask).
+func TestEncodeCreateWindowRequest_OpaqueValueOrder(t *testing.T) {
+	const eventMask = 0x00000002
+	valueMask := uint32(CWBackPixmap | CWEventMask)
+	valueList := []uint32{0, eventMask}
+
+	got := encodeCreateWindowRequest(
+		LSBFirst, 0x10, 0x20,
+		0, 0, 800, 600,
+		24, 0x30, valueMask, valueList,
+	)
+	want := []byte{
+		1, 24, 10, 0, // opcode, depth, length (8 + 2 values)
+		0x10, 0x00, 0x00, 0x00, // window
+		0x20, 0x00, 0x00, 0x00, // parent
+		0x00, 0x00, 0x00, 0x00, // x, y
+		0x20, 0x03, 0x58, 0x02, // width=800, height=600
+		0x00, 0x00, 0x01, 0x00, // border width, class=InputOutput
+		0x30, 0x00, 0x00, 0x00, // visual
+		0x01, 0x08, 0x00, 0x00, // value mask: 1|0x800 = 0x0801
+		0x00, 0x00, 0x00, 0x00, // backpixmap = None
+		0x02, 0x00, 0x00, 0x00, // event mask
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("opaque CreateWindow request = %v, want %v", got, want)
+	}
+}

--- a/internal/platform/x11/transparent_test.go
+++ b/internal/platform/x11/transparent_test.go
@@ -105,3 +105,15 @@ func TestCreateColormapRequest_BigEndian(t *testing.T) {
 		t.Errorf("big-endian request = %v, want %v", got, want)
 	}
 }
+
+// TestFreeColormapRequest verifies the wire encoding of FreeColormap.
+func TestFreeColormapRequest(t *testing.T) {
+	got := createFreeColormapRequest(LSBFirst, 0x11223344)
+	want := []byte{
+		79, 0, 2, 0, // opcode, unused, length
+		0x44, 0x33, 0x22, 0x11, // colormap
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("FreeColormap request = %v, want %v", got, want)
+	}
+}

--- a/internal/platform/x11/transparent_test.go
+++ b/internal/platform/x11/transparent_test.go
@@ -1,0 +1,107 @@
+//go:build linux
+
+package x11
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestFindARGBVisual_SelectsDepth32 verifies that a 32-bit TrueColor visual
+// with an unoccupied alpha byte is selected over the root visual.
+func TestFindARGBVisual_SelectsDepth32(t *testing.T) {
+	screen := &ScreenInfo{
+		RootVisual: 0x10,
+		RootDepth:  24,
+		Depths: []DepthInfo{
+			{
+				Depth: 24,
+				Visuals: []VisualType{
+					{VisualID: 0x10, Class: classTrueColor, RedMask: 0xFF0000, GreenMask: 0x00FF00, BlueMask: 0x0000FF},
+				},
+			},
+			{
+				Depth: 32,
+				Visuals: []VisualType{
+					{VisualID: 0x20, Class: classTrueColor, RedMask: 0x00FF0000, GreenMask: 0x0000FF00, BlueMask: 0x000000FF},
+				},
+			},
+		},
+	}
+
+	visual, depth, ok := findARGBVisual(screen)
+	if !ok {
+		t.Fatal("findARGBVisual returned ok=false, want an ARGB visual")
+	}
+	if visual.VisualID != 0x20 {
+		t.Errorf("VisualID = %#x, want 0x20", visual.VisualID)
+	}
+	if depth != 32 {
+		t.Errorf("depth = %d, want 32", depth)
+	}
+}
+
+// TestFindARGBVisual_NoARGBReturnsFalse verifies the fallback path when the
+// screen has no usable 32-bit visual.
+func TestFindARGBVisual_NoARGBReturnsFalse(t *testing.T) {
+	screen := &ScreenInfo{
+		RootVisual: 0x10,
+		RootDepth:  24,
+		Depths: []DepthInfo{
+			{
+				Depth: 24,
+				Visuals: []VisualType{
+					{VisualID: 0x10, Class: classTrueColor, RedMask: 0xFF0000, GreenMask: 0x00FF00, BlueMask: 0x0000FF},
+				},
+			},
+			{
+				Depth: 32,
+				Visuals: []VisualType{
+					// Masks cover all 32 bits — no alpha byte.
+					{VisualID: 0x21, Class: classTrueColor, RedMask: 0xFF000000, GreenMask: 0x00FF0000, BlueMask: 0x0000FFFF},
+				},
+			},
+		},
+	}
+
+	if _, _, ok := findARGBVisual(screen); ok {
+		t.Error("findARGBVisual returned ok=true, want false for a visual without alpha")
+	}
+	if _, _, ok := findARGBVisual(nil); ok {
+		t.Error("findARGBVisual(nil) returned ok=true, want false")
+	}
+}
+
+// TestCreateColormapRequest_LittleEndian verifies the wire encoding of the
+// CreateColormap request on a little-endian connection.
+func TestCreateColormapRequest_LittleEndian(t *testing.T) {
+	got := createColormapRequest(LSBFirst, 0x11223344, 0x55667788, 0x99AABBCC, allocNone)
+	want := []byte{
+		78, 0, 5, 0, // opcode, unused, length
+		0x44, 0x33, 0x22, 0x11, // colormap
+		0x88, 0x77, 0x66, 0x55, // window
+		0xCC, 0xBB, 0xAA, 0x99, // visual
+		0,       // alloc
+		0, 0, 0, // pad to 20 bytes
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("little-endian request = %v, want %v", got, want)
+	}
+}
+
+// TestCreateColormapRequest_BigEndian verifies the wire encoding of the
+// CreateColormap request on a big-endian connection.
+func TestCreateColormapRequest_BigEndian(t *testing.T) {
+	got := createColormapRequest(MSBFirst, 0x11223344, 0x55667788, 0x99AABBCC, allocNone)
+	want := []byte{
+		78, 0, 0, 5, // opcode, unused, length
+		0x11, 0x22, 0x33, 0x44, // colormap
+		0x55, 0x66, 0x77, 0x88, // window
+		0x99, 0xAA, 0xBB, 0xCC, // visual
+		0,       // alloc
+		0, 0, 0, // pad to 20 bytes
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("big-endian request = %v, want %v", got, want)
+	}
+}

--- a/internal/platform/x11/window.go
+++ b/internal/platform/x11/window.go
@@ -44,7 +44,7 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, ResourceID, 
 	// server paint newly-exposed areas black on resize before the GPU repaints
 	// (black flicker). None leaves the background untouched — we repaint on resize
 	// and Expose. GLFW/SDL/Chromium pattern.
-	valueMask := uint32(CWBackPixmap | CWEventMask)
+	valueMask := uint32(CWBackPixmap)
 	depth := screen.RootDepth
 	visual := screen.RootVisual
 
@@ -62,11 +62,9 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, ResourceID, 
 			EventMaskLeaveWindow |
 			EventMaskPropertyChange)
 
-	// Value list (order matters - must match bit order in valueMask)
-	valueList := []uint32{
-		0,         // CWBackPixmap = None — no background fill on resize (anti-flicker)
-		eventMask, // CWEventMask
-	}
+	// Value list (order matters — must match ascending bit order in valueMask).
+	// CWBackPixmap = None — no background fill on resize (anti-flicker).
+	valueList := []uint32{0}
 
 	// Per-pixel alpha: create the window with a 32-bit ARGB visual and a
 	// matching colormap so the compositor can blend the surface alpha
@@ -82,25 +80,47 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, ResourceID, 
 			colormap = cmap
 			depth = argbDepth
 			visual = argb.VisualID
+			// X11 requires CWBorderPixel when the window depth differs from
+			// the root visual; omitting it makes XCreateWindow return BadMatch
+			// (winit sets border_pixel(0) for the same reason).
+			valueMask |= CWBorderPixel
+			valueList = append(valueList, 0) // CWBorderPixel = 0
 			valueMask |= CWColormap
-			valueList = append(valueList, uint32(cmap))
 		}
 	}
 
-	// Build request
-	// Request length = 8 + len(valueList) in 4-byte units
-	reqLen := uint16(8 + len(valueList))
+	valueMask |= CWEventMask
+	valueList = append(valueList, eventMask) // CWEventMask
+	if colormap != 0 {
+		valueList = append(valueList, uint32(colormap)) // CWColormap
+	}
 
-	e := NewEncoder(c.byteOrder)
+	req := encodeCreateWindowRequest(
+		c.byteOrder, windowID, screen.Root,
+		config.X, config.Y, config.Width, config.Height,
+		depth, visual, valueMask, valueList,
+	)
+
+	if _, err := c.sendRequest(req); err != nil {
+		return 0, 0, fmt.Errorf("x11: CreateWindow failed: %w", err)
+	}
+
+	return windowID, colormap, nil
+}
+
+// encodeCreateWindowRequest builds the CreateWindow request body.
+// Request length = 8 + len(valueList) in 4-byte units.
+func encodeCreateWindowRequest(bo ByteOrder, windowID ResourceID, parent ResourceID, x, y int16, width, height uint16, depth uint8, visual uint32, valueMask uint32, valueList []uint32) []byte {
+	e := NewEncoder(bo)
 	e.PutUint8(OpcodeCreateWindow)
 	e.PutUint8(depth) // depth
-	e.PutUint16(reqLen)
+	e.PutUint16(uint16(8 + len(valueList)))
 	e.PutUint32(uint32(windowID))
-	e.PutUint32(uint32(screen.Root))
-	e.PutInt16(config.X)
-	e.PutInt16(config.Y)
-	e.PutUint16(config.Width)
-	e.PutUint16(config.Height)
+	e.PutUint32(uint32(parent))
+	e.PutInt16(x)
+	e.PutInt16(y)
+	e.PutUint16(width)
+	e.PutUint16(height)
 	e.PutUint16(0) // border width
 	e.PutUint16(WindowClassInputOutput)
 	e.PutUint32(visual)
@@ -108,12 +128,7 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, ResourceID, 
 	for _, v := range valueList {
 		e.PutUint32(v)
 	}
-
-	if _, err := c.sendRequest(e.Bytes()); err != nil {
-		return 0, 0, fmt.Errorf("x11: CreateWindow failed: %w", err)
-	}
-
-	return windowID, colormap, nil
+	return e.Bytes()
 }
 
 // findARGBVisual returns a 32-bit TrueColor visual whose RGB masks leave

--- a/internal/platform/x11/window.go
+++ b/internal/platform/x11/window.go
@@ -27,15 +27,18 @@ const classTrueColor = 4
 // color cells lazily from the colormap.
 const allocNone = 0
 
-// CreateWindow creates a new X11 window.
-func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
+// CreateWindow creates a new X11 window. It returns the window ID and, when
+// a transparent ARGB visual was used, the matching colormap ID (0 otherwise)
+// so callers can free it on teardown.
+func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, ResourceID, error) {
 	screen := c.DefaultScreen()
 	if screen == nil {
-		return 0, fmt.Errorf("x11: no default screen")
+		return 0, 0, fmt.Errorf("x11: no default screen")
 	}
 
 	// Generate window ID
 	windowID := c.GenerateID()
+	colormap := ResourceID(0)
 
 	// Background pixmap None, not a black BackPixel: a black BackPixel makes the X
 	// server paint newly-exposed areas black on resize before the GPU repaints
@@ -74,8 +77,9 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
 		if argb, argbDepth, ok := findARGBVisual(screen); ok {
 			cmap := c.GenerateID()
 			if err := c.CreateColormap(cmap, screen.Root, argb.VisualID, allocNone); err != nil {
-				return 0, err
+				return 0, 0, err
 			}
+			colormap = cmap
 			depth = argbDepth
 			visual = argb.VisualID
 			valueMask |= CWColormap
@@ -106,10 +110,10 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
 	}
 
 	if _, err := c.sendRequest(e.Bytes()); err != nil {
-		return 0, fmt.Errorf("x11: CreateWindow failed: %w", err)
+		return 0, 0, fmt.Errorf("x11: CreateWindow failed: %w", err)
 	}
 
-	return windowID, nil
+	return windowID, colormap, nil
 }
 
 // findARGBVisual returns a 32-bit TrueColor visual whose RGB masks leave
@@ -160,6 +164,26 @@ func (c *Connection) CreateColormap(id, window ResourceID, visual uint32, alloc 
 		return fmt.Errorf("x11: CreateColormap failed: %w", err)
 	}
 	return nil
+}
+
+// FreeColormap frees a colormap resource.
+func (c *Connection) FreeColormap(colormap ResourceID) error {
+	req := createFreeColormapRequest(c.byteOrder, colormap)
+	if _, err := c.sendRequest(req); err != nil {
+		return fmt.Errorf("x11: FreeColormap failed: %w", err)
+	}
+	return nil
+}
+
+// createFreeColormapRequest builds the FreeColormap request body.
+// Wire format: opcode, unused, length=2, colormap.
+func createFreeColormapRequest(bo ByteOrder, colormap ResourceID) []byte {
+	e := NewEncoder(bo)
+	e.PutUint8(OpcodeFreeColormap)
+	e.PutUint8(0)  // unused
+	e.PutUint16(2) // length
+	e.PutUint32(uint32(colormap))
+	return e.Bytes()
 }
 
 // MapWindow makes a window visible.

--- a/internal/platform/x11/window.go
+++ b/internal/platform/x11/window.go
@@ -10,14 +10,22 @@ import (
 
 // WindowConfig holds configuration for creating a window.
 type WindowConfig struct {
-	Title      string
-	Width      uint16
-	Height     uint16
-	X          int16
-	Y          int16
-	Resizable  bool
-	Fullscreen bool
+	Title       string
+	Width       uint16
+	Height      uint16
+	X           int16
+	Y           int16
+	Resizable   bool
+	Fullscreen  bool
+	Transparent bool
 }
+
+// X11 visual class for TrueColor (depth 24/32).
+const classTrueColor = 4
+
+// allocNone is the AllocNone value for CreateColormap: the server allocates
+// color cells lazily from the colormap.
+const allocNone = 0
 
 // CreateWindow creates a new X11 window.
 func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
@@ -34,6 +42,8 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
 	// (black flicker). None leaves the background untouched — we repaint on resize
 	// and Expose. GLFW/SDL/Chromium pattern.
 	valueMask := uint32(CWBackPixmap | CWEventMask)
+	depth := screen.RootDepth
+	visual := screen.RootVisual
 
 	// Event mask - listen for common events
 	eventMask := uint32(
@@ -55,13 +65,31 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
 		eventMask, // CWEventMask
 	}
 
+	// Per-pixel alpha: create the window with a 32-bit ARGB visual and a
+	// matching colormap so the compositor can blend the surface alpha
+	// against the desktop (GLFW/SDL3 pattern, ADR-060). Falls back to the
+	// root visual when no ARGB visual is available — transparency then
+	// silently degrades to opaque.
+	if config.Transparent {
+		if argb, argbDepth, ok := findARGBVisual(screen); ok {
+			cmap := c.GenerateID()
+			if err := c.CreateColormap(cmap, screen.Root, argb.VisualID, allocNone); err != nil {
+				return 0, err
+			}
+			depth = argbDepth
+			visual = argb.VisualID
+			valueMask |= CWColormap
+			valueList = append(valueList, uint32(cmap))
+		}
+	}
+
 	// Build request
 	// Request length = 8 + len(valueList) in 4-byte units
 	reqLen := uint16(8 + len(valueList))
 
 	e := NewEncoder(c.byteOrder)
 	e.PutUint8(OpcodeCreateWindow)
-	e.PutUint8(screen.RootDepth) // depth
+	e.PutUint8(depth) // depth
 	e.PutUint16(reqLen)
 	e.PutUint32(uint32(windowID))
 	e.PutUint32(uint32(screen.Root))
@@ -71,7 +99,7 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
 	e.PutUint16(config.Height)
 	e.PutUint16(0) // border width
 	e.PutUint16(WindowClassInputOutput)
-	e.PutUint32(screen.RootVisual)
+	e.PutUint32(visual)
 	e.PutUint32(valueMask)
 	for _, v := range valueList {
 		e.PutUint32(v)
@@ -82,6 +110,56 @@ func (c *Connection) CreateWindow(config WindowConfig) (ResourceID, error) {
 	}
 
 	return windowID, nil
+}
+
+// findARGBVisual returns a 32-bit TrueColor visual whose RGB masks leave
+// the top byte free for alpha, plus its depth. Returns ok=false when the
+// screen has no ARGB visual so callers can fall back to the root visual.
+func findARGBVisual(screen *ScreenInfo) (VisualType, uint8, bool) {
+	if screen == nil {
+		return VisualType{}, 0, false
+	}
+	for _, depth := range screen.Depths {
+		if depth.Depth != 32 {
+			continue
+		}
+		for _, v := range depth.Visuals {
+			if v.Class != classTrueColor {
+				continue
+			}
+			mask := v.RedMask | v.GreenMask | v.BlueMask
+			// A 32-bit TrueColor visual without alpha covers all 32 bits;
+			// an ARGB visual leaves the top byte unoccupied.
+			if mask != 0 && mask != 0xFFFFFFFF {
+				return v, depth.Depth, true
+			}
+		}
+	}
+	return VisualType{}, 0, false
+}
+
+// createColormapRequest builds the CreateColormap request body.
+// Wire format: opcode, unused, length=5, colormap, window, visual, alloc, pad.
+func createColormapRequest(bo ByteOrder, id, window ResourceID, visual uint32, alloc uint8) []byte {
+	e := NewEncoder(bo)
+	e.PutUint8(OpcodeCreateColormap)
+	e.PutUint8(0)  // unused
+	e.PutUint16(5) // length: 20 bytes / 4
+	e.PutUint32(uint32(id))
+	e.PutUint32(uint32(window))
+	e.PutUint32(visual)
+	e.PutUint8(alloc)
+	e.PutPad()
+	return e.Bytes()
+}
+
+// CreateColormap creates a colormap for the given visual.
+func (c *Connection) CreateColormap(id, window ResourceID, visual uint32, alloc uint8) error {
+	req := createColormapRequest(c.byteOrder, id, window, visual, alloc)
+	if _, err := c.sendRequest(req); err != nil {
+		return fmt.Errorf("x11: CreateColormap failed: %w", err)
+	}
+	return nil
 }
 
 // MapWindow makes a window visible.

--- a/renderer.go
+++ b/renderer.go
@@ -70,6 +70,10 @@ type RenderTarget struct {
 	// VSync preference for this window
 	vsync bool
 
+	// transparent requests CompositeAlphaModePremultiplied for this surface
+	// when the adapter advertises support (ADR-060, gogpu#361).
+	transparent bool
+
 	// damageRects holds the dirty regions for the current frame (physical pixels,
 	// top-left origin). Set by Context.SetDamageRects(), consumed and cleared by
 	// present(). When nil, the full surface is presented (backward compatible).
@@ -180,14 +184,15 @@ type Renderer struct {
 }
 
 // newRenderer creates and initializes a new renderer.
-func newRenderer(platWin platform.PlatformWindow, graphicsAPI types.GraphicsAPI, vsync bool, powerPref gputypes.PowerPreference) (*Renderer, error) {
+func newRenderer(platWin platform.PlatformWindow, graphicsAPI types.GraphicsAPI, vsync bool, powerPref gputypes.PowerPreference, transparent bool) (*Renderer, error) {
 	r := &Renderer{
 		powerPreference: powerPref,
 	}
 	r.primary = &RenderTarget{
-		renderer:   r,
-		platWindow: platWin,
-		vsync:      vsync,
+		renderer:    r,
+		platWindow:  platWin,
+		vsync:       vsync,
+		transparent: transparent,
 	}
 
 	// Phase 1: Create GPU instance with backend mask (may include multiple backends).
@@ -299,14 +304,16 @@ func (r *Renderer) configureSurface(ws *RenderTarget) error {
 
 // configure configures the wgpu surface with current dimensions and format.
 func (ws *RenderTarget) configure(device *wgpu.Device, adapter *wgpu.Adapter) error {
-	presentMode := ws.resolvePresentMode(adapter)
+	caps := adapter.GetSurfaceCapabilities(ws.surface)
+	presentMode := resolvePresentMode(caps, ws.vsync)
+	alphaMode := resolveAlphaMode(caps, ws.transparent)
 
 	return ws.surface.Configure(device, &wgpu.SurfaceConfiguration{
 		Format:      ws.format,
 		Usage:       gputypes.TextureUsageRenderAttachment,
 		Width:       ws.width,
 		Height:      ws.height,
-		AlphaMode:   gputypes.CompositeAlphaModeOpaque,
+		AlphaMode:   alphaMode,
 		PresentMode: presentMode,
 	})
 }
@@ -315,23 +322,22 @@ func (ws *RenderTarget) configure(device *wgpu.Device, adapter *wgpu.Adapter) er
 // Rust wgpu fallback pattern. For VSync on (AutoVsync): FifoRelaxed -> Fifo.
 // For VSync off (AutoNoVsync): Immediate -> Mailbox -> Fifo.
 // Falls back to Fifo which is guaranteed by the Vulkan spec.
-func (ws *RenderTarget) resolvePresentMode(adapter *wgpu.Adapter) gputypes.PresentMode {
-	caps := adapter.GetSurfaceCapabilities(ws.surface)
+func resolvePresentMode(caps *wgpu.SurfaceCapabilities, vsync bool) gputypes.PresentMode {
 	if caps == nil {
 		// No capabilities available — use safe default.
 		mode := gputypes.PresentModeFifo
-		if !ws.vsync {
+		if !vsync {
 			mode = gputypes.PresentModeImmediate
 		}
 		slog.Debug("gogpu: no surface capabilities, using default present mode",
-			"mode", mode, "vsync", ws.vsync)
+			"mode", mode, "vsync", vsync)
 		return mode
 	}
 
 	supported := caps.PresentModes
 	var mode gputypes.PresentMode
 
-	if ws.vsync {
+	if vsync {
 		// VSync on: FifoRelaxed -> Fifo (like Rust AutoVsync).
 		mode = pickPresentMode(supported,
 			gputypes.PresentModeFifoRelaxed,
@@ -347,8 +353,30 @@ func (ws *RenderTarget) resolvePresentMode(adapter *wgpu.Adapter) gputypes.Prese
 	}
 
 	slog.Debug("gogpu: resolved present mode",
-		"mode", mode, "vsync", ws.vsync, "supported", supported)
+		"mode", mode, "vsync", vsync, "supported", supported)
 	return mode
+}
+
+// resolveAlphaMode selects the surface alpha compositing mode.
+// Transparent windows request CompositeAlphaModePremultiplied; if the
+// adapter does not advertise it (or capabilities are unavailable) the
+// surface falls back to Opaque, preserving pre-ADR-060 behavior.
+func resolveAlphaMode(caps *wgpu.SurfaceCapabilities, transparent bool) gputypes.CompositeAlphaMode {
+	if !transparent {
+		return gputypes.CompositeAlphaModeOpaque
+	}
+	if caps == nil {
+		slog.Debug("gogpu: no surface capabilities, using opaque alpha mode")
+		return gputypes.CompositeAlphaModeOpaque
+	}
+	for _, mode := range caps.AlphaModes {
+		if mode == gputypes.CompositeAlphaModePremultiplied {
+			return mode
+		}
+	}
+	slog.Debug("gogpu: premultiplied alpha unsupported, using opaque alpha mode",
+		"supported", caps.AlphaModes)
+	return gputypes.CompositeAlphaModeOpaque
 }
 
 // pickPresentMode returns the first mode from preferred that is in supported.

--- a/renderer_init_test.go
+++ b/renderer_init_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gogpu/gogpu/gpu/types"
 	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
 )
 
 // TestConfigureSurface_ZeroDimensionsSkips verifies that configureSurface
@@ -154,6 +155,67 @@ func TestPickPresentMode_EmptySupportedReturnsFifo(t *testing.T) {
 	got := pickPresentMode(nil, gputypes.PresentModeImmediate)
 	if got != gputypes.PresentModeFifo {
 		t.Errorf("pickPresentMode(nil) = %v, want Fifo", got)
+	}
+}
+
+// TestResolvePresentMode_NilCapsUsesVsyncDefault verifies the nil-capabilities
+// fallback keeps the previous default-mode behavior after the refactor.
+func TestResolvePresentMode_NilCapsUsesVsyncDefault(t *testing.T) {
+	if got := resolvePresentMode(nil, true); got != gputypes.PresentModeFifo {
+		t.Errorf("resolvePresentMode(nil, vsync=true) = %v, want Fifo", got)
+	}
+	if got := resolvePresentMode(nil, false); got != gputypes.PresentModeImmediate {
+		t.Errorf("resolvePresentMode(nil, vsync=false) = %v, want Immediate", got)
+	}
+}
+
+// TestResolvePresentMode_PicksFromCapabilities verifies present-mode selection
+// honors the supported list from surface capabilities.
+func TestResolvePresentMode_PicksFromCapabilities(t *testing.T) {
+	caps := &wgpu.SurfaceCapabilities{
+		PresentModes: []gputypes.PresentMode{gputypes.PresentModeFifo},
+	}
+	if got := resolvePresentMode(caps, false); got != gputypes.PresentModeFifo {
+		t.Errorf("resolvePresentMode(caps, vsync=false) = %v, want Fifo (only supported)", got)
+	}
+}
+
+// TestResolveAlphaMode_OpaqueWhenNotTransparent verifies the default surface
+// configuration stays CompositeAlphaModeOpaque (backward compatible).
+func TestResolveAlphaMode_OpaqueWhenNotTransparent(t *testing.T) {
+	caps := &wgpu.SurfaceCapabilities{
+		AlphaModes: []gputypes.CompositeAlphaMode{gputypes.CompositeAlphaModePremultiplied},
+	}
+	if got := resolveAlphaMode(caps, false); got != gputypes.CompositeAlphaModeOpaque {
+		t.Errorf("resolveAlphaMode(caps, false) = %v, want Opaque", got)
+	}
+}
+
+// TestResolveAlphaMode_PremultipliedWhenSupported verifies transparent windows
+// select CompositeAlphaModePremultiplied when the adapter advertises it.
+func TestResolveAlphaMode_PremultipliedWhenSupported(t *testing.T) {
+	caps := &wgpu.SurfaceCapabilities{
+		AlphaModes: []gputypes.CompositeAlphaMode{
+			gputypes.CompositeAlphaModeOpaque,
+			gputypes.CompositeAlphaModePremultiplied,
+		},
+	}
+	if got := resolveAlphaMode(caps, true); got != gputypes.CompositeAlphaModePremultiplied {
+		t.Errorf("resolveAlphaMode(caps, true) = %v, want Premultiplied", got)
+	}
+}
+
+// TestResolveAlphaMode_FallsBackToOpaque verifies transparent windows degrade
+// to Opaque when premultiplied alpha is unsupported or capabilities are nil.
+func TestResolveAlphaMode_FallsBackToOpaque(t *testing.T) {
+	opaqueOnly := &wgpu.SurfaceCapabilities{
+		AlphaModes: []gputypes.CompositeAlphaMode{gputypes.CompositeAlphaModeOpaque},
+	}
+	if got := resolveAlphaMode(opaqueOnly, true); got != gputypes.CompositeAlphaModeOpaque {
+		t.Errorf("resolveAlphaMode(opaqueOnly, true) = %v, want Opaque fallback", got)
+	}
+	if got := resolveAlphaMode(nil, true); got != gputypes.CompositeAlphaModeOpaque {
+		t.Errorf("resolveAlphaMode(nil, true) = %v, want Opaque fallback", got)
 	}
 }
 

--- a/window_manager.go
+++ b/window_manager.go
@@ -310,6 +310,7 @@ func (a *App) NewWindow(config Config) (*Window, error) {
 		Resizable:         config.Resizable,
 		Fullscreen:        config.Fullscreen,
 		Frameless:         config.Frameless,
+		Transparent:       config.Transparent,
 		TabbingMode:       int(config.TabbingMode),
 		TabbingIdentifier: config.TabbingIdentifier,
 	})

--- a/window_manager.go
+++ b/window_manager.go
@@ -332,12 +332,13 @@ func (a *App) NewWindow(config Config) (*Window, error) {
 
 	// Create RenderTarget for this window.
 	ws := &RenderTarget{
-		renderer:   a.renderer,
-		platWindow: platWindow,
-		surface:    surface,
-		format:     a.renderer.surfaceFormat,
-		vsync:      false, // Secondary windows: Immediate (ADR-010 VSync strategy)
-		state:      SurfaceReady,
+		renderer:    a.renderer,
+		platWindow:  platWindow,
+		surface:     surface,
+		format:      a.renderer.surfaceFormat,
+		vsync:       false, // Secondary windows: Immediate (ADR-010 VSync strategy)
+		transparent: config.Transparent,
+		state:       SurfaceReady,
 	}
 
 	// Configure surface with initial dimensions on the render thread.


### PR DESCRIPTION
Part of #361 (ADR-060). Stacked on #419 — this branch contains the #419 commits; once #419 merges, the diff will narrow to just this PR's changes.

**Changes**
- **Windows**: \DwmEnableBlurBehindWindow\ with an empty region (\CreateRectRgn(0,0,-1,-1)\) — the winit/SDL3 pattern. \WS_EX_LAYERED\ is intentionally NOT used (GDI whole-window opacity, per the maintainer's guidance)
- **macOS**: \NSWindow isOpaque=false\ at creation + \CAMetalLayer isOpaque=false\ on the surface layer. The wgpu HAL CAMetalLayer follow-up remains tracked separately
- **X11**: transparent windows use a 32-bit ARGB TrueColor visual plus a matching colormap, with root-visual fallback when unavailable
- **Wayland**: compositor-owned transparency — gogpu never sets an opaque region
- \platform.Config.Transparent\ plumbed through primary and secondary window creation

**Tests**
- X11 ARGB visual selection (found / not found / nil screen)
- X11 \CreateColormap\ wire encoding (little + big endian)
- Full Windows test suite + Linux/macOS cross-compile