### PR TITLE
fix: continue debug overlay animations on idle frames

### DIFF
--- a/app.go
+++ b/app.go
@@ -1113,6 +1113,15 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 		ctx := newContextForSurface(a.renderer, ws, frame.scale)
 		frame.onDraw(ctx)
 
+		// An overlay that requested another frame is pending GPU work even when
+		// application content is clean. Start an overlay-only frame so the normal
+		// end-frame path can draw, submit, and present it.
+		overlayOnlyAcquire := !ws.frameStarted && !ws.pixelPresented &&
+			!ws.acquireFailed && ws.overlayNeedsRedraw
+		if overlayOnlyAcquire {
+			ws.ensureFrameStarted()
+		}
+
 		// No frame started. Two very different reasons:
 		//
 		// The callback issued no draw calls, so lazy acquire never acquired
@@ -1127,7 +1136,11 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 		// (surface outdated, not yet configured). Demand-driven mode already
 		// consumed the invalidation, so that one does need another frame.
 		if !ws.frameStarted {
-			if ws.acquireFailed {
+			// Content acquisition keeps the existing retry policy because its
+			// invalidation was consumed. Overlay-only work remains pending until
+			// the next external invalidation instead of spinning while a surface
+			// is minimized, unconfigured, or lost.
+			if ws.acquireFailed && !overlayOnlyAcquire {
 				a.RequestRedraw()
 			}
 			ws.resetLazyState()
@@ -1135,15 +1148,29 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 			continue
 		}
 
+		// WriteSurfacePixels has already presented and bypasses GPU overlays.
+		// Preserve their pending work, but do not self-schedule a frame that
+		// cannot composite them; a later non-pixel invalidation will retry.
+		overlayDeferred := ws.pixelPresented
+
 		// On outdated, present() reconfigured the surface; re-render once at the
 		// live scale (a DPI change is an outdated trigger, so frame.scale may be
 		// stale). One retry only — looping can livelock a live resize; if still
 		// outdated, request another frame since nothing else reschedules on-demand.
-		if ws.frameStarted && a.renderer.endFrameForSurface(ws) {
+		endResult := a.renderer.endFrameForSurface(ws)
+		if endResult.reconfigured {
 			ws.prepareLazyAcquire()
 			frame.onDraw(newContextForSurface(a.renderer, ws, ws.platWindow.ScaleFactor()))
-			if ws.frameStarted && a.renderer.endFrameForSurface(ws) {
-				a.RequestRedraw()
+			overlayDeferred = overlayDeferred || ws.pixelPresented
+			if !ws.frameStarted && !ws.pixelPresented &&
+				!ws.acquireFailed && ws.overlayNeedsRedraw {
+				ws.ensureFrameStarted()
+			}
+			if ws.frameStarted {
+				endResult = a.renderer.endFrameForSurface(ws)
+				if endResult.reconfigured && !overlayOnlyAcquire {
+					a.RequestRedraw()
+				}
 			}
 		}
 
@@ -1151,7 +1178,11 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 		// when any overlay returns true from Draw, request another frame so
 		// it can continue animating (FPS counter, fade effects). The loop
 		// automatically stops when all overlays return false.
-		if ws.overlayNeedsRedraw {
+		// A failed overlay-only submit/present keeps the overlay pending for an
+		// external invalidation, but must not turn a permanent GPU error into an
+		// unbounded redraw loop. Content frames retain their existing retry policy.
+		overlayCanSelfSchedule := !overlayOnlyAcquire || endResult.completed
+		if ws.overlayNeedsRedraw && !overlayDeferred && overlayCanSelfSchedule {
 			a.RequestRedraw()
 		}
 		ws.resetLazyState()

--- a/app.go
+++ b/app.go
@@ -1095,104 +1095,95 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 	a.renderer.DrainDeferredDestroys()
 
 	for _, frame := range frames {
-		ws := frame.window.surface
-		if ws == nil {
-			continue
-		}
-		a.syncFrameSurfaceSize(ws, frame.physW, frame.physH)
-
-		// Lazy acquire: reset per-frame state for deferred beginFrame.
-		// beginFrame is called on first draw call, not upfront.
-		// If OnDraw produces no GPU work → no acquire, no present.
-		ws.prepareLazyAcquire()
-
-		// Set renderer's currentSurface so draw methods target this window.
-		a.renderer.currentSurface = ws
-
-		// Call per-window draw callback.
-		ctx := newContextForSurface(a.renderer, ws, frame.scale)
-		frame.onDraw(ctx)
-
-		// An overlay that requested another frame is pending GPU work even when
-		// application content is clean. Start an overlay-only frame so the normal
-		// end-frame path can draw, submit, and present it.
-		overlayOnlyAcquire := !ws.frameStarted && !ws.pixelPresented &&
-			!ws.acquireFailed && ws.overlayNeedsRedraw
-		if overlayOnlyAcquire {
-			ws.ensureFrameStarted()
-		}
-
-		// No frame started. Two very different reasons:
-		//
-		// The callback issued no draw calls, so lazy acquire never acquired
-		// anything. That is what lazy acquire is for, not a failure — there is
-		// nothing to present and nothing to retry. Asking for another frame
-		// here is a loop with no exit: a demand-driven UI draws nothing when
-		// nothing changed, so the next frame draws nothing either, and the app
-		// spins at whatever rate the platform allows, burning CPU on an idle
-		// window (~27% of a core on X11, with no visible frames at all).
-		//
-		// Or a draw call did ask for the swapchain and could not have it
-		// (surface outdated, not yet configured). Demand-driven mode already
-		// consumed the invalidation, so that one does need another frame.
-		if !ws.frameStarted {
-			// Content acquisition keeps the existing retry policy because its
-			// invalidation was consumed. Overlay-only work remains pending until
-			// the next external invalidation instead of spinning while a surface
-			// is minimized, unconfigured, or lost.
-			if ws.acquireFailed && !overlayOnlyAcquire {
-				a.RequestRedraw()
-			}
-			ws.resetLazyState()
-			a.renderer.currentSurface = nil
-			continue
-		}
-
-		// WriteSurfacePixels has already presented and bypasses GPU overlays.
-		// Preserve their pending work, but do not self-schedule a frame that
-		// cannot composite them; a later non-pixel invalidation will retry.
-		overlayDeferred := ws.pixelPresented
-
-		// On outdated, present() reconfigured the surface; re-render once at the
-		// live scale (a DPI change is an outdated trigger, so frame.scale may be
-		// stale). One retry only — looping can livelock a live resize; if still
-		// outdated, request another frame since nothing else reschedules on-demand.
-		endResult := a.renderer.endFrameForSurface(ws)
-		if endResult.reconfigured {
-			ws.prepareLazyAcquire()
-			frame.onDraw(newContextForSurface(a.renderer, ws, ws.platWindow.ScaleFactor()))
-			overlayDeferred = overlayDeferred || ws.pixelPresented
-			if !ws.frameStarted && !ws.pixelPresented &&
-				!ws.acquireFailed && ws.overlayNeedsRedraw {
-				ws.ensureFrameStarted()
-			}
-			if ws.frameStarted {
-				endResult = a.renderer.endFrameForSurface(ws)
-				if endResult.reconfigured && !overlayOnlyAcquire {
-					a.RequestRedraw()
-				}
-			}
-		}
-
-		// Self-sustaining debug overlay loop (ADR-066, Chromium pattern):
-		// when any overlay returns true from Draw, request another frame so
-		// it can continue animating (FPS counter, fade effects). The loop
-		// automatically stops when all overlays return false.
-		// A failed overlay-only submit/present keeps the overlay pending for an
-		// external invalidation, but must not turn a permanent GPU error into an
-		// unbounded redraw loop. Content frames retain their existing retry policy.
-		overlayCanSelfSchedule := !overlayOnlyAcquire || endResult.completed
-		if ws.overlayNeedsRedraw && !overlayDeferred && overlayCanSelfSchedule {
-			a.RequestRedraw()
-		}
-		ws.resetLazyState()
-		a.renderer.currentSurface = nil
+		a.renderWindowFrame(frame)
 	}
 
 	// Poll submissions once after all windows are presented.
 	a.renderer.pollSubmissions()
 }
 
+// renderWindowFrame draws, finishes, and schedules follow-up work for one
+// window. Keeping this policy together makes the distinction between consumed
+// content invalidations and pending overlay work explicit.
+func (a *App) renderWindowFrame(frame windowFrame) {
+	ws := frame.window.surface
+	if ws == nil {
+		return
+	}
+	a.syncFrameSurfaceSize(ws, frame.physW, frame.physH)
+
+	// Lazy acquire: beginFrame is called on the first draw call. If OnDraw
+	// produces no GPU work, there is nothing to acquire or present.
+	ws.prepareLazyAcquire()
+	a.renderer.currentSurface = ws
+	defer func() {
+		ws.resetLazyState()
+		a.renderer.currentSurface = nil
+	}()
+	frame.onDraw(newContextForSurface(a.renderer, ws, frame.scale))
+
+	overlayOnlyAcquire := startPendingOverlayFrame(ws)
+	if !ws.frameStarted {
+		// Content acquisition consumed its invalidation and must retry. Failed
+		// overlay-only work remains pending for the next external invalidation.
+		if ws.acquireFailed && !overlayOnlyAcquire {
+			a.RequestRedraw()
+		}
+		return
+	}
+
+	// WriteSurfacePixels bypasses GPU overlays. Preserve pending overlay work,
+	// but do not self-schedule a frame which cannot composite it.
+	overlayDeferred := ws.pixelPresented
+	endResult := a.renderer.endFrameForSurface(ws)
+	if endResult.reconfigured {
+		endResult, overlayDeferred = a.retryReconfiguredFrame(
+			frame, ws, overlayOnlyAcquire, overlayDeferred,
+		)
+	}
+
+	// Overlay-only failures stay pending without turning a permanent GPU error
+	// into an unbounded redraw loop. Content frames keep their retry policy.
+	overlayCanSelfSchedule := !overlayOnlyAcquire || endResult.completed
+	if ws.overlayNeedsRedraw && !overlayDeferred && overlayCanSelfSchedule {
+		a.RequestRedraw()
+	}
+}
+
+// startPendingOverlayFrame acquires a frame when the application produced no
+// GPU work but a debug overlay still has animation work pending.
+func startPendingOverlayFrame(ws *RenderTarget) bool {
+	overlayOnly := !ws.frameStarted && !ws.pixelPresented &&
+		!ws.acquireFailed && ws.overlayNeedsRedraw
+	if overlayOnly {
+		ws.ensureFrameStarted()
+	}
+	return overlayOnly
+}
+
+// retryReconfiguredFrame replays a frame once after an outdated present. A
+// second outdated result is deferred to a future content frame; looping here
+// can livelock during a live resize.
+func (a *App) retryReconfiguredFrame(
+	frame windowFrame,
+	ws *RenderTarget,
+	overlayOnlyAcquire bool,
+	overlayDeferred bool,
+) (frameEndResult, bool) {
+	ws.prepareLazyAcquire()
+	frame.onDraw(newContextForSurface(a.renderer, ws, ws.platWindow.ScaleFactor()))
+	overlayDeferred = overlayDeferred || ws.pixelPresented
+	startPendingOverlayFrame(ws)
+	if !ws.frameStarted {
+		return frameEndResult{reconfigured: true}, overlayDeferred
+	}
+
+	result := a.renderer.endFrameForSurface(ws)
+	if result.reconfigured && !overlayOnlyAcquire {
+		a.RequestRedraw()
+	}
+	return result, overlayDeferred
+}
 func (a *App) syncFrameSurfaceSize(ws *RenderTarget, physW, physH int) {
 	// initRenderer may leave the surface unconfigured when PhysicalSize was 0.
 	if !ws.CanRender() && ws.platWindow != nil {

--- a/app_overlay_frame_test.go
+++ b/app_overlay_frame_test.go
@@ -1,0 +1,334 @@
+//go:build !rust && !(js && wasm) && !android
+
+package gogpu
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+)
+
+type finiteFrameOverlay struct {
+	draws int
+}
+
+func (*finiteFrameOverlay) Name() string { return "finite-frame" }
+
+func (o *finiteFrameOverlay) Draw(gpucontext.DebugOverlayContext) bool {
+	o.draws++
+	return o.draws < 2
+}
+
+type namedIdleOverlay string
+
+func (o namedIdleOverlay) Name() string { return string(o) }
+func (namedIdleOverlay) Draw(gpucontext.DebugOverlayContext) bool {
+	return false
+}
+
+func isolatedDebugOverlays(overlays ...gpucontext.DebugOverlay) []gpucontext.DebugOverlay {
+	return append(overlays,
+		namedIdleOverlay(overlayNameDamage),
+		namedIdleOverlay(overlayNameFPS),
+	)
+}
+
+type persistentFrameOverlay struct {
+	draws      int
+	beforeDone func()
+}
+
+func (*persistentFrameOverlay) Name() string { return "persistent-frame" }
+func (o *persistentFrameOverlay) Draw(gpucontext.DebugOverlayContext) bool {
+	o.draws++
+	if o.beforeDone != nil {
+		o.beforeDone()
+	}
+	return true
+}
+
+func newHeadlessRenderTarget(t *testing.T, configure bool) (*Renderer, *RenderTarget) {
+	t.Helper()
+
+	instance, err := wgpu.CreateInstance(nil)
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+	surface, err := instance.CreateSurfaceFromTarget(wgpu.HeadlessSurfaceTarget{})
+	if err != nil {
+		instance.Release()
+		t.Fatalf("CreateSurfaceFromTarget: %v", err)
+	}
+	adapter, err := instance.RequestAdapter(&wgpu.RequestAdapterOptions{
+		CompatibleSurface:    surface,
+		ForceFallbackAdapter: true,
+	})
+	if err != nil {
+		surface.Release()
+		instance.Release()
+		t.Fatalf("RequestAdapter: %v", err)
+	}
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		adapter.Release()
+		surface.Release()
+		instance.Release()
+		t.Fatalf("RequestDevice: %v", err)
+	}
+	t.Cleanup(func() {
+		device.Release()
+		surface.Release()
+		adapter.Release()
+		instance.Release()
+	})
+
+	const size = 64
+	renderer := &Renderer{device: device, adapter: adapter}
+	ws := &RenderTarget{
+		renderer: renderer,
+		surface:  surface,
+		state:    SurfaceConfigured,
+		width:    size,
+		height:   size,
+		format:   gputypes.TextureFormatBGRA8Unorm,
+		vsync:    true,
+	}
+	renderer.primary = ws
+	if configure {
+		if err := ws.configure(device, adapter); err != nil {
+			t.Fatalf("Configure: %v", err)
+		}
+	}
+	return renderer, ws
+}
+
+func TestRenderFrameGPU_OverlayAnimationContinuesWithoutContentDamage(t *testing.T) {
+	renderer, ws := newHeadlessRenderTarget(t, true)
+	overlay := &finiteFrameOverlay{}
+	ws.debugOverlays = isolatedDebugOverlays(overlay)
+	app := &App{
+		renderLoop: &mockRenderLoop{},
+		renderer:   renderer,
+	}
+
+	frame := windowFrame{window: &Window{surface: ws}, scale: 1}
+	frame.onDraw = func(ctx *Context) { ctx.MarkPreserveContent() }
+	app.renderFrameGPU([]windowFrame{frame})
+	if overlay.draws != 1 {
+		t.Fatalf("overlay draws after content frame = %d, want 1", overlay.draws)
+	}
+	if !app.pendingRedraw.Swap(false) {
+		t.Fatal("animating overlay did not request its next frame")
+	}
+
+	// The UI has no new damage on the requested frame. The overlay must still
+	// acquire, render, and present an overlay-only frame to finish its animation.
+	frame.onDraw = func(*Context) {}
+	app.renderFrameGPU([]windowFrame{frame})
+
+	if overlay.draws != 2 {
+		t.Errorf("overlay draws after idle frame = %d, want 2", overlay.draws)
+	}
+	if ws.frameNumber != 2 {
+		t.Errorf("presented frames = %d, want 2", ws.frameNumber)
+	}
+	if ws.overlayNeedsRedraw {
+		t.Error("finished overlay remained pending")
+	}
+	if app.pendingRedraw.Load() {
+		t.Error("finished overlay requested another frame")
+	}
+}
+
+func TestRenderFrameGPU_FailedOverlayAcquireWaitsForExternalInvalidation(t *testing.T) {
+	renderer, ws := newHeadlessRenderTarget(t, false)
+	overlay := &finiteFrameOverlay{}
+	ws.debugOverlays = isolatedDebugOverlays(overlay)
+	ws.overlayNeedsRedraw = true
+	app := &App{renderLoop: &mockRenderLoop{}, renderer: renderer}
+	frame := windowFrame{
+		window: &Window{surface: ws},
+		onDraw: func(*Context) {},
+		scale:  1,
+	}
+
+	// A stale configured state exercises a real failed GetCurrentTexture call.
+	// Recovery configures the surface, but the overlay-only frame must not
+	// self-schedule indefinitely if acquisition remains unavailable.
+	app.renderFrameGPU([]windowFrame{frame})
+	if app.pendingRedraw.Load() {
+		t.Fatal("failed overlay-only acquire self-scheduled another frame")
+	}
+	if !ws.overlayNeedsRedraw {
+		t.Fatal("failed overlay-only acquire discarded pending work")
+	}
+	if overlay.draws != 0 {
+		t.Fatalf("overlay draws after failed acquire = %d, want 0", overlay.draws)
+	}
+
+	// A later external invalidation retries the preserved work. The recovery
+	// from the first attempt made this acquire succeed.
+	app.renderFrameGPU([]windowFrame{frame})
+	if overlay.draws != 1 {
+		t.Fatalf("overlay draws after external retry = %d, want 1", overlay.draws)
+	}
+	if !app.pendingRedraw.Swap(false) {
+		t.Fatal("animating overlay did not request its next frame after recovery")
+	}
+
+	app.renderFrameGPU([]windowFrame{frame})
+	if overlay.draws != 2 {
+		t.Errorf("overlay draws after recovery animation = %d, want 2", overlay.draws)
+	}
+	if app.pendingRedraw.Load() {
+		t.Error("finished overlay requested another frame")
+	}
+}
+
+func TestRenderFrameGPU_FailedOverlayPresentDoesNotSelfSchedule(t *testing.T) {
+	renderer, ws := newHeadlessRenderTarget(t, true)
+	// Unconfiguring after the overlay records its commands makes the subsequent
+	// PresentWithDamage fail while still exercising a successful frame acquire.
+	overlay := &persistentFrameOverlay{beforeDone: ws.surface.Unconfigure}
+	ws.debugOverlays = isolatedDebugOverlays(overlay)
+	ws.overlayNeedsRedraw = true
+	app := &App{renderLoop: &mockRenderLoop{}, renderer: renderer}
+	frame := windowFrame{
+		window: &Window{surface: ws},
+		onDraw: func(*Context) {},
+		scale:  1,
+	}
+
+	for range 3 {
+		if err := ws.configure(renderer.device, renderer.adapter); err != nil {
+			t.Fatalf("reconfigure before external retry: %v", err)
+		}
+		app.renderFrameGPU([]windowFrame{frame})
+		if app.pendingRedraw.Swap(false) {
+			t.Error("failed overlay-only present scheduled an unbounded retry")
+		}
+		if !ws.overlayNeedsRedraw {
+			t.Error("failed overlay-only present discarded pending work")
+		}
+	}
+	if overlay.draws != 3 {
+		t.Errorf("overlay draws after external retries = %d, want 3", overlay.draws)
+	}
+}
+
+func TestRenderFrameGPU_UnavailablePendingOverlayDoesNotSelfSchedule(t *testing.T) {
+	tests := []struct {
+		name string
+		ws   *RenderTarget
+	}{
+		{name: "unconfigured", ws: &RenderTarget{state: SurfaceReady}},
+		{
+			name: "minimized",
+			ws: &RenderTarget{
+				state:      SurfaceReady,
+				platWindow: &mockWindow{width: 0, height: 0},
+			},
+		},
+		{name: "lost", ws: &RenderTarget{state: SurfaceLost}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overlay := &finiteFrameOverlay{}
+			renderer := &Renderer{}
+			tt.ws.renderer = renderer
+			tt.ws.debugOverlays = isolatedDebugOverlays(overlay)
+			tt.ws.overlayNeedsRedraw = true
+			renderer.primary = tt.ws
+			app := &App{renderLoop: &mockRenderLoop{}, renderer: renderer}
+			frame := windowFrame{
+				window: &Window{surface: tt.ws},
+				onDraw: func(*Context) {},
+				scale:  1,
+			}
+
+			for range 3 {
+				app.renderFrameGPU([]windowFrame{frame})
+				if app.pendingRedraw.Swap(false) {
+					t.Error("unavailable overlay-only frame scheduled an unbounded retry")
+				}
+			}
+			if !tt.ws.overlayNeedsRedraw {
+				t.Error("pending overlay work was discarded instead of deferred")
+			}
+			if overlay.draws != 0 {
+				t.Errorf("overlay draws = %d without a surface, want 0", overlay.draws)
+			}
+		})
+	}
+}
+
+func TestRenderFrameGPU_PixelPresentedFrameDefersPendingOverlay(t *testing.T) {
+	for _, frameStarted := range []bool{false, true} {
+		t.Run(fmt.Sprintf("frame_started_%t", frameStarted), func(t *testing.T) {
+			renderer, ws := newHeadlessRenderTarget(t, true)
+			overlay := &finiteFrameOverlay{}
+			ws.debugOverlays = isolatedDebugOverlays(overlay)
+			ws.overlayNeedsRedraw = true
+			app := &App{renderLoop: &mockRenderLoop{}, renderer: renderer}
+			frame := windowFrame{
+				window: &Window{surface: ws},
+				onDraw: func(*Context) {
+					// WriteSurfacePixels sets this after bypassing the GPU frame path.
+					ws.pixelPresented = true
+					ws.frameStarted = frameStarted
+				},
+				scale: 1,
+			}
+
+			for range 3 {
+				app.renderFrameGPU([]windowFrame{frame})
+				if app.pendingRedraw.Swap(false) {
+					t.Error("pixel presentation scheduled an overlay frame it cannot composite")
+				}
+			}
+			if !ws.overlayNeedsRedraw {
+				t.Error("pixel presentation discarded pending overlay work")
+			}
+			if overlay.draws != 0 {
+				t.Errorf("overlay draws on pixel-present path = %d, want 0", overlay.draws)
+			}
+		})
+	}
+}
+
+func TestRenderFrameGPU_UnavailableOverlayDoesNotSuppressOtherSurfaceRetry(t *testing.T) {
+	renderer := &Renderer{}
+	overlaySurface := &RenderTarget{
+		renderer:           renderer,
+		state:              SurfaceReady,
+		debugOverlays:      isolatedDebugOverlays(new(finiteFrameOverlay)),
+		overlayNeedsRedraw: true,
+	}
+	contentSurface := &RenderTarget{renderer: renderer, state: SurfaceReady}
+	app := &App{renderLoop: &mockRenderLoop{}, renderer: renderer}
+	frames := []windowFrame{
+		{
+			window: &Window{surface: overlaySurface},
+			onDraw: func(*Context) {},
+			scale:  1,
+		},
+		{
+			window: &Window{surface: contentSurface},
+			onDraw: func(ctx *Context) { ctx.MarkPreserveContent() },
+			scale:  1,
+		},
+	}
+
+	app.renderFrameGPU(frames)
+
+	if !app.pendingRedraw.Load() {
+		t.Error("content acquire failure on another surface did not retain its retry")
+	}
+	if !overlaySurface.overlayNeedsRedraw {
+		t.Error("unavailable surface discarded its pending overlay")
+	}
+}

--- a/app_overlay_frame_test.go
+++ b/app_overlay_frame_test.go
@@ -219,6 +219,56 @@ func TestRenderFrameGPU_FailedOverlayPresentDoesNotSelfSchedule(t *testing.T) {
 	}
 }
 
+func TestRetryReconfiguredFrameReplaysAtLiveScale(t *testing.T) {
+	renderer, ws := newHeadlessRenderTarget(t, true)
+	ws.platWindow = &mockWindow{width: 64, height: 64, scaleFactor: 2}
+	app := &App{renderLoop: &mockRenderLoop{}, renderer: renderer}
+	draws := 0
+	frame := windowFrame{
+		window: &Window{surface: ws},
+		onDraw: func(ctx *Context) {
+			draws++
+			if ctx.ScaleFactor() != 2 {
+				t.Errorf("retry scale = %v, want live scale 2", ctx.ScaleFactor())
+			}
+			ctx.MarkPreserveContent()
+		},
+		scale: 1,
+	}
+
+	result, overlayDeferred := app.retryReconfiguredFrame(frame, ws, false, false)
+
+	if !result.completed || result.reconfigured {
+		t.Errorf("retry result = %+v, want completed without another reconfigure", result)
+	}
+	if overlayDeferred {
+		t.Fatal("GPU retry unexpectedly deferred an overlay")
+	}
+	if draws != 1 {
+		t.Errorf("retry draw callbacks = %d, want 1", draws)
+	}
+}
+
+func TestRetryReconfiguredFrameWithoutGPUWorkDefers(t *testing.T) {
+	renderer, ws := newHeadlessRenderTarget(t, true)
+	ws.platWindow = &mockWindow{width: 64, height: 64, scaleFactor: 1}
+	app := &App{renderLoop: &mockRenderLoop{}, renderer: renderer}
+	frame := windowFrame{
+		window: &Window{surface: ws},
+		onDraw: func(*Context) {},
+		scale:  1,
+	}
+
+	result, overlayDeferred := app.retryReconfiguredFrame(frame, ws, false, false)
+
+	if !result.reconfigured || result.completed {
+		t.Errorf("retry result = %+v, want reconfigured and incomplete", result)
+	}
+	if overlayDeferred {
+		t.Fatal("retry without pixel presentation deferred an overlay")
+	}
+}
+
 func TestRenderFrameGPU_UnavailablePendingOverlayDoesNotSelfSchedule(t *testing.T) {
 	tests := []struct {
 		name string

--- a/context.go
+++ b/context.go
@@ -106,6 +106,9 @@ func (c *Context) RemoveDebugOverlay(name string) {
 	for i, overlay := range ws.debugOverlays {
 		if overlay.Name() == name {
 			ws.debugOverlays = append(ws.debugOverlays[:i], ws.debugOverlays[i+1:]...)
+			if len(ws.debugOverlays) == 0 {
+				ws.overlayNeedsRedraw = false
+			}
 			return
 		}
 	}

--- a/context_command_encoder_test.go
+++ b/context_command_encoder_test.go
@@ -12,7 +12,8 @@ import (
 
 type countingSubmitQueue struct {
 	noop.Queue
-	submits int
+	submits   int
+	submitErr error
 }
 
 type commandEncoderFailDevice struct{ noop.Device }
@@ -25,6 +26,9 @@ func (d *commandEncoderFailDevice) CreateCommandEncoder(
 
 func (q *countingSubmitQueue) Submit(_ []hal.CommandBuffer) (uint64, error) {
 	q.submits++
+	if q.submitErr != nil {
+		return 0, q.submitErr
+	}
 	return uint64(q.submits), nil
 }
 
@@ -96,7 +100,9 @@ func TestContextCommandEncoderReusesAndSubmitsFrameEncoderOnce(t *testing.T) {
 		t.Fatalf("encoder submitted before frame end: %d", queue.submits)
 	}
 
-	target.submitFrameEncoder(target.renderer)
+	if !target.submitFrameEncoder(target.renderer) {
+		t.Fatal("frame encoder submission failed")
+	}
 	if queue.submits != 1 {
 		t.Fatalf("frame submissions = %d, want 1", queue.submits)
 	}
@@ -219,12 +225,32 @@ func TestSubmitFrameEncoderDropsFinishFailure(t *testing.T) {
 	}
 	encoder.CopyBufferToBuffer(nil, 0, nil, 0, 1)
 
-	target.submitFrameEncoder(target.renderer)
+	if target.submitFrameEncoder(target.renderer) {
+		t.Fatal("invalid frame encoder was reported submitted")
+	}
 	if target.frameEncoder != nil {
 		t.Fatal("failed frame encoder was retained")
 	}
 	if queue.submits != 0 {
 		t.Fatalf("invalid frame submissions = %d, want 0", queue.submits)
+	}
+}
+
+func TestSubmitFrameEncoderReportsQueueFailure(t *testing.T) {
+	ctx, target, queue := newSharedEncoderTestContext(t)
+	if encoder := ctx.CommandEncoder(); encoder == nil {
+		t.Fatal("CommandEncoder returned nil")
+	}
+	queue.submitErr = errors.New("injected submit failure")
+
+	if target.submitFrameEncoder(target.renderer) {
+		t.Fatal("failed queue submission was reported successful")
+	}
+	if target.frameEncoder != nil {
+		t.Fatal("failed frame encoder was retained")
+	}
+	if queue.submits != 1 {
+		t.Fatalf("submission attempts = %d, want 1", queue.submits)
 	}
 }
 
@@ -235,8 +261,12 @@ func TestEndFrameDiscardsEncoderAfterPixelPresent(t *testing.T) {
 	}
 	target.pixelPresented = true
 
-	if target.renderer.endFrameForSurface(target) {
+	result := target.renderer.endFrameForSurface(target)
+	if result.reconfigured {
 		t.Fatal("pixel-presented frame unexpectedly reconfigured")
+	}
+	if !result.completed {
+		t.Fatal("pixel-presented frame was not reported complete")
 	}
 	if target.frameEncoder != nil {
 		t.Fatal("pixel-presented frame retained its encoder")

--- a/context_preserve_content_test.go
+++ b/context_preserve_content_test.go
@@ -271,6 +271,20 @@ func TestRemoveDebugOverlay_NotFound(t *testing.T) {
 	}
 }
 
+func TestRemoveDebugOverlay_LastOverlayClearsPendingRedraw(t *testing.T) {
+	ws := newTestWindowSurface()
+	ctx := newContext(ws.renderer, 1.0)
+
+	ctx.RegisterDebugOverlay(&mockDebugOverlay{name: "fps"})
+	ws.overlayNeedsRedraw = true
+
+	ctx.RemoveDebugOverlay("fps")
+
+	if ws.overlayNeedsRedraw {
+		t.Error("removed last overlay remained pending")
+	}
+}
+
 // TestContextRenderTarget_PreserveContent verifies that the ggcanvas adapter
 // exposes the external-content state for the surface targeted by its Context.
 func TestContextRenderTarget_PreserveContent(t *testing.T) {

--- a/renderer.go
+++ b/renderer.go
@@ -97,7 +97,8 @@ type RenderTarget struct {
 	// signaling it needs another frame to complete visualization (e.g., fade
 	// animation, FPS counter). The caller (App frame loop) checks this and
 	// calls RequestRedraw for a self-sustaining render loop that automatically
-	// stops when all overlays return false (Chromium pattern).
+	// stops when all overlays return false (Chromium pattern). This is pending
+	// work for the next frame and intentionally survives lazy-state cleanup.
 	overlayNeedsRedraw bool
 
 	// hasGPUWork tracks whether any draw calls were issued this frame.
@@ -588,11 +589,17 @@ func (r *Renderer) EndFrame() {
 	r.pollSubmissions()
 }
 
+// frameEndResult reports whether the surface was reconfigured and whether all
+// work for the frame was successfully submitted and presented.
+type frameEndResult struct {
+	reconfigured bool
+	completed    bool
+}
+
 // endFrameForSurface flushes, presents, and releases frame resources for a
 // specific RenderTarget. Used by the multi-window frame loop. Unlike EndFrame,
 // it does NOT poll submissions -- the caller polls once after all windows.
-// Returns true if present() reconfigured an outdated surface (see present).
-func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
+func (r *Renderer) endFrameForSurface(ws *RenderTarget) frameEndResult {
 	// PresentPixels already presented — skip normal present path (ADR-052).
 	if ws.pixelPresented {
 		ws.discardFrameEncoder()
@@ -602,12 +609,12 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 			ws.platWindow.SyncFrame()
 		}
 		ws.releaseFrame()
-		return false
+		return frameEndResult{completed: true}
 	}
 
-	ws.flushClear(r.device, r)
+	clearOK := ws.flushClear(r.device, r)
 	ws.drawDebugOverlays()
-	ws.submitFrameEncoder(r)
+	submitOK := ws.submitFrameEncoder(r)
 	ws.frameNumber++
 	// Request frame callback BEFORE present (winit pre_present_notify pattern).
 	// Wayland spec: "The frame request will take effect on the next commit."
@@ -615,9 +622,10 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	if ws.platWindow != nil {
 		ws.platWindow.SyncFrame()
 	}
-	reconfigured := ws.present()
+	result := ws.present()
+	result.completed = clearOK && submitOK && result.completed
 	ws.releaseFrame()
-	return reconfigured
+	return result
 }
 
 // pollSubmissions performs non-blocking submission tracking: frees GPU resources
@@ -638,10 +646,11 @@ func (r *Renderer) pollSubmissions() {
 // wl_display_flush during vkQueuePresentKHR. The display lock serializes this with
 // the main thread's DispatchDefaultQueue (ADR-041 Phase 2).
 //
-// Returns true if the surface was outdated and reconfigured — caller re-renders.
-func (ws *RenderTarget) present() (reconfigured bool) {
+// A reconfigured surface must be rendered again; completed is true only when
+// this frame was successfully presented.
+func (ws *RenderTarget) present() frameEndResult {
 	if ws.currentSurfaceTexture == nil {
-		return false
+		return frameEndResult{}
 	}
 	finalDamage := unionAllSources(ws.damageSources)
 	lockDisplay(ws.platWindow)
@@ -651,7 +660,7 @@ func (ws *RenderTarget) present() (reconfigured bool) {
 		ds.reset()
 	}
 	if err == nil {
-		return false
+		return frameEndResult{completed: true}
 	}
 	// Mirror recoverFromAcquireError: outdated is expected (resize/DPI/monitor),
 	// not an error — reconfigure and signal the caller to re-render.
@@ -661,19 +670,19 @@ func (ws *RenderTarget) present() (reconfigured bool) {
 			if cfgErr := ws.configure(ws.renderer.device, ws.renderer.adapter); cfgErr != nil {
 				slog.Error("gogpu: reconfigure after outdated failed", "err", cfgErr)
 				ws.state = SurfaceLost
-				return false
+				return frameEndResult{}
 			}
-			return true
+			return frameEndResult{reconfigured: true}
 		}
-		return false
+		return frameEndResult{}
 	}
 	if errors.Is(err, wgpu.ErrSurfaceLost) {
 		slog.Error("gogpu: surface lost on present", "err", err)
 		ws.state = SurfaceLost
-		return false
+		return frameEndResult{}
 	}
 	slog.Error("PRESENT ERROR", "err", err)
-	return false
+	return frameEndResult{}
 }
 
 // setTransactionPresent toggles Core Animation transaction-based present on
@@ -732,7 +741,6 @@ func (ws *RenderTarget) resetLazyState() {
 	ws.hasGPUWork = false
 	ws.pixelPresented = false
 	ws.acquireFailed = false
-	ws.overlayNeedsRedraw = false
 }
 
 // ensureFrameEncoder returns the framework-owned encoder for this surface
@@ -755,18 +763,18 @@ func (ws *RenderTarget) ensureFrameEncoder() (*wgpu.CommandEncoder, error) {
 }
 
 // submitFrameEncoder finishes and submits the framework-owned shared encoder.
-func (ws *RenderTarget) submitFrameEncoder(r *Renderer) {
+func (ws *RenderTarget) submitFrameEncoder(r *Renderer) bool {
 	encoder := ws.frameEncoder
 	ws.frameEncoder = nil
 	if encoder == nil {
-		return
+		return true
 	}
 	commands, err := encoder.Finish()
 	if err != nil {
 		slog.Error("finish shared frame encoder failed", "err", err)
-		return
+		return false
 	}
-	r.submitTracked(commands)
+	return r.submitTracked(commands)
 }
 
 // drawDebugOverlays iterates registered debug overlays and calls their Draw
@@ -788,12 +796,16 @@ func (ws *RenderTarget) drawDebugOverlays() {
 	initFPSOverlayIfNeeded(ws)
 
 	if len(ws.debugOverlays) == 0 {
+		ws.overlayNeedsRedraw = false
 		return
 	}
 	if ws.currentView == nil {
 		return
 	}
 
+	// Consume the prior request before recording this frame. A successful
+	// overlay can set it again; an encoder failure must not create a retry loop.
+	ws.overlayNeedsRedraw = false
 	encoder, err := ws.ensureFrameEncoder()
 	if err != nil {
 		slog.Error("gogpu: debug overlay encoder unavailable", "err", err)
@@ -808,7 +820,6 @@ func (ws *RenderTarget) drawDebugOverlays() {
 		FrameNumber:   ws.frameNumber,
 	}
 
-	ws.overlayNeedsRedraw = false
 	for _, overlay := range ws.debugOverlays {
 		if overlay.Draw(ctx) {
 			ws.overlayNeedsRedraw = true
@@ -913,20 +924,20 @@ func (ws *RenderTarget) flushClear(device *wgpu.Device, r *Renderer) bool {
 		return false
 	}
 
-	r.submitTracked(commands)
-	return true
+	return r.submitTracked(commands)
 }
 
 // submitTracked submits commands with non-blocking tracking.
 // The command buffer is stored and released only when GPU finishes using it.
 // BUG-GOGPU-004: HAL manages fences internally — single vkQueueSubmit per frame.
-func (r *Renderer) submitTracked(commands *wgpu.CommandBuffer) {
+func (r *Renderer) submitTracked(commands *wgpu.CommandBuffer) bool {
 	subIdx, err := r.device.Queue().Submit(commands)
 	if err != nil {
 		slog.Error("submit failed", "err", err)
-		return
+		return false
 	}
 	r.tracker.track(subIdx, commands)
+	return true
 }
 
 // Size returns the current render target size.

--- a/renderer_skip_present_test.go
+++ b/renderer_skip_present_test.go
@@ -45,10 +45,11 @@ func TestPrepareLazyAcquire_SetsState(t *testing.T) {
 	}
 }
 
-func TestResetLazyState_ClearsAll(t *testing.T) {
+func TestResetLazyState_ClearsPerFrameState(t *testing.T) {
 	ws := newTestWindowSurface()
 	ws.frameStarted = true
 	ws.hasGPUWork = true
+	ws.overlayNeedsRedraw = true
 
 	ws.resetLazyState()
 
@@ -57,6 +58,9 @@ func TestResetLazyState_ClearsAll(t *testing.T) {
 	}
 	if ws.hasGPUWork {
 		t.Error("resetLazyState should clear hasGPUWork")
+	}
+	if !ws.overlayNeedsRedraw {
+		t.Error("resetLazyState should preserve pending overlay work")
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep debug-overlay animation demand pending across lazy-frame cleanup
- acquire an overlay-only frame when application content is idle
- propagate clear, submit, and present completion so failed overlay-only frames park work instead of self-scheduling forever
- preserve the existing content-frame retry policy and defer overlay work on pixel-present paths
- clear stale demand when the last overlay is removed
- add lifecycle coverage for idle animation, acquire/submit/present failures, unavailable surfaces, pixels, and multiple surfaces

## Why

An overlay can request its next animation frame after the application has no content damage. The lazy frame path previously discarded that demand before acquiring or presenting another frame, so animations stopped after the first draw. Merely preserving the flag is not sufficient: persistent surface or queue failures would then create an unbounded redraw loop. This change carries completion status through the frame boundary and only self-schedules a successful overlay-only frame.

## Verification

- focused overlay lifecycle tests, repeated and under the race detector
- debug overlay tests with damage/FPS environment modes enabled
- `go test ./...`
- `go test -race ./...`
- Linux and Windows package test cross-compilation
- `gofmt` and `git diff --check`

`go vet ./...` reports only existing Darwin `unsafe.Pointer` warnings in unchanged platform files.

Addresses Bug 2 of #442. Bug 1 remains outside this PR.
