### PR TITLE
feat(win32): add KeyCancel for Ctrl+Break (VK_CANCEL)

### DIFF
--- a/app.go
+++ b/app.go
@@ -2014,6 +2014,8 @@ func gpucontextKeyToInputKey(key gpucontext.Key) input.Key {
 		return input.KeyNumLock
 	case gpucontext.KeyPause:
 		return input.KeyPause
+	case gpucontext.KeyCancel:
+		return input.KeyCancel
 
 	default:
 		return input.KeyUnknown

--- a/app_test.go
+++ b/app_test.go
@@ -363,6 +363,7 @@ func TestGpucontextKeyToInputKey(t *testing.T) {
 		{"ScrollLock", gpucontext.KeyScrollLock, input.KeyScrollLock},
 		{"NumLock", gpucontext.KeyNumLock, input.KeyNumLock},
 		{"Pause", gpucontext.KeyPause, input.KeyPause},
+		{"Cancel", gpucontext.KeyCancel, input.KeyCancel},
 		{"Unknown", gpucontext.Key(9999), input.KeyUnknown},
 	}
 

--- a/input/keyboard.go
+++ b/input/keyboard.go
@@ -131,6 +131,7 @@ const (
 	KeyPrintScreen
 	KeyScrollLock
 	KeyPause
+	KeyCancel // Win32 Ctrl+Break (VK_CANCEL); distinct from KeyPause
 
 	KeyCount // Number of keys
 )

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -2003,6 +2003,7 @@ const (
 	vkControl   = 0x11
 	vkMenu      = 0x12 // Alt
 	vkPause     = 0x13
+	vkCancel    = 0x03 // Ctrl+Break arrives as VK_CANCEL, not VK_PAUSE
 	vkCapital   = 0x14 // Caps Lock
 	vkSpace     = 0x20
 	vkPrior     = 0x21 // Page Up
@@ -2232,6 +2233,11 @@ func vkCodeToKey(vkCode uintptr) gpucontext.Key {
 		return gpucontext.KeyNumLock
 	case vkPause:
 		return gpucontext.KeyPause
+	case vkCancel:
+		// Ctrl+Break is delivered as VK_CANCEL (0x03), distinct from the
+		// plain Pause key (VK_PAUSE). Report it as KeyCancel so hosts can
+		// bind Ctrl+Break to an interrupt without losing the distinction.
+		return gpucontext.KeyCancel
 	}
 
 	return gpucontext.KeyUnknown


### PR DESCRIPTION
On Win32 the Pause key (VK_PAUSE) and Ctrl+Break (VK_CANCEL) are two
distinct virtual keys, but vkCodeToKey reported both as KeyPause, so
applications could not tell an interrupt from the plain Pause key.

Add a dedicated KeyCancel so the distinction survives to the public
input API. Depends on gpucontext PR adding KeyCancel to the Key enum.

- internal/platform/platform_windows.go: VK_CANCEL -> gpucontext.KeyCancel
- input/keyboard.go: KeyCancel in the public Key enum
- app.go: gpucontext.KeyCancel -> input.KeyCancel in mapToInputKey
- app_test.go: mapping case ({"Cancel", ...})

Handling Ctrl+Break (Ctrl+Pause) as an interrupt is useful because:

It is the second canonical stop combination on Windows. Alongside Ctrl+C, Ctrl+Break is the standard way to interrupt execution in a console (on Unix: intr/quit, SIGINT/SIGQUIT). The GUI build of f4 used to lose this pair — gogpu either reported it as Pause or dropped it entirely.
Not everything stops with Ctrl+C. Many interactive programs (vim, ssh, various CLI tools) trap Ctrl+C or misbehave on it. Ctrl+Break is the fallback/alternative interrupt users expect from a terminal out of the box.
A GUI window has no console signal. In a real console, the OS handles Ctrl+Break. Inside a gogpu window there is no console window, so the combination must reach the PTY as ordinary input — through the same path as Ctrl+C (ETX) — transplanting familiar terminal behavior into the GUI.
It unblocks hung commands. Without it, a long-running operation (dir /s, a full-disk grep, an interactive shell) in the fullscreen GUI build could only be stopped by closing the window.
The cost is minimal and safe. Via a dedicated KeyCancel code, the Pause key keeps its own meaning (media/scroll), and only "Pause + Ctrl" becomes the interrupt — preserving both compatibility and API distinguishability.