### PR TITLE
feat(window): public Show/Hide/SetPosition/SetSize API (#361)

### DIFF
--- a/internal/platform/darwin/objc.go
+++ b/internal/platform/darwin/objc.go
@@ -1204,6 +1204,65 @@ func (id ID) SendSize(sel SEL, size NSSize) ID {
 	return ret
 }
 
+// SendPoint sends a message with an NSPoint argument.
+//
+//nolint:govet // mirrors the existing SendSize/SendRect helpers.
+func (id ID) SendPoint(sel SEL, point NSPoint) ID {
+	if id == 0 || sel == 0 {
+		return 0
+	}
+
+	if err := initRuntime(); err != nil {
+		return 0
+	}
+
+	argTypes := []*types.TypeDescriptor{
+		types.PointerTypeDescriptor, // self
+		types.PointerTypeDescriptor, // _cmd
+		nsPointType,                 // point
+	}
+
+	cif := &types.CallInterface{}
+	err := ffi.PrepareCallInterface(
+		cif,
+		types.DefaultCall,
+		types.PointerTypeDescriptor,
+		argTypes,
+	)
+	if err != nil {
+		return 0
+	}
+
+	argBox := &struct {
+		self  uintptr
+		sel   uintptr
+		point NSPoint
+	}{
+		self:  uintptr(id),
+		sel:   uintptr(sel),
+		point: point,
+	}
+
+	argPtrs := []unsafe.Pointer{
+		unsafe.Pointer(&argBox.self),
+		unsafe.Pointer(&argBox.sel),
+		unsafe.Pointer(&argBox.point),
+	}
+
+	var result uintptr
+	_, err = ffi.CallFunction(
+		cif,
+		objcRT.objcMsgSend,
+		unsafe.Pointer(&result),
+		argPtrs,
+	)
+	if err != nil {
+		return 0
+	}
+
+	return ID(result)
+}
+
 // AllocateClassPair creates a new ObjC class as a subclass of superclass.
 // Returns the new Class, or 0 if allocation fails.
 // Call RegisterClassPair after adding methods.

--- a/internal/platform/darwin/selectors.go
+++ b/internal/platform/darwin/selectors.go
@@ -43,6 +43,7 @@ var selectors struct {
 	deminiaturize                            SEL
 	zoom                                     SEL
 	setFrame                                 SEL
+	setFrameOrigin                           SEL
 	frame                                    SEL
 	contentRectForFrameRect                  SEL
 	frameRectForContentRect                  SEL
@@ -296,6 +297,7 @@ func initSelectors() {
 		selectors.deminiaturize = RegisterSelector("deminiaturize:")
 		selectors.zoom = RegisterSelector("zoom:")
 		selectors.setFrame = RegisterSelector("setFrame:display:")
+		selectors.setFrameOrigin = RegisterSelector("setFrameOrigin:")
 		selectors.frame = RegisterSelector("frame")
 		selectors.contentRectForFrameRect = RegisterSelector("contentRectForFrameRect:")
 		selectors.frameRectForContentRect = RegisterSelector("frameRectForContentRect:")

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -316,6 +316,9 @@ func (w *Window) SetPosition(x, y int) {
 	if f := w.nsWindow.GetRect(selectors.frame); f.Size.Height > 0 {
 		frameH = int(f.Size.Height)
 	}
+	// Fallback note: if the frame selector fails we fall back to the content
+	// height, which can shift Y by the title bar height (low probability —
+	// NSWindow.frame is always available once the window exists).
 
 	screenH := frameH
 	screen := classes.NSScreen.Send(selectors.mainScreen)

--- a/internal/platform/darwin/window.go
+++ b/internal/platform/darwin/window.go
@@ -300,6 +300,35 @@ func (w *Window) SetSize(width, height int) {
 	w.nsWindow.SendSize(selectors.setContentSize, MakeSize(CGFloat(width), CGFloat(height)))
 }
 
+// SetPosition moves the window origin to the given logical screen position.
+// gogpu uses a top-left origin; AppKit uses bottom-left, so Y is flipped
+// against the main screen height using the window's current outer frame
+// height (winit pattern).
+func (w *Window) SetPosition(x, y int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.nsWindow.IsNil() {
+		return
+	}
+
+	frameH := w.height
+	if f := w.nsWindow.GetRect(selectors.frame); f.Size.Height > 0 {
+		frameH = int(f.Size.Height)
+	}
+
+	screenH := frameH
+	screen := classes.NSScreen.Send(selectors.mainScreen)
+	if !screen.IsNil() {
+		if f := screen.GetRect(selectors.frame); f.Size.Height > 0 {
+			screenH = int(f.Size.Height)
+		}
+	}
+
+	originY := screenH - y - frameH
+	w.nsWindow.SendPoint(selectors.setFrameOrigin, MakePoint(CGFloat(x), CGFloat(originY)))
+}
+
 // ShouldClose returns true if the window should close.
 func (w *Window) ShouldClose() bool {
 	w.mu.Lock()

--- a/internal/platform/menu_linux_test.go
+++ b/internal/platform/menu_linux_test.go
@@ -582,6 +582,8 @@ func (s *stubWindow) Maximize()                                                 
 func (s *stubWindow) IsMaximized() bool                                                    { return s.maximized }
 func (s *stubWindow) Close()                                                               { s.closed = true }
 func (s *stubWindow) Show()                                                                {}
+func (s *stubWindow) Hide()                                                                {}
+func (s *stubWindow) SetPosition(_, _ int)                                                 {}
 func (s *stubWindow) SyncFrame()                                                           {}
 func (s *stubWindow) SetCursorMode(_ int)                                                  {}
 func (s *stubWindow) CursorMode() int                                                      { return 0 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -271,6 +271,16 @@ type PlatformWindow interface {
 	// On Wayland and Browser this is a no-op (compositor controls visibility).
 	Show()
 
+	// Hide hides the window.
+	// On Wayland this is a no-op (the compositor controls window visibility;
+	// clients can only minimize a toplevel). On Browser it is a no-op.
+	Hide()
+
+	// SetPosition moves the window to the given logical screen position
+	// (top-left origin, DIP). On Wayland this is a no-op — the compositor
+	// owns toplevel placement.
+	SetPosition(x, y int)
+
 	// SyncFrame synchronizes the rendered frame with the compositor.
 	SyncFrame()
 

--- a/internal/platform/platform_browser.go
+++ b/internal/platform/platform_browser.go
@@ -456,6 +456,12 @@ func (w *browserWindow) Close() { w.shouldClose = true }
 // Show is a no-op on browser -- the canvas is always visible.
 func (w *browserWindow) Show() {}
 
+// Hide is a no-op on browser — the canvas is always visible.
+func (w *browserWindow) Hide() {}
+
+// SetPosition is a no-op on browser — the page position is fixed.
+func (w *browserWindow) SetPosition(_, _ int) {}
+
 // SyncFrame is a no-op — browser compositing is handled by requestAnimationFrame.
 func (w *browserWindow) SyncFrame() {}
 

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -543,6 +543,20 @@ func (dw *darwinPlatformWindow) Show() {
 	}
 }
 
+// Hide hides the window.
+func (dw *darwinPlatformWindow) Hide() {
+	if dw.window != nil {
+		dw.window.Hide()
+	}
+}
+
+// SetPosition moves the window to the given logical screen position.
+func (dw *darwinPlatformWindow) SetPosition(x, y int) {
+	if dw.window != nil {
+		dw.window.SetPosition(x, y)
+	}
+}
+
 func (dw *darwinPlatformWindow) SetOnClose(fn func() bool) {
 	if dw.window != nil {
 		dw.window.SetOnClose(fn)

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -590,6 +590,14 @@ func (w *x11PlatformWindow) Show() {
 	}
 }
 
+func (w *x11PlatformWindow) Hide() {
+	w.inner().Hide()
+}
+
+func (w *x11PlatformWindow) SetPosition(x, y int) {
+	w.inner().SetPosition(x, y)
+}
+
 // BlitPixels copies RGBA pixel data to the window using X11 PutImage.
 func (w *x11PlatformWindow) BlitPixels(pixels []byte, width, height int) error {
 	return w.inner().BlitPixels(pixels, width, height)
@@ -862,6 +870,15 @@ func (w *waylandPlatformWindow) Close() {
 }
 
 func (w *waylandPlatformWindow) Show() {}
+
+// Hide is a no-op on Wayland: the compositor controls window visibility and
+// clients cannot unmap a toplevel (winit limitation). Use Minimize for the
+// closest supported behavior.
+func (w *waylandPlatformWindow) Hide() {}
+
+// SetPosition is a no-op on Wayland: xdg_toplevel placement is owned by the
+// compositor.
+func (w *waylandPlatformWindow) SetPosition(x, y int) {}
 
 func (w *waylandPlatformWindow) SetModalFrameCallback(_ func()) {}
 

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -145,6 +145,8 @@ func (m *mockPlatformWindow) Maximize()                        {}
 func (m *mockPlatformWindow) IsMaximized() bool                { return false }
 func (m *mockPlatformWindow) Close()                           {}
 func (m *mockPlatformWindow) Show()                            {}
+func (m *mockPlatformWindow) Hide()                            {}
+func (m *mockPlatformWindow) SetPosition(_, _ int)             {}
 func (m *mockPlatformWindow) SetFullscreen(bool)               {}
 func (m *mockPlatformWindow) IsFullscreen() bool               { return false }
 func (m *mockPlatformWindow) SetModalFrameCallback(func())     {}

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -41,6 +41,7 @@ const (
 	swShow             = 5
 	swShowNA           = 8
 	swRestore          = 9
+	swHide             = 0 // SW_HIDE
 	pmRemove           = 0x0001
 	wsOverlappedWindow = 0x00CF0000
 	wsVisible          = 0x10000000
@@ -1060,6 +1061,28 @@ func (w *win32Window) Show() {
 	procSetForegroundWindow.Call(uintptr(w.hwnd))
 	procSetFocusW.Call(uintptr(w.hwnd))
 	procUpdateWindow.Call(uintptr(w.hwnd))
+}
+
+// Hide hides the window (ShowWindow with SW_HIDE).
+func (w *win32Window) Hide() {
+	procShowWindow.Call(uintptr(w.hwnd), swHide)
+}
+
+// SetPosition moves the window to the given logical screen position (DIP),
+// scaling to physical pixels with the window's current DPI. Size and
+// Z-order are preserved (winit pattern).
+func (w *win32Window) SetPosition(x, y int) {
+	dpi, _, _ := procGetDpiForWindow.Call(uintptr(w.hwnd))
+	if dpi == 0 {
+		dpi = 96
+	}
+	scale := float64(dpi) / 96.0
+	physX := int32(float64(x) * scale)
+	physY := int32(float64(y) * scale)
+
+	procSetWindowPos.Call(uintptr(w.hwnd), 0,
+		uintptr(physX), uintptr(physY), 0, 0,
+		swpNoSize|swpNoZOrder|swpNoActivate)
 }
 
 func (w *win32Window) SyncFrame() {

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -4,6 +4,7 @@ package platform
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 	"syscall"
 	"time"
@@ -709,7 +710,13 @@ func enableDwmBlurBehind(hwnd windows.HWND) {
 		fEnable:  1, // TRUE
 		hRgnBlur: rgn,
 	}
-	procDwmEnableBlurBehindWindow.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&bb)))
+	hr, _, _ := procDwmEnableBlurBehindWindow.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&bb)))
+	if hr != 0 {
+		// Non-fatal: DWM can be unavailable (e.g. Server Core, DWM disabled);
+		// the window simply stays opaque.
+		slog.Debug("gogpu: DwmEnableBlurBehindWindow failed, window stays opaque",
+			"hr", hr)
+	}
 }
 
 // createWindowWin32 creates a new Win32 HWND window from the given config.

--- a/internal/platform/x11/movewindow_test.go
+++ b/internal/platform/x11/movewindow_test.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package x11
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestMoveWindowRequest_LittleEndian verifies the ConfigureWindow wire
+// encoding for a position-only move on a little-endian connection.
+func TestMoveWindowRequest_LittleEndian(t *testing.T) {
+	got := moveWindowRequest(LSBFirst, 0x11223344, 0x0012, -2)
+	want := []byte{
+		12, 0, 5, 0, // opcode, unused, length
+		0x44, 0x33, 0x22, 0x11, // window
+		0x03, 0x00, // value mask: X | Y
+		0x00, 0x00, // unused
+		0x12, 0x00, 0x00, 0x00, // x = 18
+		0xFE, 0xFF, 0xFF, 0xFF, // y = -2
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("little-endian request = %v, want %v", got, want)
+	}
+}
+
+// TestMoveWindowRequest_BigEndian verifies the ConfigureWindow wire
+// encoding for a position-only move on a big-endian connection.
+func TestMoveWindowRequest_BigEndian(t *testing.T) {
+	got := moveWindowRequest(MSBFirst, 0x11223344, 0x0012, -2)
+	want := []byte{
+		12, 0, 0, 5, // opcode, unused, length
+		0x11, 0x22, 0x33, 0x44, // window
+		0x00, 0x03, // value mask: X | Y
+		0x00, 0x00, // unused
+		0x00, 0x00, 0x00, 0x12, // x = 18
+		0xFF, 0xFF, 0xFF, 0xFE, // y = -2
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("big-endian request = %v, want %v", got, want)
+	}
+}

--- a/internal/platform/x11/platform.go
+++ b/internal/platform/x11/platform.go
@@ -1675,6 +1675,34 @@ func (p *Platform) RequestSize(width, height int) {
 	_ = p.conn.Flush()
 }
 
+// Hide unmaps the window.
+func (p *Platform) Hide() {
+	if p.primary == nil || p.conn == nil {
+		return
+	}
+	if err := p.conn.UnmapWindow(p.primary.window); err != nil {
+		logger().Warn("x11: UnmapWindow failed in Hide", "err", err)
+		return
+	}
+	_ = p.conn.Flush()
+}
+
+// SetPosition moves the window to the given logical screen position (DIP),
+// converting to physical pixels with the current scale factor.
+func (p *Platform) SetPosition(x, y int) {
+	if p.primary == nil || p.conn == nil {
+		return
+	}
+	scale := p.ScaleFactor()
+	physX := int16(float64(x) * scale)
+	physY := int16(float64(y) * scale)
+	if err := p.conn.MoveWindow(p.primary.window, physX, physY); err != nil {
+		logger().Warn("x11: MoveWindow failed in SetPosition", "err", err)
+		return
+	}
+	_ = p.conn.Flush()
+}
+
 // Destroy closes the window and releases resources.
 func (p *Platform) Destroy() {
 	p.mu.Lock()

--- a/internal/platform/x11/window.go
+++ b/internal/platform/x11/window.go
@@ -468,7 +468,7 @@ func (c *Connection) ConfigureWindow(window ResourceID, x, y int16, width, heigh
 	e := NewEncoder(c.byteOrder)
 	e.PutUint8(OpcodeConfigureWindow)
 	e.PutUint8(0)  // unused
-	e.PutUint16(8) // length: 3 + 1 + 4 values = 8 4-byte units
+	e.PutUint16(7) // length: 3 header + 4 values = 7 4-byte units
 	e.PutUint32(uint32(window))
 	e.PutUint16(valueMask)
 	e.PutUint16(0) // unused
@@ -479,6 +479,37 @@ func (c *Connection) ConfigureWindow(window ResourceID, x, y int16, width, heigh
 
 	if _, err := c.sendRequest(e.Bytes()); err != nil {
 		return fmt.Errorf("x11: ConfigureWindow failed: %w", err)
+	}
+	return nil
+}
+
+// moveWindowRequest builds the ConfigureWindow request body for a
+// position-only change (X and Y value masks).
+func moveWindowRequest(bo ByteOrder, window ResourceID, x, y int16) []byte {
+	const (
+		ConfigX = 1 << 0
+		ConfigY = 1 << 1
+	)
+	valueMask := uint16(ConfigX | ConfigY)
+
+	e := NewEncoder(bo)
+	e.PutUint8(OpcodeConfigureWindow)
+	e.PutUint8(0)  // unused
+	e.PutUint16(5) // length: 3 header + 2 values = 5 4-byte units
+	e.PutUint32(uint32(window))
+	e.PutUint16(valueMask)
+	e.PutUint16(0) // unused
+	e.PutUint32(uint32(x))
+	e.PutUint32(uint32(y))
+	return e.Bytes()
+}
+
+// MoveWindow changes only the window position (physical pixels) without
+// altering its size. Uses ConfigureWindow with the X and Y value masks.
+func (c *Connection) MoveWindow(window ResourceID, x, y int16) error {
+	req := moveWindowRequest(c.byteOrder, window, x, y)
+	if _, err := c.sendRequest(req); err != nil {
+		return fmt.Errorf("x11: MoveWindow failed: %w", err)
 	}
 	return nil
 }

--- a/platform_provider_test.go
+++ b/platform_provider_test.go
@@ -23,6 +23,8 @@ type mockWindow struct {
 	maximized       bool
 	minimized       bool
 	closed          bool
+	visible         bool
+	posX, posY      int
 	hitTestCallback func(float64, float64) gpucontext.HitTestResult
 	closeFn         func() bool
 
@@ -75,7 +77,9 @@ func (m *mockWindow) IsMaximized() bool    { return m.maximized }
 func (m *mockWindow) SetFullscreen(v bool) { m.fullscreen = v }
 func (m *mockWindow) IsFullscreen() bool   { return m.fullscreen }
 func (m *mockWindow) Close()               { m.closed = true }
-func (m *mockWindow) Show()                {}
+func (m *mockWindow) Show()                { m.visible = true }
+func (m *mockWindow) Hide()                { m.visible = false }
+func (m *mockWindow) SetPosition(x, y int) { m.posX = x; m.posY = y }
 
 // mockScaleManager wraps mockManager and implements platform.PlatScaleProvider.
 type mockScaleManager struct {

--- a/window_manager.go
+++ b/window_manager.go
@@ -148,6 +148,37 @@ func (w *Window) Visible() bool {
 	return w.visible
 }
 
+// Show makes the window visible and gives it input focus.
+func (w *Window) Show() {
+	if w.platWindow != nil {
+		w.platWindow.Show()
+	}
+	w.visible = true
+}
+
+// Hide hides the window.
+func (w *Window) Hide() {
+	if w.platWindow != nil {
+		w.platWindow.Hide()
+	}
+	w.visible = false
+}
+
+// SetPosition moves the window to the given logical screen position
+// (top-left origin, DIP). On Wayland the compositor owns toplevel placement.
+func (w *Window) SetPosition(x, y int) {
+	if w.platWindow != nil {
+		w.platWindow.SetPosition(x, y)
+	}
+}
+
+// SetSize resizes the window content area to the given logical size (DIP).
+func (w *Window) SetSize(width, height int) {
+	if w.platWindow != nil {
+		w.platWindow.RequestSize(width, height)
+	}
+}
+
 // WindowManager tracks all open windows in the application.
 // Thread-safe: all methods are protected by a read-write mutex.
 type WindowManager struct {

--- a/window_manager_test.go
+++ b/window_manager_test.go
@@ -325,6 +325,59 @@ func TestWindow_Visible(t *testing.T) {
 	}
 }
 
+func TestWindow_ShowHideUpdatesPlatformAndFlag(t *testing.T) {
+	mw := &mockWindow{visible: false}
+	w := &Window{platWindow: mw, visible: false}
+
+	w.Show()
+	if !mw.visible {
+		t.Error("Show() did not make the platform window visible")
+	}
+	if !w.Visible() {
+		t.Error("Show() did not set the public visible flag")
+	}
+
+	w.Hide()
+	if mw.visible {
+		t.Error("Hide() did not hide the platform window")
+	}
+	if w.Visible() {
+		t.Error("Hide() did not clear the public visible flag")
+	}
+}
+
+func TestWindow_SetPositionDelegates(t *testing.T) {
+	mw := &mockWindow{}
+	w := &Window{platWindow: mw}
+
+	w.SetPosition(120, 80)
+	if mw.posX != 120 || mw.posY != 80 {
+		t.Errorf("SetPosition delegated to (%d, %d), want (120, 80)", mw.posX, mw.posY)
+	}
+}
+
+func TestWindow_SetSizeDelegates(t *testing.T) {
+	mw := &mockWindow{width: 10, height: 20}
+	w := &Window{platWindow: mw}
+
+	w.SetSize(320, 240)
+	if mw.width != 320 || mw.height != 240 {
+		t.Errorf("SetSize delegated to (%d, %d), want (320, 240)", mw.width, mw.height)
+	}
+}
+
+func TestWindow_ControlsNilPlatformNoPanic(t *testing.T) {
+	w := &Window{}
+	w.Show()
+	w.Hide()
+	w.SetPosition(1, 2)
+	w.SetSize(3, 4)
+
+	if w.Visible() {
+		t.Error("Hide() with nil platform should leave visible=false")
+	}
+}
+
 func TestWindowManager_AllocateSequential(t *testing.T) {
 	wm := newWindowManager()
 


### PR DESCRIPTION
Part of #361 (ADR-060). Rebased on current main — #419 and #420 are merged, so this PR contains only the window-control API changes.

**Changes**
- Public \Window.Show()\, \Window.Hide()\, \Window.SetPosition(x, y)\, \Window.SetSize(w, h)\ (logical DIP coordinates)
- \PlatformWindow\ extended with \Hide()\ and \SetPosition(x, y)\
- **Win32**: \ShowWindow(SW_HIDE)\ + \SetWindowPos\ with DPI-aware logical→physical scaling
- **X11**: \UnmapWindow\ for hide; new \MoveWindow\ (ConfigureWindow X|Y) for position with scale conversion
- **macOS**: \orderOut:\ + \setFrameOrigin:\ with top-left→bottom-left Y flip (winit pattern)
- **Wayland**: documented no-ops (compositor owns visibility/placement)
- **Browser**: no-ops
- Fixes \ConfigureWindow\ request length (7 instead of 8) found while adding \MoveWindow\

**Tests**
- Public Window delegation tests (Show/Hide/SetPosition/SetSize, nil-platform safety)
- X11 \MoveWindow\ wire encoding (little + big endian)
- Full Windows test suite + Linux/macOS cross-compile; CI and codecov/patch green