### PR TITLE
fix(menu): macOS Role+Action — custom Action takes precedence (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.1] - 2026-08-04
+
+### Fixed
+
+- **macOS: menu Role + Action ignored** — when a `MenuItem` had both `Role` (e.g., `RoleAbout`) and a custom `Action` callback, the `Action` was silently ignored because the role handler returned early before reaching the callback path. Now: if `Action` is set, it takes precedence over the system selector. Reported by @jbunds (#423).
+
 ## [0.49.0] - 2026-08-04
 
 ### Added

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -1651,7 +1651,7 @@ func (p *darwinPlatform) addPlatformItem(parentMenu darwin.ID, item MenuItem) {
 		return
 	}
 
-	if item.Role != MenuRoleNone {
+	if item.Role != MenuRoleNone && item.Action == nil {
 		roleStr := roleToString(item.Role)
 		if roleStr != "" {
 			darwin.AddMenuItemWithRole(parentMenu, item.Title, roleStr)


### PR DESCRIPTION
## [0.49.1] - 2026-08-04

### Fixed

- **macOS: menu Role + Action ignored** — when a `MenuItem` had both `Role` (e.g., `RoleAbout`) and a custom `Action` callback, the `Action` was silently ignored. Now: if `Action` is set, it takes precedence over the system selector.

One-line fix in `addPlatformItem` (platform_darwin.go:1654): `item.Role != MenuRoleNone` → `item.Role != MenuRoleNone && item.Action == nil`.

Linux and Windows unaffected (already pass Action through role handlers).