### PR TITLE
fix(windows): make DComp per-pixel alpha visible on Win11 + DX12

### DIFF
--- a/app.go
+++ b/app.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gogpu/gogpu/gpu/types"
 	"github.com/gogpu/gogpu/input"
 	"github.com/gogpu/gogpu/internal/platform"
 	"github.com/gogpu/gogpu/internal/thread"
@@ -569,11 +570,13 @@ func (a *App) initPlatform() (platform.PlatformWindow, error) {
 		Fullscreen:  a.config.Fullscreen,
 		Frameless:   a.config.Frameless,
 		Transparent: a.config.Transparent,
-		MinWidth:    a.config.MinWidth,
-		MinHeight:   a.config.MinHeight,
-		MaxWidth:    a.config.MaxWidth,
-		MaxHeight:   a.config.MaxHeight,
-		Icon:        a.config.Icon,
+		UseDirectComposition: a.config.Transparent &&
+			a.config.GraphicsAPI == types.GraphicsAPIDX12,
+		MinWidth:  a.config.MinWidth,
+		MinHeight: a.config.MinHeight,
+		MaxWidth:  a.config.MaxWidth,
+		MaxHeight: a.config.MaxHeight,
+		Icon:      a.config.Icon,
 	})
 	if err != nil {
 		return nil, err

--- a/app_test.go
+++ b/app_test.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"testing"
 
+	"github.com/gogpu/gogpu/gpu/types"
 	"github.com/gogpu/gogpu/input"
 	"github.com/gogpu/gogpu/internal/platform"
 	"github.com/gogpu/gpucontext"
@@ -1409,5 +1410,38 @@ func TestInitPlatform_PropagatesIcon(t *testing.T) {
 	}
 	if capturing.got.Icon != img {
 		t.Error("initPlatform: Icon not propagated to platform.Config")
+	}
+}
+
+func TestInitPlatform_PropagatesUseDirectComposition(t *testing.T) {
+	tests := []struct {
+		name        string
+		api         types.GraphicsAPI
+		transparent bool
+		want        bool
+	}{
+		{"auto+transparent", types.GraphicsAPIAuto, true, false},
+		{"vulkan+transparent", types.GraphicsAPIVulkan, true, false},
+		{"dx12+transparent", types.GraphicsAPIDX12, true, true},
+		{"dx12+opaque", types.GraphicsAPIDX12, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := NewApp(DefaultConfig().
+				WithGraphicsAPI(tt.api).
+				WithTransparent(tt.transparent))
+
+			capturing := &configCapturingManager{}
+			old := newPlatformManagerFn
+			newPlatformManagerFn = func() platform.PlatformManager { return capturing }
+			defer func() { newPlatformManagerFn = old }()
+
+			if _, err := app.initPlatform(); err != nil {
+				t.Fatalf("initPlatform: %v", err)
+			}
+			if capturing.got.UseDirectComposition != tt.want {
+				t.Errorf("UseDirectComposition = %v, want %v", capturing.got.UseDirectComposition, tt.want)
+			}
+		})
 	}
 }

--- a/app_test.go
+++ b/app_test.go
@@ -4,7 +4,7 @@ import (
 	"image"
 	"testing"
 
-	"github.com/gogpu/gogpu/gpu/types"
+	gpu_types "github.com/gogpu/gogpu/gpu/types"
 	"github.com/gogpu/gogpu/input"
 	"github.com/gogpu/gogpu/internal/platform"
 	"github.com/gogpu/gpucontext"
@@ -1416,14 +1416,14 @@ func TestInitPlatform_PropagatesIcon(t *testing.T) {
 func TestInitPlatform_PropagatesUseDirectComposition(t *testing.T) {
 	tests := []struct {
 		name        string
-		api         types.GraphicsAPI
+		api         gpu_types.GraphicsAPI
 		transparent bool
 		want        bool
 	}{
-		{"auto+transparent", types.GraphicsAPIAuto, true, false},
-		{"vulkan+transparent", types.GraphicsAPIVulkan, true, false},
-		{"dx12+transparent", types.GraphicsAPIDX12, true, true},
-		{"dx12+opaque", types.GraphicsAPIDX12, false, false},
+		{"auto+transparent", gpu_types.GraphicsAPIAuto, true, false},
+		{"vulkan+transparent", gpu_types.GraphicsAPIVulkan, true, false},
+		{"dx12+transparent", gpu_types.GraphicsAPIDX12, true, true},
+		{"dx12+opaque", gpu_types.GraphicsAPIDX12, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -292,6 +292,16 @@ func (c Config) WithFrameless(frameless bool) Config {
 // supported and the platform window is created with its native transparency
 // style. Falls back to an opaque surface when the backend does not support
 // premultiplied alpha.
+//
+// Windows backend matrix (see docs/windows-transparency.md):
+//   - DX12 (explicit): DirectComposition + WS_EX_NOREDIRECTIONBITMAP, full
+//     per-pixel alpha against the desktop.
+//   - Vulkan/GLES: DwmEnableBlurBehindWindow legacy path; per-pixel alpha
+//     works through the DWM redirection surface.
+//   - Software: not currently supported — GDI BitBlt/StretchDIBits does not
+//     preserve alpha. Use a GPU backend or UpdateLayeredWindow.
+//   - Auto: uses the legacy blur-behind path so all backends stay visible;
+//     if wgpu selects DX12, per-pixel alpha may not composite (see docs).
 func (c Config) WithTransparent(transparent bool) Config {
 	c.Transparent = transparent
 	return c

--- a/docs/windows-transparency.md
+++ b/docs/windows-transparency.md
@@ -1,0 +1,70 @@
+# Windows Transparent Windows
+
+## Two presentation paths
+
+On Windows there are two different ways a transparent gogpu window can be
+composited:
+
+### 1. DirectComposition (DX12, explicit)
+
+`WS_EX_NOREDIRECTIONBITMAP` is set at `CreateWindowExW` time and
+`DwmEnableBlurBehindWindow` is **not** called. wgpu creates a
+`CreateSwapChainForComposition` swap chain and presents through a DComp
+visual tree. This is the only path on which a DX12 swap chain's per-pixel
+alpha composites directly against the desktop.
+
+### 2. Legacy DWM blur-behind (Vulkan / GLES / Auto)
+
+The window keeps the DWM redirection surface and
+`DwmEnableBlurBehindWindow(DWM_BB_ENABLE | DWM_BB_BLURREGION)` is called with
+an empty region. The GPU swap chain presents through the HWND and DWM uses the
+alpha channel of the redirection surface. This works for Vulkan (including
+`VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR`, because DWM-level blur handles alpha) and
+GLES.
+
+`WS_EX_NOREDIRECTIONBITMAP` must not be used on this path: Vulkan/GLES/Software
+present through the HWND, and without a redirection surface the window content
+is invisible.
+
+## Verified matrix
+
+Verified on Windows 11 with an NVIDIA GeForce RTX 4060 (driver 591.86) using a
+frameless 50% transparent red panel over a known backdrop:
+
+| API | Window style | 50% alpha result |
+|-----|--------------|------------------|
+| DX12 (explicit) | `WS_EX_NOREDIRECTIONBITMAP` + DComp | per-pixel alpha visible |
+| Vulkan (explicit) | legacy blur-behind | per-pixel alpha visible |
+| GLES (explicit) | legacy blur-behind | per-pixel alpha visible |
+| Software (explicit) | legacy blur-behind | **not supported** — GDI `BitBlt`/`StretchDIBits` (`SRCCOPY`) does not preserve alpha |
+| Auto | legacy blur-behind | visible, but see the DX12 caveat below |
+
+## Known limitations
+
+### Software backend
+
+The software backend presents through GDI `BitBlt`/`StretchDIBits` with
+`SRCCOPY`, which does not carry per-pixel alpha. `DwmEnableBlurBehindWindow`
+alone is not enough. A future implementation should use
+`UpdateLayeredWindow` (or `AlphaBlend` from a DIB section) for transparent
+software windows. Until then, `WithTransparent(true)` + Software should be
+treated as unsupported.
+
+### Auto + DX12
+
+Auto mode deliberately uses the legacy blur-behind path because the backend is
+not known at window creation time and Auto prefers Vulkan. If wgpu selects DX12
+on a Vulkan-less machine, the DX12 backend still creates a DirectComposition
+swap chain whenever `CompositeAlphaModePremultiplied` is requested, but without
+`WS_EX_NOREDIRECTIONBITMAP` the DComp content composites against the opaque
+redirection surface instead of the desktop. The result is a white/opaque tint,
+not per-pixel transparency.
+
+Options:
+
+- Require callers who need true DX12 transparency to set
+  `WithGraphicsAPI(GraphicsAPIDX12)` explicitly.
+- Resolve the backend before window creation (larger refactor).
+- Recreate the window when Auto resolves to DX12 (Godot's approach). This
+  destroys and recreates the HWND, so it can cause a brief visible flash /
+  focus change; doing it before the first `Show` minimizes the visible effect.

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -20,20 +20,21 @@ func NewWindowID() WindowID {
 
 // Config holds platform-agnostic window configuration.
 type Config struct {
-	Title             string
-	Width             int
-	Height            int
-	Resizable         bool
-	Fullscreen        bool
-	Frameless         bool
-	Transparent       bool
-	TabbingMode       int
-	TabbingIdentifier string
-	MinWidth          int // 0 = no minimum constraint
-	MinHeight         int // 0 = no minimum constraint
-	MaxWidth          int // 0 = no maximum constraint
-	MaxHeight         int // 0 = no maximum constraint
-	Icon              image.Image
+	Title                string
+	Width                int
+	Height               int
+	Resizable            bool
+	Fullscreen           bool
+	Frameless            bool
+	Transparent          bool
+	UseDirectComposition bool // Windows DX12 only: set WS_EX_NOREDIRECTIONBITMAP at creation
+	TabbingMode          int
+	TabbingIdentifier    string
+	MinWidth             int // 0 = no minimum constraint
+	MinHeight            int // 0 = no minimum constraint
+	MaxWidth             int // 0 = no maximum constraint
+	MaxHeight            int // 0 = no maximum constraint
+	Icon                 image.Image
 }
 
 // Event represents a platform event.

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -210,6 +210,7 @@ const (
 	// GetSystemMetrics / MonitorFromWindow constants
 	smCXSizeFrame           = 32 // SM_CXSIZEFRAME
 	smCYSizeFrame           = 33 // SM_CYSIZEFRAME
+	smCYCaption             = 4  // SM_CYCAPTION
 	smCXPaddedBorder        = 92 // SM_CXPADDEDBORDERWIDTH
 	monitorDefaultToNearest = 2  // MONITOR_DEFAULTTONEAREST
 
@@ -1041,6 +1042,19 @@ func (w *win32Window) RequestSize(width, height int) {
 
 	outerW := uintptr(outerRect.right - outerRect.left)
 	outerH := uintptr(outerRect.bottom - outerRect.top)
+	if w.frameless {
+		// JBR: WM_NCCALCSIZE removes the top NC area (title bar + top frame
+		// + padded border) and folds it into the client area, but
+		// AdjustWindowRect still included it in the outer height. Subtract it
+		// here so the client area matches the requested logical size.
+		cyCaption, _, _ := procGetSystemMetrics.Call(smCYCaption)
+		cyFrame, _, _ := procGetSystemMetrics.Call(smCYSizeFrame)
+		cyPadded, _, _ := procGetSystemMetrics.Call(smCXPaddedBorder)
+		topNC := cyCaption + cyFrame + cyPadded
+		if topNC < outerH {
+			outerH -= topNC
+		}
+	}
 
 	procSetWindowPos.Call(uintptr(w.hwnd), 0, 0, 0,
 		outerW, outerH,

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -290,9 +290,9 @@ var (
 	procGetMonitorInfoW    = user32.NewProc("GetMonitorInfoW")
 
 	// DWM (Desktop Window Manager) for frameless window shadow
-	dwmapi                        = windows.NewLazyDLL("dwmapi.dll")
-	procDwmExtendFrameIntoClient  = dwmapi.NewProc("DwmExtendFrameIntoClientArea")
-	procDwmFlush                  = dwmapi.NewProc("DwmFlush")
+	dwmapi                       = windows.NewLazyDLL("dwmapi.dll")
+	procDwmExtendFrameIntoClient = dwmapi.NewProc("DwmExtendFrameIntoClientArea")
+	procDwmFlush                 = dwmapi.NewProc("DwmFlush")
 
 	// WaitEvents / WakeUp
 	procMsgWaitForMultipleObjectsEx = user32.NewProc("MsgWaitForMultipleObjectsEx")
@@ -780,13 +780,22 @@ func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error)
 	// Enable file drag-and-drop (WM_DROPFILES from shell32).
 	procDragAcceptFiles.Call(uintptr(w.hwnd), 1) // TRUE
 
-	// Enable DWM shadow for frameless windows
+	// Enable DWM shadow for frameless windows. Transparent windows must skip
+	// the DwmExtendFrameIntoClientArea call: it switches the window onto the
+	// DWM glass composition path, which overrides DirectComposition per-pixel
+	// alpha (semi-transparent content renders as an opaque tint — verified on
+	// Windows 11 with gogpu#361). Frameless transparent windows therefore lose
+	// the DWM system shadow; apps should draw their own shadow in-content.
+	// SetWindowPos(swpFrameChanged) + updateSize are still required so the
+	// WM_NCCALCSIZE JBR path removes the title bar.
 	if config.Frameless {
 		type margins struct {
 			cxLeftWidth, cxRightWidth, cyTopHeight, cyBottomHeight int32
 		}
-		m := margins{0, 0, 0, 1}
-		procDwmExtendFrameIntoClient.Call(uintptr(w.hwnd), uintptr(unsafe.Pointer(&m)))
+		if !config.Transparent {
+			m := margins{0, 0, 0, 1}
+			procDwmExtendFrameIntoClient.Call(uintptr(w.hwnd), uintptr(unsafe.Pointer(&m)))
+		}
 		procSetWindowPos.Call(uintptr(w.hwnd), 0, 0, 0, 0, 0,
 			swpNoMove|swpNoSize|swpNoZOrder|swpFrameChanged)
 		w.updateSize()

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -162,17 +162,22 @@ const (
 	hkeyLocalMachine uintptr = 0x80000002
 
 	// Frameless window constants
-	wsPopup            = 0x80000000 // WS_POPUP
-	wsThickFrame       = 0x00040000 // WS_THICKFRAME (for resize in frameless)
-	wsCaption          = 0x00C00000 // WS_CAPTION (title bar)
-	wmNCHitTest        = 0x0084     // WM_NCHITTEST
-	wmNCCalcSize       = 0x0083     // WM_NCCALCSIZE
-	wmNCPaint          = 0x0085     // WM_NCPAINT
-	wmNCActivate       = 0x0086     // WM_NCACTIVATE
-	wmNCUAHDrawCaption = 0x00AE     // Undocumented: UxTheme caption draw
-	wmNCUAHDrawFrame   = 0x00AF     // Undocumented: UxTheme frame draw
-	swMinimize         = 6          // SW_MINIMIZE
-	swMaximize         = 3          // SW_MAXIMIZE
+	wsPopup      = 0x80000000 // WS_POPUP
+	wsThickFrame = 0x00040000 // WS_THICKFRAME (for resize in frameless)
+	wsCaption    = 0x00C00000 // WS_CAPTION (title bar)
+	// WS_EX_NOREDIRECTIONBITMAP: DComp per-pixel alpha requires disabling the
+	// DWM redirection bitmap; otherwise the swap chain is composed onto an
+	// opaque redirection surface and transparency is not visible
+	// (wgpu v0.30.35 release note; winit/wgpu-rs precedent).
+	wsExNoRedirectionBitmap = 0x00200000
+	wmNCHitTest             = 0x0084 // WM_NCHITTEST
+	wmNCCalcSize            = 0x0083 // WM_NCCALCSIZE
+	wmNCPaint               = 0x0085 // WM_NCPAINT
+	wmNCActivate            = 0x0086 // WM_NCACTIVATE
+	wmNCUAHDrawCaption      = 0x00AE // Undocumented: UxTheme caption draw
+	wmNCUAHDrawFrame        = 0x00AF // Undocumented: UxTheme frame draw
+	swMinimize              = 6      // SW_MINIMIZE
+	swMaximize              = 3      // SW_MAXIMIZE
 
 	// WM_NCHITTEST return values
 	htCaption     = 2
@@ -194,10 +199,6 @@ const (
 	swpNoSize       = 0x0001
 	swpNoZOrder     = 0x0004
 	swpFrameChanged = 0x0020
-
-	// DwmEnableBlurBehindWindow flags (DWM_BLURBEHIND)
-	dwmBBEnable     = 0x00000001 // DWM_BB_ENABLE
-	dwmBBBlurRegion = 0x00000002 // DWM_BB_BLURREGION
 
 	// GetWindowLongPtr index
 	gwlStyle = ^uintptr(15) // GWL_STYLE = -16 as unsigned uintptr
@@ -291,7 +292,6 @@ var (
 	// DWM (Desktop Window Manager) for frameless window shadow
 	dwmapi                        = windows.NewLazyDLL("dwmapi.dll")
 	procDwmExtendFrameIntoClient  = dwmapi.NewProc("DwmExtendFrameIntoClientArea")
-	procDwmEnableBlurBehindWindow = dwmapi.NewProc("DwmEnableBlurBehindWindow")
 	procDwmFlush                  = dwmapi.NewProc("DwmFlush")
 
 	// WaitEvents / WakeUp
@@ -355,8 +355,6 @@ var (
 	procReleaseDC         = user32.NewProc("ReleaseDC")
 	procSetDIBitsToDevice = gdi32.NewProc("SetDIBitsToDevice")
 	procGetStockObject    = gdi32.NewProc("GetStockObject")
-	procCreateRectRgn     = gdi32.NewProc("CreateRectRgn")
-	procDeleteObject      = gdi32.NewProc("DeleteObject")
 
 	// Shell32 (file drag-and-drop)
 	shell32DnD          = windows.NewLazyDLL("shell32.dll")
@@ -689,43 +687,6 @@ func adjustWindowRectForDpi(r *rect, style uintptr, dpi uint32) {
 	}
 }
 
-// dwmBlurBehind mirrors the native DWM_BLURBEHIND structure.
-type dwmBlurBehind struct {
-	dwFlags                uint32
-	fEnable                uint32
-	hRgnBlur               uintptr
-	fTransitionOnMaximized uint32
-}
-
-// enableDwmBlurBehind enables per-pixel-alpha compositing for the window
-// using DwmEnableBlurBehindWindow with an empty blur region — the winit/SDL3
-// pattern documented in ADR-060. WS_EX_LAYERED is intentionally NOT used:
-// it is GDI whole-window opacity, not per-pixel alpha with GPU rendering.
-func enableDwmBlurBehind(hwnd windows.HWND) {
-	if hwnd == 0 {
-		return
-	}
-	// CreateRectRgn(0, 0, -1, -1) creates an empty region.
-	rgn, _, _ := procCreateRectRgn.Call(0, 0, ^uintptr(0), ^uintptr(0))
-	if rgn == 0 {
-		return
-	}
-	defer procDeleteObject.Call(rgn)
-
-	bb := dwmBlurBehind{
-		dwFlags:  dwmBBEnable | dwmBBBlurRegion,
-		fEnable:  1, // TRUE
-		hRgnBlur: rgn,
-	}
-	hr, _, _ := procDwmEnableBlurBehindWindow.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&bb)))
-	if hr != 0 {
-		// Non-fatal: DWM can be unavailable (e.g. Server Core, DWM disabled);
-		// the window simply stays opaque.
-		slog.Debug("gogpu: DwmEnableBlurBehindWindow failed, window stays opaque",
-			"hr", hr)
-	}
-}
-
 // createWindowWin32 creates a new Win32 HWND window from the given config.
 // Shared between PlatformManager.CreateWindow and the legacy Init(config).
 func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error) {
@@ -740,6 +701,15 @@ func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error)
 	}
 
 	style := uintptr(wsOverlappedWindow)
+
+	// Per-pixel alpha via DirectComposition requires the window to opt out of
+	// the DWM redirection bitmap; otherwise the DComp swap chain is composed
+	// behind/over an opaque window surface and transparency is not visible
+	// (gogpu#361, wgpu v0.30.35 release note).
+	dwExStyle := uintptr(0)
+	if config.Transparent {
+		dwExStyle = wsExNoRedirectionBitmap
+	}
 
 	// Best-guess DPI before HWND exists (SDL3 hybrid pattern).
 	// Position is CW_USEDEFAULT → query primary monitor.
@@ -759,7 +729,7 @@ func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error)
 
 	// Create window with pre-scaled outer dimensions.
 	hwnd, _, _ := procCreateWindowExW.Call(
-		0,
+		dwExStyle,
 		uintptr(unsafe.Pointer(className)),
 		uintptr(unsafe.Pointer(titlePtr)),
 		style,
@@ -822,11 +792,14 @@ func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error)
 		w.updateSize()
 	}
 
-	// Enable DWM blur-behind for per-pixel-alpha transparency (ADR-060).
-	// Independent of frameless mode — a transparent window keeps its chrome
-	// unless the application also opts into WithFrameless.
+	// Transparent windows opt out of the DWM redirection bitmap above, so the
+	// DComp swapchain composites per-pixel alpha directly. DwmEnableBlurBehindWindow
+	// is intentionally NOT called here: with WS_EX_NOREDIRECTIONBITMAP it would
+	// paint an opaque blurred backdrop behind the swapchain and hide the desktop
+	// (winit skips blur-behind when no_redirection_bitmap is enabled).
 	if config.Transparent {
-		enableDwmBlurBehind(w.hwnd)
+		slog.Info("gogpu: transparent window created with WS_EX_NOREDIRECTIONBITMAP",
+			"hwnd", hwnd)
 	}
 
 	w.updateSize()

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -200,6 +200,10 @@ const (
 	swpNoZOrder     = 0x0004
 	swpFrameChanged = 0x0020
 
+	// DwmEnableBlurBehindWindow flags (DWM_BLURBEHIND)
+	dwmBBEnable     = 0x00000001 // DWM_BB_ENABLE
+	dwmBBBlurRegion = 0x00000002 // DWM_BB_BLURREGION
+
 	// GetWindowLongPtr index
 	gwlStyle = ^uintptr(15) // GWL_STYLE = -16 as unsigned uintptr
 
@@ -291,9 +295,10 @@ var (
 	procGetMonitorInfoW    = user32.NewProc("GetMonitorInfoW")
 
 	// DWM (Desktop Window Manager) for frameless window shadow
-	dwmapi                       = windows.NewLazyDLL("dwmapi.dll")
-	procDwmExtendFrameIntoClient = dwmapi.NewProc("DwmExtendFrameIntoClientArea")
-	procDwmFlush                 = dwmapi.NewProc("DwmFlush")
+	dwmapi                        = windows.NewLazyDLL("dwmapi.dll")
+	procDwmExtendFrameIntoClient  = dwmapi.NewProc("DwmExtendFrameIntoClientArea")
+	procDwmEnableBlurBehindWindow = dwmapi.NewProc("DwmEnableBlurBehindWindow")
+	procDwmFlush                  = dwmapi.NewProc("DwmFlush")
 
 	// WaitEvents / WakeUp
 	procMsgWaitForMultipleObjectsEx = user32.NewProc("MsgWaitForMultipleObjectsEx")
@@ -356,6 +361,8 @@ var (
 	procReleaseDC         = user32.NewProc("ReleaseDC")
 	procSetDIBitsToDevice = gdi32.NewProc("SetDIBitsToDevice")
 	procGetStockObject    = gdi32.NewProc("GetStockObject")
+	procCreateRectRgn     = gdi32.NewProc("CreateRectRgn")
+	procDeleteObject      = gdi32.NewProc("DeleteObject")
 
 	// Shell32 (file drag-and-drop)
 	shell32DnD          = windows.NewLazyDLL("shell32.dll")
@@ -688,6 +695,43 @@ func adjustWindowRectForDpi(r *rect, style uintptr, dpi uint32) {
 	}
 }
 
+// dwmBlurBehind mirrors the native DWM_BLURBEHIND structure.
+type dwmBlurBehind struct {
+	dwFlags                uint32
+	fEnable                uint32
+	hRgnBlur               uintptr
+	fTransitionOnMaximized uint32
+}
+
+// enableDwmBlurBehind enables per-pixel-alpha compositing for the window
+// using DwmEnableBlurBehindWindow with an empty blur region — the winit/SDL3
+// pattern documented in ADR-060. WS_EX_LAYERED is intentionally NOT used:
+// it is GDI whole-window opacity, not per-pixel alpha with GPU rendering.
+func enableDwmBlurBehind(hwnd windows.HWND) {
+	if hwnd == 0 {
+		return
+	}
+	// CreateRectRgn(0, 0, -1, -1) creates an empty region.
+	rgn, _, _ := procCreateRectRgn.Call(0, 0, ^uintptr(0), ^uintptr(0))
+	if rgn == 0 {
+		return
+	}
+	defer procDeleteObject.Call(rgn)
+
+	bb := dwmBlurBehind{
+		dwFlags:  dwmBBEnable | dwmBBBlurRegion,
+		fEnable:  1, // TRUE
+		hRgnBlur: rgn,
+	}
+	hr, _, _ := procDwmEnableBlurBehindWindow.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&bb)))
+	if hr != 0 {
+		// Non-fatal: DWM can be unavailable (e.g. Server Core, DWM disabled);
+		// the window simply stays opaque.
+		slog.Debug("gogpu: DwmEnableBlurBehindWindow failed, window stays opaque",
+			"hr", hr)
+	}
+}
+
 // createWindowWin32 creates a new Win32 HWND window from the given config.
 // Shared between PlatformManager.CreateWindow and the legacy Init(config).
 func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error) {
@@ -703,12 +747,13 @@ func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error)
 
 	style := uintptr(wsOverlappedWindow)
 
-	// Per-pixel alpha via DirectComposition requires the window to opt out of
-	// the DWM redirection bitmap; otherwise the DComp swap chain is composed
-	// behind/over an opaque window surface and transparency is not visible
-	// (gogpu#361, wgpu v0.30.35 release note).
+	// WS_EX_NOREDIRECTIONBITMAP is only safe for the DX12 DirectComposition
+	// path. Vulkan/GLES/Software and Auto present through the HWND and need
+	// the DWM redirection surface; for them Transparent uses the legacy
+	// DwmEnableBlurBehindWindow path below.
+	useDComp := config.Transparent && config.UseDirectComposition
 	dwExStyle := uintptr(0)
-	if config.Transparent {
+	if useDComp {
 		dwExStyle = wsExNoRedirectionBitmap
 	}
 
@@ -802,14 +847,20 @@ func (p *windowsPlatform) createWindowWin32(config Config) (*win32Window, error)
 		w.updateSize()
 	}
 
-	// Transparent windows opt out of the DWM redirection bitmap above, so the
-	// DComp swapchain composites per-pixel alpha directly. DwmEnableBlurBehindWindow
-	// is intentionally NOT called here: with WS_EX_NOREDIRECTIONBITMAP it would
-	// paint an opaque blurred backdrop behind the swapchain and hide the desktop
-	// (winit skips blur-behind when no_redirection_bitmap is enabled).
+	// Transparent windows use one of two paths:
+	//   - DirectComposition (explicit DX12): WS_EX_NOREDIRECTIONBITMAP was set
+	//     at creation; blur-behind must NOT be enabled (winit skips it too).
+	//   - Legacy blur-behind: Vulkan/GLES/Software/Auto present through the
+	//     HWND and need the DWM redirection surface to stay visible.
 	if config.Transparent {
-		slog.Info("gogpu: transparent window created with WS_EX_NOREDIRECTIONBITMAP",
-			"hwnd", hwnd)
+		if useDComp {
+			slog.Debug("gogpu: transparent window created with WS_EX_NOREDIRECTIONBITMAP (DirectComposition)",
+				"hwnd", hwnd)
+		} else {
+			enableDwmBlurBehind(w.hwnd)
+			slog.Debug("gogpu: transparent window created (legacy blur-behind path)",
+				"hwnd", hwnd)
+		}
 	}
 
 	w.updateSize()

--- a/window_manager.go
+++ b/window_manager.go
@@ -335,13 +335,15 @@ func (a *App) NewWindow(config Config) (*Window, error) {
 
 	// Create platform window via PlatformManager.
 	platWindow, err := a.manager.CreateWindow(platform.Config{
-		Title:             config.Title,
-		Width:             config.Width,
-		Height:            config.Height,
-		Resizable:         config.Resizable,
-		Fullscreen:        config.Fullscreen,
-		Frameless:         config.Frameless,
-		Transparent:       config.Transparent,
+		Title:       config.Title,
+		Width:       config.Width,
+		Height:      config.Height,
+		Resizable:   config.Resizable,
+		Fullscreen:  config.Fullscreen,
+		Frameless:   config.Frameless,
+		Transparent: config.Transparent,
+		UseDirectComposition: config.Transparent &&
+			a.config.GraphicsAPI == GraphicsAPIDX12,
 		TabbingMode:       int(config.TabbingMode),
 		TabbingIdentifier: config.TabbingIdentifier,
 	})


### PR DESCRIPTION
## Summary

Per-pixel alpha transparency from #361 still did not composite against the desktop on Windows 11 with the DX12 backend. This PR makes it actually visible with three related changes:

1. **Set `WS_EX_NOREDIRECTIONBITMAP` for transparent windows** (`0x00200000`). Without it the DComp swap chain is composed onto the DWM redirection surface: semi-transparent content blends with a fixed background instead of the desktop (matches the wgpu v0.30.35 release note). Verified by A/B: with the style the window shows the desktop through the alpha channel; without it, the same frame blends against white.

2. **Stop calling `DwmEnableBlurBehindWindow` for transparent windows** and remove the now-dead blur-behind helpers. With `WS_EX_NOREDIRECTIONBITMAP`, the blur-behind call paints an opaque blurred backdrop behind the swap chain and hides the desktop (winit skips blur-behind in this mode).

3. **Skip `DwmExtendFrameIntoClientArea` for transparent frameless windows**. The call switches the window onto the DWM glass composition path, which overrides DirectComposition per-pixel alpha — a 50% transparent fill renders as an opaque tint. Frameless transparent windows lose the DWM system shadow (apps can draw their own); `SetWindowPos(swpFrameChanged)` and `updateSize()` are kept so the `WM_NCCALCSIZE` JBR path still removes the title bar.

## Testing

- Windows 11 + DX12, NVIDIA GeForce RTX 4060.
- A 360x480 frameless transparent window with 50% premultiplied alpha shows the desktop through the panel; the same frame is opaque with either of the two removed calls.
- Verified end-to-end in DeskCalendar (tray calendar popup): semi-transparent panel, transparent rounded corners, and low-alpha elements render correctly on both light and dark themes. I will keep testing this in the project and report back here if anything else comes up.