### PR TITLE
feat(sound): 12 SystemSound types + fix Windows Click mapping (#433, ADR-063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **12 SystemSound types** (#433, ADR-063) — expanded from 5 to 12: Click, Invoke, Focus, MoveNext, MovePrev, GoBack, Show, Hide, Alert, Error, Warning, Success. UWP ElementSoundPlayer parity.
+
+### Fixed
+
+- **Windows: Click mapped to notification beep** (#433) — `sound.Click` now plays `Windows Navigation Start.wav` (subtle UI click) with fallback to `.Default` registry alias. Was `.Default` → `Windows Background.wav` (notification sound).
+
 ## [0.50.1] - 2026-08-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Built on [gogpu/wgpu](https://github.com/gogpu/wgpu) — the unified Go WebGPU p
 | **Input Models** | Three coexisting models: callbacks (`EventSource`), state polling (`Input()`, Ebiten-style), SDL-style event queue (`PollInputEvent()`) |
 | **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, runtime window resize (`RequestSize`), mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), OS drag-and-drop: incoming (all 4 desktop platforms) + outgoing drag source (`StartDrag`, all 5 platforms), GPU adapter power preference, native macOS window tabbing, native system menus (macOS + Windows), native file dialogs (macOS + Windows + Linux D-Bus/zenity/kdialog) |
 | **Scroll** | ScrollPhase + IsMomentum for macOS trackpad momentum detection (ADR-032), pixel/line/page delta modes |
-| **Sound** | Platform system sounds for UI feedback (winmm, NSSound, canberra/PulseAudio) |
+| **Sound** | 12 UI sound types (UWP ElementSoundPlayer parity): Click, Invoke, Focus, Navigate, Show/Hide, feedback. winmm, NSSound, canberra |
 | **Compute** | Full compute shader support |
 | **Window Chrome** | Frameless windows with custom title bars, DWM shadow, hit-test regions |
 | **HiDPI** | Per-monitor DPI, runtime DPI change (`ScaleChangedEvent` on all platforms), WM_DPICHANGED, logical/physical coordinate split, WithSize in logical DIP (ADR-030, ADR-059) |
@@ -608,7 +608,7 @@ Vulkan     DX12  Metal  GLES   Software
 | `gmath/` | Vec2, Vec3, Vec4, Mat4, Color |
 | `window/` | Window configuration |
 | `input/` | Keyboard and mouse input |
-| `sound/` | Platform system sounds (Click, Alert, Error, Warning, Success) |
+| `sound/` | Platform system sounds — 12 types: Click, Invoke, Focus, Navigate, Show/Hide, Alert, Error, Warning, Success (UWP parity) |
 | `internal/platform/` | Platform-specific windowing (Win32, Cocoa, X11, Wayland, Browser) |
 | `internal/thread/` | Multi-thread rendering (RenderLoop) |
 

--- a/sound/sound.go
+++ b/sound/sound.go
@@ -20,8 +20,22 @@ import (
 type SystemSound int
 
 const (
-	// Click is the default UI interaction sound (button press, menu select).
+	// Click is the default UI interaction sound (button press, checkbox toggle).
 	Click SystemSound = iota
+	// Invoke is an action invoked sound (command execution).
+	Invoke
+	// Focus plays when an element receives keyboard focus.
+	Focus
+	// MoveNext plays on forward navigation (Tab, Right, Down).
+	MoveNext
+	// MovePrev plays on backward navigation (Shift+Tab, Left, Up).
+	MovePrev
+	// GoBack plays on back navigation.
+	GoBack
+	// Show plays when a dialog or flyout appears.
+	Show
+	// Hide plays when a dialog or flyout is dismissed.
+	Hide
 	// Alert is a notification sound.
 	Alert
 	// Error indicates an error occurred.
@@ -37,6 +51,20 @@ func (s SystemSound) String() string {
 	switch s {
 	case Click:
 		return "Click"
+	case Invoke:
+		return "Invoke"
+	case Focus:
+		return "Focus"
+	case MoveNext:
+		return "MoveNext"
+	case MovePrev:
+		return "MovePrev"
+	case GoBack:
+		return "GoBack"
+	case Show:
+		return "Show"
+	case Hide:
+		return "Hide"
 	case Alert:
 		return "Alert"
 	case Error:
@@ -61,7 +89,7 @@ var state struct {
 	enabled bool
 
 	// lastPlay tracks the last play time per SystemSound for debounce.
-	lastPlay [5]time.Time // indexed by SystemSound
+	lastPlay [12]time.Time // indexed by SystemSound
 }
 
 // SetEnabled enables or disables UI sound playback globally.

--- a/sound/sound_darwin.go
+++ b/sound/sound_darwin.go
@@ -18,6 +18,20 @@ func darwinSoundName(s SystemSound) string {
 	switch s {
 	case Click:
 		return "Tink"
+	case Invoke:
+		return "Pop"
+	case Focus:
+		return "Tink"
+	case MoveNext:
+		return "Tink"
+	case MovePrev:
+		return "Tink"
+	case GoBack:
+		return "Tink"
+	case Show:
+		return "Blow"
+	case Hide:
+		return "Pop"
 	case Alert:
 		return "Glass"
 	case Error:

--- a/sound/sound_linux.go
+++ b/sound/sound_linux.go
@@ -20,6 +20,17 @@ func xdgSoundPaths(s SystemSound) []string {
 			filepath.Join(stereo, "button-pressed.oga"),
 			filepath.Join(stereo, "message.oga"),
 		}
+	case Invoke:
+		return []string{
+			filepath.Join(stereo, "button-pressed.oga"),
+		}
+	case Focus, MoveNext, MovePrev, GoBack, Hide:
+		return nil
+	case Show:
+		return []string{
+			filepath.Join(stereo, "dialog-information.oga"),
+			filepath.Join(stereo, "message.oga"),
+		}
 	case Alert:
 		return []string{
 			filepath.Join(stereo, "bell.oga"),
@@ -104,8 +115,10 @@ func platformPlay(s SystemSound) {
 // canberaSoundID maps SystemSound to libcanberra/XDG event IDs.
 func canberaSoundID(s SystemSound) string {
 	switch s {
-	case Click:
+	case Click, Invoke:
 		return "button-pressed"
+	case Show:
+		return "dialog-information"
 	case Alert:
 		return "bell"
 	case Error:

--- a/sound/sound_test.go
+++ b/sound/sound_test.go
@@ -34,6 +34,13 @@ func TestSystemSoundString(t *testing.T) {
 		want  string
 	}{
 		{Click, "Click"},
+		{Invoke, "Invoke"},
+		{Focus, "Focus"},
+		{MoveNext, "MoveNext"},
+		{MovePrev, "MovePrev"},
+		{GoBack, "GoBack"},
+		{Show, "Show"},
+		{Hide, "Hide"},
 		{Alert, "Alert"},
 		{Error, "Error"},
 		{Warning, "Warning"},
@@ -50,7 +57,6 @@ func TestSystemSoundString(t *testing.T) {
 }
 
 func TestPlayDisabled(t *testing.T) {
-	// Sounds are disabled by default; Play should not panic.
 	defer func() {
 		state.mu.Lock()
 		state.enabled = false
@@ -58,6 +64,13 @@ func TestPlayDisabled(t *testing.T) {
 	}()
 
 	Play(Click)
+	Play(Invoke)
+	Play(Focus)
+	Play(MoveNext)
+	Play(MovePrev)
+	Play(GoBack)
+	Play(Show)
+	Play(Hide)
 	Play(Alert)
 	Play(Error)
 	Play(Warning)
@@ -81,7 +94,7 @@ func TestDebounce(t *testing.T) {
 	defer func() {
 		state.mu.Lock()
 		state.enabled = false
-		state.lastPlay = [5]time.Time{}
+		state.lastPlay = [12]time.Time{}
 		state.mu.Unlock()
 	}()
 
@@ -114,7 +127,7 @@ func TestDebounceExpired(t *testing.T) {
 	defer func() {
 		state.mu.Lock()
 		state.enabled = false
-		state.lastPlay = [5]time.Time{}
+		state.lastPlay = [12]time.Time{}
 		state.mu.Unlock()
 	}()
 
@@ -172,7 +185,7 @@ func TestDifferentSoundsNotDebounced(t *testing.T) {
 	defer func() {
 		state.mu.Lock()
 		state.enabled = false
-		state.lastPlay = [5]time.Time{}
+		state.lastPlay = [12]time.Time{}
 		state.mu.Unlock()
 	}()
 

--- a/sound/sound_windows.go
+++ b/sound/sound_windows.go
@@ -23,39 +23,57 @@ const (
 	sndFilename  = 0x00020000 // pszSound is a file name
 )
 
-// windowsSoundAlias maps SystemSound to Windows registry sound aliases.
-// These correspond to entries under HKCU\AppEvents\Schemes\Apps\.Default.
-func windowsSoundAlias(s SystemSound) string {
-	switch s {
-	case Click:
-		return ".Default"
-	case Alert:
-		return "SystemNotification"
-	case Error:
-		return "SystemHand"
-	case Warning:
-		return "SystemExclamation"
-	case Success:
-		return "SystemAsterisk"
-	default:
-		return ".Default"
-	}
-}
+// navigationWav is a subtle UI click sound shipped with Windows.
+const navigationWav = `C:\Windows\Media\Windows Navigation Start.wav`
 
-func platformPlay(s SystemSound) {
-	alias := windowsSoundAlias(s)
+func playAlias(alias string) {
 	ptr, err := windows.UTF16PtrFromString(alias)
 	if err != nil {
 		return
 	}
-	// PlaySoundW(pszSound, hmod, fdwSound)
-	// SND_ALIAS|SND_ASYNC|SND_NODEFAULT: play the registry alias
-	// asynchronously; if no sound is configured, skip silently.
 	procPlaySnd.Call(
 		uintptr(unsafe.Pointer(ptr)),
 		0,
 		uintptr(sndAlias|sndAsync|sndNoDefault),
 	)
+}
+
+func playWavFile(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	ptr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return false
+	}
+	ret, _, _ := procPlaySnd.Call(
+		uintptr(unsafe.Pointer(ptr)),
+		0,
+		uintptr(sndFilename|sndAsync|sndNoDefault),
+	)
+	return ret != 0
+}
+
+func platformPlay(s SystemSound) {
+	switch s {
+	case Click, Invoke, Focus, MoveNext, MovePrev, GoBack:
+		if playWavFile(navigationWav) {
+			return
+		}
+		playAlias(".Default")
+	case Show:
+		playAlias("SystemNotification")
+	case Hide:
+		// Silent -- standard UX, no sound on dismiss.
+	case Alert:
+		playAlias("SystemNotification")
+	case Error:
+		playAlias("SystemHand")
+	case Warning:
+		playAlias("SystemExclamation")
+	case Success:
+		playAlias("SystemAsterisk")
+	}
 }
 
 func platformPlayFile(path string) error {


### PR DESCRIPTION
## Summary

- **12 SystemSound types** for UWP ElementSoundPlayer parity: Click, Invoke, Focus, MoveNext, MovePrev, GoBack, Show, Hide, Alert, Error, Warning, Success
- **Fix Windows Click** — plays `Windows Navigation Start.wav` (subtle UI click) instead of `.Default` (notification beep)
- Platform mappings for macOS (NSSound) and Linux (canberra/XDG)

## Test plan

- [x] `go test ./sound/...` — 9 tests pass
- [x] Build: Windows, Linux, macOS — clean
- [x] Lint: 0 issues
- [x] Manual: Windows Click = subtle click, not notification beep