### PR TITLE
release: v0.52.0 — compositor-owned render target (ADR-067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.0] - 2026-08-10
+
+### Added
+
+- **Compositor-owned render target** (ADR-067, #443) — fundamental architecture redesign. Compositor (gogpu) owns composition texture; drawing library (gg) renders into provided view. Enterprise pattern validated by Chromium cc/, GTK4 GSK, Flutter flow/ source code.
+  - `composView`: content cache texture — gg/g3d draw here, persists between frames
+  - Overlay draws on swapchain after blit — never accumulates, fade works on idle content
+  - `blitPipeline`: passthrough copy (composition → swapchain, no blend)
+  - `compositePipeline`: premultiplied alpha blend (MSAA overlay compositing)
+  - `tryOverlayOnlyFrame()`: overlay-only frames when content idle
+  - `externalContent` flag: separate from `frameCleared` (g3d → gg coordination)
+  - Persistent MSAA composite bind group on RenderTarget (not per-frame)
+  - `damage_scissor.go`: canonical damage scissor computation (moved from gg)
+  - `compositor_blit.go`: `SurfaceCompositor` implementation, `BlitDrawRecorder`, `CompositorBlitResources`
+  - 20+ tests for overlay lifecycle, damage scissor, compositor resources
+
+### Changed
+
+- **deps:** gpucontext v0.26.0 → v0.27.0 (SurfaceCompositor interface)
+
 ## [0.51.0] - 2026-08-10
 
 ### Added

--- a/app.go
+++ b/app.go
@@ -1126,7 +1126,14 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 		// Or a draw call did ask for the swapchain and could not have it
 		// (surface outdated, not yet configured). Demand-driven mode already
 		// consumed the invalidation, so that one does need another frame.
-		if !ws.frameStarted {
+		//
+		// ADR-067: overlay-only frame. If the composition texture still holds
+		// content from the previous frame (composView != nil) and an overlay
+		// needs another frame (e.g., FPS counter, fade animation), acquire the
+		// swapchain and run endFrame to blit the preserved composition texture
+		// with updated overlays. This enables self-sustaining overlay animation
+		// even when the application's OnDraw callback draws nothing.
+		if !ws.frameStarted && !ws.tryOverlayOnlyFrame() {
 			if ws.acquireFailed {
 				a.RequestRedraw()
 			}

--- a/compositor_blit.go
+++ b/compositor_blit.go
@@ -1,0 +1,302 @@
+package gogpu
+
+import (
+	"encoding/binary"
+	"fmt"
+	"image"
+	"log/slog"
+	"math"
+
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+)
+
+// BlitDrawRecorder is the interface content renderers (gg, g3d) implement to
+// record draw calls into a compositor-owned render pass. The compositor owns
+// the render pass lifecycle (BeginRenderPass, LoadOp, scissor, End) and lets
+// each renderer record its draws at the appropriate point.
+//
+// This decouples the compositor (gogpu) from renderer internals. Each renderer
+// implements RecordBlitDraws with its own pipeline/bind-group logic.
+type BlitDrawRecorder interface {
+	// RecordBlitDraws records non-MSAA textured quad draws into the render pass.
+	// The pass is already begun with the correct LoadOp and viewport.
+	// The recorder must only call SetPipeline/SetBindGroup/SetVertexBuffer/Draw.
+	RecordBlitDraws(pass *wgpu.RenderPassEncoder)
+}
+
+// CompositorBlitResources holds per-surface GPU resources for the surface
+// compositor's MSAA overlay alpha-composite path. When an MSAA render pass
+// produces a transparent overlay, it resolves into a single-sample texture.
+// These resources blit that texture onto the existing surface content.
+//
+// Corresponds to gg's surfaceCompositeVertBuf/UniformBuf/BindGroup/BoundView
+// that previously lived in GPURenderSession.
+type CompositorBlitResources struct {
+	VertBuf    *wgpu.Buffer
+	UniformBuf *wgpu.Buffer
+	BindGroup  *wgpu.BindGroup
+	BoundView  *wgpu.TextureView
+}
+
+// ReleaseBinding drops the bind group before its sampled overlay resolve
+// texture is destroyed or replaced. The vertex and uniform buffers remain
+// reusable across surface resizes.
+func (r *CompositorBlitResources) ReleaseBinding() {
+	if r.BindGroup != nil {
+		r.BindGroup.Release()
+		r.BindGroup = nil
+	}
+	r.BoundView = nil
+}
+
+// Destroy releases all compositor blit resources.
+func (r *CompositorBlitResources) Destroy() {
+	r.ReleaseBinding()
+	if r.UniformBuf != nil {
+		r.UniformBuf.Release()
+		r.UniformBuf = nil
+	}
+	if r.VertBuf != nil {
+		r.VertBuf.Release()
+		r.VertBuf = nil
+	}
+}
+
+// EncodeCompositorBlitPass records a non-MSAA blit render pass to the
+// swapchain surface with damage-aware scissoring. Exported for use by
+// content renderers that need compositor-controlled blit passes.
+func (r *Renderer) EncodeCompositorBlitPass(
+	encoder *wgpu.CommandEncoder,
+	view *wgpu.TextureView,
+	w, h uint32,
+	preserveContent bool,
+	damageRects []image.Rectangle,
+	baseRecorder BlitDrawRecorder,
+	overlayRecorders []BlitOverlayDraw,
+) error {
+	hasDamage := len(damageRects) > 0
+	loadOp := gputypes.LoadOpClear
+	if hasDamage || preserveContent {
+		loadOp = gputypes.LoadOpLoad
+	}
+
+	rp, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		Label: "compositor_blit_pass",
+		ColorAttachments: []wgpu.RenderPassColorAttachment{{
+			View:       view,
+			LoadOp:     loadOp,
+			StoreOp:    gputypes.StoreOpStore,
+			ClearValue: gputypes.Color{R: 0, G: 0, B: 0, A: 1},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("begin compositor blit pass: %w", err)
+	}
+	rp.SetViewport(0, 0, float32(w), float32(h), 0, 1)
+
+	// Base layer: per-rect scissor when damage rects exist (ADR-028).
+	r.recordBaseBlitDraws(rp, baseRecorder, hasDamage, damageRects, w, h)
+
+	// Overlay draws: per-overlay scissor intersected with damage union.
+	r.recordOverlayBlitDraws(rp, overlayRecorders, damageRects, w, h)
+
+	if endErr := rp.End(); endErr != nil {
+		slog.Warn("compositor blit pass End failed", "err", endErr)
+	}
+	return nil
+}
+
+// recordBaseBlitDraws records base layer draws with per-rect damage scissoring.
+func (r *Renderer) recordBaseBlitDraws(rp *wgpu.RenderPassEncoder, base BlitDrawRecorder, hasDamage bool, rects []image.Rectangle, w, h uint32) {
+	if base == nil {
+		return
+	}
+	if hasDamage {
+		for _, dr := range rects {
+			dx, dy, dw, dh, valid := computeDamageScissor(nil, w, h, dr)
+			if valid {
+				rp.SetScissorRect(dx, dy, dw, dh)
+				base.RecordBlitDraws(rp)
+			}
+		}
+	} else {
+		base.RecordBlitDraws(rp)
+	}
+}
+
+// recordOverlayBlitDraws records overlay draws with per-overlay damage scissoring.
+func (r *Renderer) recordOverlayBlitDraws(rp *wgpu.RenderPassEncoder, overlays []BlitOverlayDraw, rects []image.Rectangle, w, h uint32) {
+	if len(overlays) == 0 {
+		return
+	}
+	damageUnion := damageRectsUnion(rects)
+	for _, overlay := range overlays {
+		if ApplyOverlayScissorWithDamage(rp, overlay.ScissorRect, w, h, damageUnion) {
+			overlay.Recorder.RecordBlitDraws(rp)
+		}
+	}
+}
+
+// BlitOverlayDraw pairs a scissor rect with a draw recorder for overlay
+// rendering. Each overlay can have its own scissor state.
+type BlitOverlayDraw struct {
+	// ScissorRect is the scissor rect in device pixels. nil means full surface.
+	ScissorRect *[4]uint32
+	// Recorder records the overlay's draw calls.
+	Recorder BlitDrawRecorder
+}
+
+// applyOverlayScissorWithDamage applies the scissor rect for an overlay,
+// intersecting with the damage union rect. Returns false if the intersection
+// is empty (overlay entirely outside damage).
+func ApplyOverlayScissorWithDamage(rp *wgpu.RenderPassEncoder, rect *[4]uint32, w, h uint32, damage image.Rectangle) bool {
+	if damage.Empty() {
+		// No damage constraint — use group scissor or full surface.
+		if rect != nil {
+			rp.SetScissorRect(rect[0], rect[1], rect[2], rect[3])
+		} else {
+			rp.SetScissorRect(0, 0, w, h)
+		}
+		return true
+	}
+	dx, dy, dw, dh, valid := computeDamageScissor(rect, w, h, damage)
+	if !valid {
+		return false
+	}
+	rp.SetScissorRect(dx, dy, dw, dh)
+	return true
+}
+
+// encodeSurfaceCompositePass alpha-blends a transparent overlay resolve texture
+// onto the existing single-sample surface using the blit pipeline's alpha
+// blending mode. Used when MSAA overlay rendering resolves into an intermediate
+// texture that must be composited on top of previous surface content.
+//
+// This replaces gg's encodeSurfaceCompositePass. The pipeline is gogpu's
+// dedicated blit pipeline (blitPipeline) with its own resources, independent
+// of any content renderer's pipelines.
+func (r *Renderer) encodeSurfaceCompositePass(
+	encoder *wgpu.CommandEncoder,
+	view *wgpu.TextureView,
+	compositeView *wgpu.TextureView,
+	w, h uint32,
+) error {
+	if compositeView == nil || view == nil {
+		return fmt.Errorf("gogpu: nil view in surface composite pass")
+	}
+	if !r.blitPipelineInited {
+		if err := r.initBlitPipeline(); err != nil {
+			return fmt.Errorf("gogpu: blit pipeline init: %w", err)
+		}
+	}
+
+	// Persistent bind group for the composite texture view — recreated only
+	// when compositeView changes (same pattern as old gg surfaceCompositeBindGroup).
+	// MUST NOT defer Release — shared encoder is submitted AFTER this function returns.
+	ws := r.currentSurface
+	if ws == nil {
+		return fmt.Errorf("gogpu: no current surface for composite")
+	}
+	if ws.compositeBindGroup == nil || ws.compositeBoundView != compositeView {
+		if ws.compositeBindGroup != nil {
+			ws.pendingCompositeRelease = ws.compositeBindGroup
+		}
+		bg, err := r.device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+			Label:  "Surface Composite Texture Bind Group",
+			Layout: r.blitTextureLayout,
+			Entries: []wgpu.BindGroupEntry{
+				{Binding: 0, Sampler: r.blitSampler},
+				{Binding: 1, TextureView: compositeView},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("gogpu: create surface composite bind group: %w", err)
+		}
+		ws.compositeBindGroup = bg
+		ws.compositeBoundView = compositeView
+	}
+	texBindGrp := ws.compositeBindGroup
+
+	// Upload full-surface quad uniforms.
+	binary.LittleEndian.PutUint32(r.blitUniformData[0:4], math.Float32bits(0))            // x
+	binary.LittleEndian.PutUint32(r.blitUniformData[4:8], math.Float32bits(0))            // y
+	binary.LittleEndian.PutUint32(r.blitUniformData[8:12], math.Float32bits(float32(w)))  // width
+	binary.LittleEndian.PutUint32(r.blitUniformData[12:16], math.Float32bits(float32(h))) // height
+	binary.LittleEndian.PutUint32(r.blitUniformData[16:20], math.Float32bits(float32(w))) // screenWidth
+	binary.LittleEndian.PutUint32(r.blitUniformData[20:24], math.Float32bits(float32(h))) // screenHeight
+	binary.LittleEndian.PutUint32(r.blitUniformData[24:28], math.Float32bits(1.0))        // alpha
+	binary.LittleEndian.PutUint32(r.blitUniformData[28:32], math.Float32bits(1.0))        // premultiplied
+	if err := r.device.Queue().WriteBuffer(r.blitUniformBuf, 0, r.blitUniformData); err != nil {
+		return fmt.Errorf("gogpu: surface composite WriteBuffer: %w", err)
+	}
+
+	rp, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		Label: "surface_composite_pass",
+		ColorAttachments: []wgpu.RenderPassColorAttachment{{
+			View:       view,
+			LoadOp:     gputypes.LoadOpLoad,
+			StoreOp:    gputypes.StoreOpStore,
+			ClearValue: gputypes.Color{R: 0, G: 0, B: 0, A: 0},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: begin surface composite pass: %w", err)
+	}
+	rp.SetViewport(0, 0, float32(w), float32(h), 0, 1)
+	rp.SetScissorRect(0, 0, w, h)
+
+	rp.SetPipeline(r.compositePipeline)
+	rp.SetBindGroup(0, r.blitUniformBindGrp, nil)
+	rp.SetBindGroup(1, texBindGrp, nil)
+	rp.Draw(6, 1, 0, 0) // 6 vertices (2 triangles) for full-screen quad
+
+	if endErr := rp.End(); endErr != nil {
+		return fmt.Errorf("gogpu: end surface composite pass: %w", endErr)
+	}
+	return nil
+}
+
+// CompositorShouldPreserve reports whether the compositor should use
+// LoadOpLoad for a surface render pass, preserving existing content.
+// True when the surface already has content from this frame (frameCleared)
+// or when an external renderer has drawn to it.
+func (ws *RenderTarget) CompositorShouldPreserve() bool {
+	return ws.frameCleared
+}
+
+// --- gpucontext.SurfaceCompositor implementation on RenderTarget ---
+
+// ShouldPreserveContent reports whether the current render pass should use
+// LoadOpLoad to preserve existing surface content.
+func (ws *RenderTarget) ShouldPreserveContent() bool {
+	return ws.externalContent
+}
+
+// DamageRects returns the damage rectangles for the current frame by
+// unioning all registered damage sources.
+func (ws *RenderTarget) DamageRects() []image.Rectangle {
+	union := unionAllSources(ws.damageSources)
+	return union
+}
+
+// MarkContentRendered signals that content has been drawn to this surface.
+func (ws *RenderTarget) MarkContentRendered() {
+	ws.frameCleared = true
+}
+
+// CompositeMSAAOverlay alpha-blends the resolved MSAA overlay onto the
+// swapchain surface using gogpu's dedicated blit pipeline.
+func (ws *RenderTarget) CompositeMSAAOverlay(encoder gpucontext.CommandEncoder, view gpucontext.TextureView, compositeView gpucontext.TextureView, w, h uint32) error {
+	if ws.renderer == nil {
+		return fmt.Errorf("gogpu: no renderer for surface composite")
+	}
+	if encoder.IsNil() || view.IsNil() || compositeView.IsNil() {
+		return fmt.Errorf("gogpu: nil handle in CompositeMSAAOverlay")
+	}
+	enc := (*wgpu.CommandEncoder)(encoder.Pointer())
+	swapView := (*wgpu.TextureView)(view.Pointer())
+	compView := (*wgpu.TextureView)(compositeView.Pointer())
+	return ws.renderer.encodeSurfaceCompositePass(enc, swapView, compView, w, h)
+}

--- a/compositor_blit_test.go
+++ b/compositor_blit_test.go
@@ -1,0 +1,59 @@
+package gogpu
+
+import (
+	"image"
+	"testing"
+
+	"github.com/gogpu/wgpu"
+)
+
+func TestCompositorBlitResources_ReleaseBinding(t *testing.T) {
+	r := &CompositorBlitResources{
+		BoundView: &wgpu.TextureView{}, // non-nil sentinel
+	}
+	// BindGroup is nil — ReleaseBinding should not panic.
+	r.ReleaseBinding()
+	if r.BoundView != nil {
+		t.Error("BoundView should be nil after ReleaseBinding")
+	}
+}
+
+func TestCompositorBlitResources_Destroy(t *testing.T) {
+	r := &CompositorBlitResources{}
+	// Calling Destroy on zero-value should not panic.
+	r.Destroy()
+}
+
+func TestApplyOverlayScissorWithDamage_ViaScissorCompute(t *testing.T) {
+	// ApplyOverlayScissorWithDamage requires a *wgpu.RenderPassEncoder
+	// (not mockable without GPU). Verify the underlying damage scissor
+	// computation that drives the overlay scissor logic.
+	x, y, w, h, valid := computeDamageScissor(nil, 800, 600, image.Rect(0, 0, 800, 600))
+	if !valid {
+		t.Error("full-surface damage should be valid")
+	}
+	if x != 0 || y != 0 || w != 800 || h != 600 {
+		t.Errorf("expected full surface scissor, got (%d, %d, %d, %d)", x, y, w, h)
+	}
+}
+
+func TestCompositorShouldPreserve(t *testing.T) {
+	tests := []struct {
+		name         string
+		frameCleared bool
+		want         bool
+	}{
+		{"no previous content", false, false},
+		{"has previous content", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &RenderTarget{
+				frameCleared: tt.frameCleared,
+			}
+			if got := ws.CompositorShouldPreserve(); got != tt.want {
+				t.Errorf("CompositorShouldPreserve() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/context.go
+++ b/context.go
@@ -147,6 +147,7 @@ func (c *Context) MarkPreserveContent() {
 		return
 	}
 	ws.frameCleared = true
+	ws.externalContent = true
 	ws.hasGPUWork = true
 }
 
@@ -250,19 +251,21 @@ func (c *Context) Renderer() *Renderer {
 	return c.renderer
 }
 
-// SurfaceView returns the current frame's surface texture view.
-// This is the GPU texture view that will be presented to the screen.
+// SurfaceView returns the current frame's render target texture view.
+// When a composition texture is active (ADR-067, debug overlays present),
+// this returns the composition view so content renders into the intermediate
+// texture. Otherwise it returns the swapchain view directly.
 // Returns nil if no frame is in progress.
 //
 // Use this with ggcanvas.RenderDirect for zero-copy GPU rendering,
-// bypassing the GPU→CPU→GPU readback path.
+// bypassing the GPU->CPU->GPU readback path.
 func (c *Context) SurfaceView() *wgpu.TextureView {
 	ws := c.activeSurface()
 	if !ws.ensureFrameStarted() {
 		return nil
 	}
 	ws.hasGPUWork = true
-	return ws.currentView
+	return ws.renderView()
 }
 
 // CommandEncoder returns the framework-owned command encoder for the active
@@ -345,16 +348,17 @@ func (r *ContextRenderTarget) CommandEncoder() gpucontext.CommandEncoder {
 // frame state to ggcanvas without introducing a dependency on gg.
 func (r *ContextRenderTarget) PreserveContent() bool {
 	ws := r.ctx.activeSurface()
-	return ws != nil && ws.frameCleared
+	return ws != nil && ws.externalContent
 }
 
-// SurfaceView returns the surface texture view as a type-safe opaque handle.
+// SurfaceView returns the render target texture view as a type-safe opaque handle.
+// When a composition texture is active (ADR-067), returns the composition view.
 func (r *ContextRenderTarget) SurfaceView() gpucontext.TextureView {
 	tv := r.ctx.SurfaceView()
 	if tv == nil {
 		return gpucontext.TextureView{}
 	}
-	return gpucontext.NewTextureView(unsafe.Pointer(tv)) //nolint:gosec // Go spec Rule 1: *T → unsafe.Pointer (ADR-018 opaque handle)
+	return gpucontext.NewTextureView(unsafe.Pointer(tv)) //nolint:gosec // Go spec Rule 1: *T -> unsafe.Pointer (ADR-018 opaque handle)
 }
 
 // SurfaceSize returns the surface dimensions.
@@ -405,6 +409,18 @@ func (r *ContextRenderTarget) RegisterDamageSource(name string) gpucontext.Damag
 // to create real GPU textures from raw pixel data.
 func (r *ContextRenderTarget) TextureCreator() gpucontext.TextureCreator {
 	return &rendererTextureCreator{renderer: r.ctx.renderer}
+}
+
+// Compositor returns the surface compositor for this render target.
+// Content renderers (gg, g3d) use this to query compositor state:
+// LoadOp decisions, damage rects, and MSAA overlay compositing.
+// Returns nil if no active surface exists.
+func (r *ContextRenderTarget) Compositor() gpucontext.SurfaceCompositor {
+	ws := r.ctx.activeSurface()
+	if ws == nil {
+		return nil
+	}
+	return ws
 }
 
 // CheckDeviceHealth returns nil if the GPU device is operational, or an error

--- a/context_preserve_content_test.go
+++ b/context_preserve_content_test.go
@@ -286,17 +286,17 @@ func TestContextRenderTarget_PreserveContent(t *testing.T) {
 		t.Error("PreserveContent() = true before external content is marked")
 	}
 
-	primary.frameCleared = true
+	primary.externalContent = true
 	if !rt.PreserveContent() {
-		t.Error("PreserveContent() = false with frameCleared=true")
+		t.Error("PreserveContent() = false with externalContent=true")
 	}
 
 	secondary := &RenderTarget{
-		renderer:     primary.renderer,
-		format:       gputypes.TextureFormatBGRA8Unorm,
-		frameCleared: true,
+		renderer:        primary.renderer,
+		format:          gputypes.TextureFormatBGRA8Unorm,
+		externalContent: true,
 	}
-	primary.frameCleared = false
+	primary.externalContent = false
 	secondaryRT := newContextForSurface(primary.renderer, secondary, 1.0).RenderTarget()
 	if !secondaryRT.PreserveContent() {
 		t.Error("PreserveContent() did not read the Context's secondary surface")

--- a/damage_overlay_test.go
+++ b/damage_overlay_test.go
@@ -307,3 +307,61 @@ func TestOverlayInstanceStride(t *testing.T) {
 		t.Errorf("overlayInstanceStride = %d, want 32", overlayInstanceStride)
 	}
 }
+
+// --- ADR-067 composition texture lifecycle tests ---
+
+func TestResetLazyState_PreservesOverlayNeedsRedraw(t *testing.T) {
+	// overlayNeedsRedraw must survive resetLazyState so the app frame loop
+	// can check it after reset and call RequestRedraw (ADR-067).
+	ws := &RenderTarget{overlayNeedsRedraw: true}
+	ws.resetLazyState()
+	if !ws.overlayNeedsRedraw {
+		t.Error("overlayNeedsRedraw was cleared by resetLazyState; should be preserved")
+	}
+}
+
+func TestRenderView_WithoutComposition(t *testing.T) {
+	// Without a composition texture, renderView returns currentView.
+	ws := &RenderTarget{}
+	// currentView is nil by default; renderView should return nil.
+	if ws.renderView() != nil {
+		t.Error("renderView() should return nil when both composView and currentView are nil")
+	}
+}
+
+func TestTryOverlayOnlyFrame_NoComposView(t *testing.T) {
+	// Without composView, overlay-only frame is not possible.
+	ws := &RenderTarget{overlayNeedsRedraw: true}
+	if ws.tryOverlayOnlyFrame() {
+		t.Error("tryOverlayOnlyFrame should return false without composView")
+	}
+}
+
+func TestTryOverlayOnlyFrame_NoRedrawNeeded(t *testing.T) {
+	// Without overlayNeedsRedraw, overlay-only frame is not needed.
+	ws := &RenderTarget{overlayNeedsRedraw: false}
+	if ws.tryOverlayOnlyFrame() {
+		t.Error("tryOverlayOnlyFrame should return false when overlayNeedsRedraw is false")
+	}
+}
+
+func TestReleaseCompositionTexture_Idempotent(t *testing.T) {
+	// Calling releaseCompositionTexture on a RenderTarget with no composition
+	// texture should be a safe no-op.
+	ws := &RenderTarget{}
+	ws.releaseCompositionTexture() // should not panic
+	if ws.composW != 0 || ws.composH != 0 {
+		t.Error("composW/composH should be 0 after release")
+	}
+}
+
+func TestHasRegisteredOverlayEnv(t *testing.T) {
+	// With no env vars set, hasRegisteredOverlayEnv returns false.
+	// Note: this test relies on sync.Once caching, so it tests the cached
+	// state which defaults to false when env vars are empty.
+	ws := &RenderTarget{}
+	// We cannot reliably test true case without env var manipulation that
+	// conflicts with sync.Once, but we can verify the method exists and
+	// returns a bool.
+	_ = ws.hasRegisteredOverlayEnv()
+}

--- a/damage_scissor.go
+++ b/damage_scissor.go
@@ -1,0 +1,50 @@
+package gogpu
+
+import "image"
+
+// computeDamageScissor computes the effective scissor rect as the intersection
+// of group clip and frame damage rect, clamped to surface bounds.
+// Returns (x, y, w, h, valid). When valid=false, the intersection is empty
+// and all fragments should be discarded.
+//
+// This is the canonical surface-level damage scissor computation used by
+// the compositor blit path (ADR-016). Content renderers (gg, g3d) produce
+// damage rects; gogpu's compositor converts them to GPU scissor rects.
+func computeDamageScissor(groupClip *[4]uint32, surfaceW, surfaceH uint32, damage image.Rectangle) (x, y, w, h uint32, valid bool) {
+	sx, sy := damage.Min.X, damage.Min.Y
+	sx2, sy2 := damage.Max.X, damage.Max.Y
+
+	if groupClip != nil {
+		gx := int(groupClip[0])
+		gy := int(groupClip[1])
+		gx2 := gx + int(groupClip[2])
+		gy2 := gy + int(groupClip[3])
+		sx = max(sx, gx)
+		sy = max(sy, gy)
+		sx2 = min(sx2, gx2)
+		sy2 = min(sy2, gy2)
+	}
+
+	sx = max(sx, 0)
+	sy = max(sy, 0)
+	sx2 = min(sx2, int(surfaceW))
+	sy2 = min(sy2, int(surfaceH))
+
+	if sx2 <= sx || sy2 <= sy {
+		return 0, 0, 0, 0, false
+	}
+	return uint32(sx), uint32(sy), uint32(sx2 - sx), uint32(sy2 - sy), true //nolint:gosec // clamped above
+}
+
+// damageRectsUnion returns the bounding box of all damage rects.
+// Returns empty rect if slice is empty.
+func damageRectsUnion(rects []image.Rectangle) image.Rectangle {
+	if len(rects) == 0 {
+		return image.Rectangle{}
+	}
+	u := rects[0]
+	for _, r := range rects[1:] {
+		u = u.Union(r)
+	}
+	return u
+}

--- a/damage_scissor_test.go
+++ b/damage_scissor_test.go
@@ -1,0 +1,148 @@
+package gogpu
+
+import (
+	"image"
+	"testing"
+)
+
+func TestComputeDamageScissor(t *testing.T) {
+	tests := []struct {
+		name      string
+		groupClip *[4]uint32
+		surfaceW  uint32
+		surfaceH  uint32
+		damage    image.Rectangle
+		wantX     uint32
+		wantY     uint32
+		wantW     uint32
+		wantH     uint32
+		wantValid bool
+	}{
+		{
+			name:      "damage only, no group clip",
+			groupClip: nil,
+			surfaceW:  800, surfaceH: 600,
+			damage: image.Rect(170, 410, 218, 458),
+			wantX:  170, wantY: 410, wantW: 48, wantH: 48,
+			wantValid: true,
+		},
+		{
+			name:      "damage intersects group clip",
+			groupClip: &[4]uint32{150, 400, 100, 100}, // x=150, y=400, w=100, h=100
+			surfaceW:  800, surfaceH: 600,
+			damage: image.Rect(170, 410, 218, 458),
+			wantX:  170, wantY: 410, wantW: 48, wantH: 48,
+			wantValid: true,
+		},
+		{
+			name:      "group clip smaller than damage",
+			groupClip: &[4]uint32{180, 420, 20, 20}, // x=180, y=420, w=20, h=20
+			surfaceW:  800, surfaceH: 600,
+			damage: image.Rect(170, 410, 218, 458),
+			wantX:  180, wantY: 420, wantW: 20, wantH: 20,
+			wantValid: true,
+		},
+		{
+			name:      "group clip outside damage — empty intersection",
+			groupClip: &[4]uint32{0, 0, 50, 50}, // top-left corner
+			surfaceW:  800, surfaceH: 600,
+			damage:    image.Rect(170, 410, 218, 458), // center-bottom
+			wantValid: false,
+		},
+		{
+			name:      "damage clamped to surface bounds",
+			groupClip: nil,
+			surfaceW:  200, surfaceH: 200,
+			damage: image.Rect(170, 180, 300, 300), // extends beyond surface
+			wantX:  170, wantY: 180, wantW: 30, wantH: 20,
+			wantValid: true,
+		},
+		{
+			name:      "damage fully outside surface — empty",
+			groupClip: nil,
+			surfaceW:  100, surfaceH: 100,
+			damage:    image.Rect(200, 200, 300, 300),
+			wantValid: false,
+		},
+		{
+			name:      "partial overlap — group clip partially in damage",
+			groupClip: &[4]uint32{160, 400, 80, 80}, // x=160..240, y=400..480
+			surfaceW:  800, surfaceH: 600,
+			damage: image.Rect(170, 410, 218, 458), // x=170..218, y=410..458
+			wantX:  170, wantY: 410, wantW: 48, wantH: 48,
+			wantValid: true,
+		},
+		{
+			name:      "full surface group clip — damage is effective scissor",
+			groupClip: &[4]uint32{0, 0, 800, 600},
+			surfaceW:  800, surfaceH: 600,
+			damage: image.Rect(100, 100, 200, 200),
+			wantX:  100, wantY: 100, wantW: 100, wantH: 100,
+			wantValid: true,
+		},
+		{
+			name:      "zero-size damage",
+			groupClip: nil,
+			surfaceW:  800, surfaceH: 600,
+			damage:    image.Rect(100, 100, 100, 100), // zero width
+			wantValid: false,
+		},
+		{
+			name:      "negative coords in damage clamped to 0",
+			groupClip: nil,
+			surfaceW:  800, surfaceH: 600,
+			damage: image.Rect(-10, -10, 50, 50),
+			wantX:  0, wantY: 0, wantW: 50, wantH: 50,
+			wantValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x, y, w, h, valid := computeDamageScissor(tt.groupClip, tt.surfaceW, tt.surfaceH, tt.damage)
+			if valid != tt.wantValid {
+				t.Fatalf("valid = %v, want %v", valid, tt.wantValid)
+			}
+			if !valid {
+				return
+			}
+			if x != tt.wantX || y != tt.wantY || w != tt.wantW || h != tt.wantH {
+				t.Errorf("scissor = (%d, %d, %d, %d), want (%d, %d, %d, %d)",
+					x, y, w, h, tt.wantX, tt.wantY, tt.wantW, tt.wantH)
+			}
+		})
+	}
+}
+
+func TestDamageRectsUnion(t *testing.T) {
+	tests := []struct {
+		name  string
+		rects []image.Rectangle
+		want  image.Rectangle
+	}{
+		{"empty", nil, image.Rectangle{}},
+		{"single", []image.Rectangle{image.Rect(10, 20, 50, 60)}, image.Rect(10, 20, 50, 60)},
+		{
+			"two_distant",
+			[]image.Rectangle{image.Rect(10, 10, 58, 58), image.Rect(500, 50, 600, 82)},
+			image.Rect(10, 10, 600, 82),
+		},
+		{
+			"three_overlapping",
+			[]image.Rectangle{
+				image.Rect(10, 10, 100, 100),
+				image.Rect(50, 50, 200, 200),
+				image.Rect(150, 150, 300, 300),
+			},
+			image.Rect(10, 10, 300, 300),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := damageRectsUnion(tt.rects)
+			if got != tt.want {
+				t.Errorf("damageRectsUnion = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/debug_fps_overlay.go
+++ b/debug_fps_overlay.go
@@ -119,8 +119,9 @@ func (o *fpsDebugOverlay) Name() string { return overlayNameFPS }
 
 // Draw renders the FPS overlay for the current frame.
 //
-// Always returns true because the FPS counter needs continuous frames to
-// maintain accurate statistics (self-sustaining render loop pattern).
+// Returns true when the visual overlay is active, requesting another frame
+// so the FPS counter stays updated (self-sustaining render loop pattern).
+// Returns false in log-only mode since no visual update is needed.
 func (o *fpsDebugOverlay) Draw(ctx gpucontext.DebugOverlayContext) bool {
 	now := time.Now()
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-webgpu/goffi v0.6.3
-	github.com/gogpu/gpucontext v0.26.0
+	github.com/gogpu/gpucontext v0.27.0
 	github.com/gogpu/gputypes v0.5.1
 	github.com/gogpu/wgpu v0.31.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gpucontext v0.26.0 h1:5s1mAa9RULjzBDw0Ej09EVqTh3q3+44BKJ/zCljVWAI=
-github.com/gogpu/gpucontext v0.26.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
+github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=
+github.com/gogpu/gpucontext v0.27.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
 github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.18.0 h1:2y83HUcAnlwEZMuHOiYTMdNYM9J8rev40gkI4zJ96Uk=

--- a/renderer.go
+++ b/renderer.go
@@ -57,6 +57,7 @@ type RenderTarget struct {
 	currentSurfaceTexture *wgpu.SurfaceTexture
 	currentView           *wgpu.TextureView
 	frameCleared          bool // Whether the frame has been cleared (for LoadOp selection)
+	externalContent       bool // External renderer (g3d) has content on surface (MarkPreserveContent)
 	// frameEncoder is borrowed by external renderers and owned by this surface.
 	// It is finished and submitted exactly once at frame end.
 	frameEncoder *wgpu.CommandEncoder
@@ -127,6 +128,33 @@ type RenderTarget struct {
 	// distinction the demand-driven loop reschedules itself forever against a
 	// UI that correctly draws nothing when nothing changed.
 	acquireFailed bool
+
+	// Compositor-owned composition texture (ADR-067).
+	// When debug overlays are active, content renderers draw into this
+	// intermediate texture instead of the swapchain image directly.
+	// gogpu composites the overlays on top, then blits the result to the
+	// swapchain. This isolates overlay rendering from content rendering,
+	// preventing bind group lifecycle conflicts.
+	// composTex is the per-frame composition surface. Content + overlay are
+	// drawn here, then blitted to swapchain. Rebuilt each frame from contentTex.
+	composTex  *wgpu.Texture
+	composView *wgpu.TextureView
+	composW    uint32
+	composH    uint32
+
+	// Note: contentTex is NOT needed. composView IS the content cache.
+	// Overlays draw on swapchain (after blit), not on composView.
+	// composView stays clean (content only) automatically.
+
+	// pendingBlitBindGroup holds the blit bind group created in blitComposToSwapchain.
+	// Released at next frame boundary (prepareLazyAcquire) after GPU completion.
+	pendingBlitBindGroup *wgpu.BindGroup
+
+	// Persistent MSAA composite bind group — recreated only when compositeView changes.
+	// Same pattern as old gg surfaceCompositeBindGroup.
+	compositeBindGroup      *wgpu.BindGroup
+	compositeBoundView      *wgpu.TextureView
+	pendingCompositeRelease *wgpu.BindGroup
 }
 
 // lockDisplay acquires the platform display lock if the window supports it.
@@ -181,6 +209,27 @@ type Renderer struct {
 	texQuadUniformBindGrp *wgpu.BindGroup
 	texQuadUniformData    []byte
 	texQuadPipelineInited bool
+
+	// Dedicated composition blit pipeline (ADR-067).
+	// This pipeline blits the composition texture to the swapchain image.
+	// It uses the SAME shader as texQuadPipeline (positionedQuadShaderSource)
+	// but has its OWN pipeline, layout, uniform buffer, and bind groups to
+	// prevent bind group lifetime conflicts with gg's render session.
+	blitPipeline       *wgpu.RenderPipeline
+	blitShader         *wgpu.ShaderModule
+	blitUniformLayout  *wgpu.BindGroupLayout
+	blitTextureLayout  *wgpu.BindGroupLayout
+	blitPipelineLayout *wgpu.PipelineLayout
+	blitSampler        *wgpu.Sampler
+	blitUniformBuf     *wgpu.Buffer
+	blitUniformBindGrp *wgpu.BindGroup
+	blitUniformData    []byte
+	blitPipelineInited bool
+
+	// compositePipeline is like blitPipeline but with premultiplied alpha blend.
+	// Used by encodeSurfaceCompositePass for MSAA overlay alpha-blending.
+	// Blit pipeline has NO blend (passthrough copy); composite pipeline blends.
+	compositePipeline *wgpu.RenderPipeline
 
 	// Texture bind group cache — device-level, shared across all windows.
 	texBindGroupCache map[*wgpu.TextureView]*wgpu.BindGroup
@@ -466,6 +515,10 @@ func (ws *RenderTarget) resize(width, height int, device *wgpu.Device, adapter *
 	ws.width = uint32(width)   //nolint:gosec // G115: validated positive above
 	ws.height = uint32(height) //nolint:gosec // G115: validated positive above
 
+	// Release stale composition texture — it will be recreated at the new
+	// size during the next frame if overlays are active.
+	ws.releaseCompositionTexture()
+
 	// Configure surface with new dimensions.
 	if err := ws.configure(device, adapter); err != nil {
 		// Restore old dimensions to keep surface consistent with swapchain.
@@ -545,6 +598,7 @@ func (ws *RenderTarget) beginFrame(platWin platform.PlatformWindow, device *wgpu
 
 	// Reset frame state for new frame
 	ws.frameCleared = false
+	ws.externalContent = false
 	ws.hasPendingClear = false
 	ws.hasGPUWork = false
 
@@ -605,8 +659,25 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 		return false
 	}
 
-	ws.flushClear(r.device, r)
+	// ADR-067: when composition texture is active, content renderers already
+	// handled the clear via their own render passes (LoadOpClear). Don't
+	// flush a pending clear here — it would wipe the rendered content.
+	// Only flush when rendering directly to swapchain (no composition texture).
+	if ws.composView == nil {
+		ws.flushClear(r.device, r)
+	} else {
+		ws.hasPendingClear = false
+	}
+
+	// ADR-067: blit cached content to swapchain FIRST, then overlays on top.
+	// composView = clean content cache (no overlay). Overlay draws on swapchain
+	// after blit → never accumulates. composView stays clean for next frame.
+	if ws.composView != nil {
+		r.blitComposToSwapchain(ws)
+	}
+
 	ws.drawDebugOverlays()
+
 	ws.submitFrameEncoder(r)
 	ws.frameNumber++
 	// Request frame callback BEFORE present (winit pre_present_notify pattern).
@@ -699,6 +770,15 @@ func (ws *RenderTarget) prepareLazyAcquire() {
 	ws.hasGPUWork = false
 	ws.pixelPresented = false
 	ws.acquireFailed = false
+	// Release blit bind group from previous frame (GPU completed by VSync).
+	if ws.pendingBlitBindGroup != nil {
+		ws.pendingBlitBindGroup.Release()
+		ws.pendingBlitBindGroup = nil
+	}
+	if ws.pendingCompositeRelease != nil {
+		ws.pendingCompositeRelease.Release()
+		ws.pendingCompositeRelease = nil
+	}
 }
 
 // ensureFrameStarted calls beginFrame on first draw call (lazy acquire pattern).
@@ -727,12 +807,27 @@ func (ws *RenderTarget) ensureFrameStarted() bool {
 }
 
 // resetLazyState clears per-frame state after frame cycle.
+// Note: overlayNeedsRedraw is NOT cleared here — it survives into the app
+// frame loop so the self-sustaining render loop (ADR-066 Chromium pattern)
+// can call RequestRedraw. It is cleared at the start of drawDebugOverlays
+// each frame.
 func (ws *RenderTarget) resetLazyState() {
 	ws.frameStarted = false
 	ws.hasGPUWork = false
 	ws.pixelPresented = false
 	ws.acquireFailed = false
-	ws.overlayNeedsRedraw = false
+}
+
+// tryOverlayOnlyFrame attempts to start an overlay-only frame when the
+// composition texture holds content from a previous frame and an overlay
+// requests another draw (ADR-067). Returns true if a frame was successfully
+// started — the caller should fall through to endFrame. Returns false if
+// no overlay-only frame is possible.
+func (ws *RenderTarget) tryOverlayOnlyFrame() bool {
+	if !ws.overlayNeedsRedraw || ws.composView == nil {
+		return false
+	}
+	return ws.ensureFrameStarted()
 }
 
 // ensureFrameEncoder returns the framework-owned encoder for this surface
@@ -773,6 +868,12 @@ func (ws *RenderTarget) submitFrameEncoder(r *Renderer) {
 // method with the current frame's GPU context. Called after all content
 // renderers have finished and before submitFrameEncoder/present.
 //
+// When overlays are present and a composition texture exists, overlays draw
+// onto the composition texture (which already contains the content). The
+// caller then blits the composition texture to the swapchain. When no
+// composition texture is available (no overlays registered before draw),
+// overlays draw directly onto the swapchain as before.
+//
 // Overlays use the shared frame encoder and surface view to record render
 // passes with LoadOp::Load (compositing on top of content). When any overlay
 // returns true (needs another frame), overlayNeedsRedraw is set so the caller
@@ -800,11 +901,15 @@ func (ws *RenderTarget) drawDebugOverlays() {
 		return
 	}
 
+	// ADR-067: overlays ALWAYS draw on swapchain (currentView), AFTER
+	// blitComposToSwapchain copies cached content. composView stays clean
+	// (content-only cache). Overlay never accumulates on composView.
+	overlayView := ws.currentView
 	ctx := gpucontext.DebugOverlayContext{
 		SurfaceWidth:  ws.width,
 		SurfaceHeight: ws.height,
-		Encoder:       gpucontext.NewCommandEncoder(unsafe.Pointer(encoder)),     //nolint:gosec // Go spec Rule 1: *T -> unsafe.Pointer
-		SurfaceView:   gpucontext.NewTextureView(unsafe.Pointer(ws.currentView)), //nolint:gosec // Go spec Rule 1: *T -> unsafe.Pointer
+		Encoder:       gpucontext.NewCommandEncoder(unsafe.Pointer(encoder)),  //nolint:gosec // Go spec Rule 1: *T -> unsafe.Pointer
+		SurfaceView:   gpucontext.NewTextureView(unsafe.Pointer(overlayView)), //nolint:gosec // Go spec Rule 1: *T -> unsafe.Pointer
 		FrameNumber:   ws.frameNumber,
 	}
 
@@ -834,6 +939,372 @@ func (ws *RenderTarget) releaseFrame() {
 	}
 	// SurfaceTexture is consumed by Present, no need to destroy it
 	ws.currentSurfaceTexture = nil
+}
+
+// renderView returns the view that content renderers should target.
+// When a composition texture is active (ADR-067), content goes to
+// the intermediate texture; otherwise directly to the swapchain.
+func (ws *RenderTarget) renderView() *wgpu.TextureView {
+	// ADR-067: ensure composition texture exists before returning the view.
+	// Content renderers call SurfaceView() → renderView() at frame start,
+	// BEFORE drawDebugOverlays. Without this, composView is nil and content
+	// renders directly to swapchain, then blitComposToSwapchain overwrites it.
+	ws.ensureCompositionTexture()
+	if ws.composView != nil {
+		return ws.composView
+	}
+	return ws.currentView
+}
+
+// ensureCompositionTexture creates the intermediate composition texture
+// lazily when debug overlays are present. The texture matches the surface
+// dimensions and format. It uses RenderAttachment (content draws into it)
+// and TextureBinding (blit samples from it).
+func (ws *RenderTarget) ensureCompositionTexture() {
+	if ws.renderer == nil || ws.renderer.device == nil {
+		return
+	}
+	if ws.currentView == nil {
+		return
+	}
+	// Only create when debug overlays are registered or env vars indicate
+	// they will be. Without overlays, render directly to swapchain (zero overhead).
+	if len(ws.debugOverlays) == 0 && !ws.hasRegisteredOverlayEnv() {
+		return
+	}
+
+	// Already sized correctly.
+	if ws.composView != nil && ws.composW == ws.width && ws.composH == ws.height {
+		return
+	}
+
+	// Release stale texture.
+	ws.releaseCompositionTexture()
+
+	tex, err := ws.renderer.device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "CompositionTexture",
+		Size:          wgpu.Extent3D{Width: ws.width, Height: ws.height, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        ws.format,
+		Usage:         wgpu.TextureUsageRenderAttachment | wgpu.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		slog.Error("gogpu: create composition texture failed", "err", err)
+		return
+	}
+
+	view, err := ws.renderer.device.CreateTextureView(tex, nil)
+	if err != nil {
+		tex.Release()
+		slog.Error("gogpu: create composition texture view failed", "err", err)
+		return
+	}
+
+	ws.composTex = tex
+	ws.composView = view
+	ws.composW = ws.width
+	ws.composH = ws.height
+}
+
+// releaseCompositionTexture frees the intermediate composition texture.
+func (ws *RenderTarget) releaseCompositionTexture() {
+	if ws.composView != nil {
+		ws.composView.Release()
+		ws.composView = nil
+	}
+	if ws.composTex != nil {
+		ws.composTex.Release()
+		ws.composTex = nil
+	}
+	ws.composW = 0
+	ws.composH = 0
+}
+
+// hasRegisteredOverlayEnv checks if any debug overlay env vars are set,
+// indicating overlays will be registered during drawDebugOverlays. This
+// enables ensureCompositionTexture to be called proactively before overlays
+// self-register, so content renders into the composition texture from the
+// start of the frame.
+func (ws *RenderTarget) hasRegisteredOverlayEnv() bool {
+	mode := getDamageDebugMode()
+	if mode.overlay || mode.log {
+		return true
+	}
+	fpsMode := getFPSDebugMode()
+	return fpsMode.overlay || fpsMode.log
+}
+
+// initBlitPipeline creates the dedicated GPU pipeline for blitting the
+// composition texture to the swapchain. This pipeline uses the same shader
+// as texQuadPipeline (positionedQuadShaderSource) but has completely
+// independent resources to prevent bind group lifetime conflicts.
+//
+//nolint:funlen // pipeline init is inherently sequential setup code
+func (r *Renderer) initBlitPipeline() error {
+	if r.blitPipelineInited {
+		return nil
+	}
+
+	var err error
+
+	r.blitShader, err = r.device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "Composition Blit Shader",
+		WGSL:  positionedQuadShaderSource,
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: blit shader: %w", err)
+	}
+
+	// Bind group 0: uniforms (rect, screen, alpha, premultiplied).
+	r.blitUniformLayout, err = r.device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "Blit Uniform Layout",
+		Entries: []gputypes.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: gputypes.ShaderStageVertex | gputypes.ShaderStageFragment,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeUniform,
+					MinBindingSize: texQuadUniformSize,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: blit uniform layout: %w", err)
+	}
+
+	// Bind group 1: sampler + texture.
+	r.blitTextureLayout, err = r.device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "Blit Texture Layout",
+		Entries: []gputypes.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: gputypes.ShaderStageFragment,
+				Sampler: &gputypes.SamplerBindingLayout{
+					Type: gputypes.SamplerBindingTypeFiltering,
+				},
+			},
+			{
+				Binding:    1,
+				Visibility: gputypes.ShaderStageFragment,
+				Texture: &gputypes.TextureBindingLayout{
+					SampleType:    gputypes.TextureSampleTypeFloat,
+					ViewDimension: gputypes.TextureViewDimension2D,
+					Multisampled:  false,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: blit texture layout: %w", err)
+	}
+
+	r.blitPipelineLayout, err = r.device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		Label:            "Blit Pipeline Layout",
+		BindGroupLayouts: []*wgpu.BindGroupLayout{r.blitUniformLayout, r.blitTextureLayout},
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: blit pipeline layout: %w", err)
+	}
+
+	// No blending needed: composition texture is the final image;
+	// copy it 1:1 to the swapchain.
+	r.blitPipeline, err = r.device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label:  "Composition Blit Pipeline",
+		Layout: r.blitPipelineLayout,
+		Vertex: wgpu.VertexState{
+			Module:     r.blitShader,
+			EntryPoint: shaderEntryVS,
+		},
+		Primitive: gputypes.PrimitiveState{
+			Topology: gputypes.PrimitiveTopologyTriangleList,
+			CullMode: gputypes.CullModeNone,
+		},
+		Fragment: &wgpu.FragmentState{
+			Module:     r.blitShader,
+			EntryPoint: shaderEntryFS,
+			Targets: []gputypes.ColorTargetState{
+				{
+					Format:    r.surfaceFormat,
+					WriteMask: gputypes.ColorWriteMaskAll,
+					// No blending: composition texture is the final composited
+					// image — copy 1:1 to swapchain (passthrough). Content was
+					// already alpha-blended during Stage 1 (gg blit into composView).
+					// MSAA composite uses encodeSurfaceCompositePass which must
+					// use its own pipeline with premultiplied alpha blend.
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: blit pipeline: %w", err)
+	}
+
+	r.blitSampler, err = r.device.CreateSampler(&wgpu.SamplerDescriptor{
+		Label:        "Blit Sampler",
+		MagFilter:    gputypes.FilterModeNearest,
+		MinFilter:    gputypes.FilterModeNearest,
+		MipmapFilter: gputypes.FilterModeNearest,
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: blit sampler: %w", err)
+	}
+
+	r.blitUniformBuf, err = r.device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "Blit Uniforms",
+		Size:  texQuadUniformSize,
+		Usage: gputypes.BufferUsageUniform | gputypes.BufferUsageCopyDst,
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: blit uniform buffer: %w", err)
+	}
+
+	r.blitUniformBindGrp, err = r.device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "Blit Uniform Bind Group",
+		Layout: r.blitUniformLayout,
+		Entries: []wgpu.BindGroupEntry{
+			{
+				Binding: 0,
+				Buffer:  r.blitUniformBuf,
+				Size:    texQuadUniformSize,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: blit uniform bind group: %w", err)
+	}
+
+	r.blitUniformData = make([]byte, texQuadUniformSize)
+
+	// Composite pipeline — same as blit but WITH premultiplied alpha blend.
+	// Used by encodeSurfaceCompositePass for MSAA overlay alpha-compositing.
+	r.compositePipeline, err = r.device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label:  "MSAA Composite Pipeline",
+		Layout: r.blitPipelineLayout,
+		Vertex: wgpu.VertexState{
+			Module:     r.blitShader,
+			EntryPoint: shaderEntryVS,
+		},
+		Primitive: gputypes.PrimitiveState{
+			Topology: gputypes.PrimitiveTopologyTriangleList,
+			CullMode: gputypes.CullModeNone,
+		},
+		Fragment: &wgpu.FragmentState{
+			Module:     r.blitShader,
+			EntryPoint: shaderEntryFS,
+			Targets: []gputypes.ColorTargetState{
+				{
+					Format:    r.surfaceFormat,
+					WriteMask: gputypes.ColorWriteMaskAll,
+					Blend: &gputypes.BlendState{
+						Color: gputypes.BlendComponent{
+							Operation: gputypes.BlendOperationAdd,
+							SrcFactor: gputypes.BlendFactorOne,
+							DstFactor: gputypes.BlendFactorOneMinusSrcAlpha,
+						},
+						Alpha: gputypes.BlendComponent{
+							Operation: gputypes.BlendOperationAdd,
+							SrcFactor: gputypes.BlendFactorOne,
+							DstFactor: gputypes.BlendFactorOneMinusSrcAlpha,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: composite pipeline: %w", err)
+	}
+
+	r.blitPipelineInited = true
+	return nil
+}
+
+// blitComposToSwapchain draws a full-screen quad sampling the composition
+// texture onto the swapchain image. Uses the dedicated blit pipeline (NOT
+// the shared texQuadPipeline) to avoid bind group lifetime conflicts with
+// gg's render session. See ADR-067.
+func (r *Renderer) blitComposToSwapchain(ws *RenderTarget) {
+	if ws.composView == nil || ws.currentView == nil {
+		return
+	}
+	if !r.blitPipelineInited {
+		if err := r.initBlitPipeline(); err != nil {
+			slog.Error("gogpu: blit pipeline init failed", "err", err)
+			return
+		}
+	}
+
+	encoder, err := ws.ensureFrameEncoder()
+	if err != nil {
+		slog.Error("gogpu: blit encoder unavailable", "err", err)
+		return
+	}
+
+	// Create per-frame bind group for the composition texture view.
+	texBindGrp, err := r.device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "Blit Texture Bind Group",
+		Layout: r.blitTextureLayout,
+		Entries: []wgpu.BindGroupEntry{
+			{
+				Binding: 0,
+				Sampler: r.blitSampler,
+			},
+			{
+				Binding:     1,
+				TextureView: ws.composView,
+			},
+		},
+	})
+	if err != nil {
+		slog.Error("gogpu: create blit texture bind group failed", "err", err)
+		return
+	}
+	// Bind group is consumed by the shared frame encoder — do NOT defer
+	// Release() here. The encoder is submitted in submitFrameEncoder AFTER
+	// this function returns. Track for release at next frame boundary
+	// (BeginFrame), where VSync guarantees GPU completion.
+	ws.pendingBlitBindGroup = texBindGrp
+
+	// Upload full-screen quad uniforms: rect = (0,0,width,height), alpha = 1.
+	binary.LittleEndian.PutUint32(r.blitUniformData[0:4], math.Float32bits(0))                    // x
+	binary.LittleEndian.PutUint32(r.blitUniformData[4:8], math.Float32bits(0))                    // y
+	binary.LittleEndian.PutUint32(r.blitUniformData[8:12], math.Float32bits(float32(ws.width)))   // width
+	binary.LittleEndian.PutUint32(r.blitUniformData[12:16], math.Float32bits(float32(ws.height))) // height
+	binary.LittleEndian.PutUint32(r.blitUniformData[16:20], math.Float32bits(float32(ws.width)))  // screenWidth
+	binary.LittleEndian.PutUint32(r.blitUniformData[20:24], math.Float32bits(float32(ws.height))) // screenHeight
+	binary.LittleEndian.PutUint32(r.blitUniformData[24:28], math.Float32bits(1.0))                // alpha
+	binary.LittleEndian.PutUint32(r.blitUniformData[28:32], math.Float32bits(1.0))                // premultiplied
+	if err := r.device.Queue().WriteBuffer(r.blitUniformBuf, 0, r.blitUniformData); err != nil {
+		slog.Error("gogpu: blit WriteBuffer uniform failed", "err", err)
+		return
+	}
+
+	renderPass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		ColorAttachments: []wgpu.RenderPassColorAttachment{
+			{
+				View:       ws.currentView,
+				LoadOp:     gputypes.LoadOpClear,
+				StoreOp:    gputypes.StoreOpStore,
+				ClearValue: gputypes.Color{R: 0, G: 0, B: 0, A: 0},
+			},
+		},
+	})
+	if err != nil {
+		slog.Error("gogpu: blit BeginRenderPass failed", "err", err)
+		return
+	}
+
+	renderPass.SetPipeline(r.blitPipeline)
+	renderPass.SetBindGroup(0, r.blitUniformBindGrp, nil)
+	renderPass.SetBindGroup(1, texBindGrp, nil)
+	renderPass.Draw(6, 1, 0, 0) // 6 vertices (2 triangles) for full-screen quad
+
+	if err := renderPass.End(); err != nil {
+		slog.Error("gogpu: blit EndRenderPass failed", "err", err)
+	}
 }
 
 // Clear defers a clear command to be applied at the start of the next render pass.
@@ -875,7 +1346,7 @@ func (ws *RenderTarget) flushClear(device *wgpu.Device, r *Renderer) bool {
 	renderPass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
 		ColorAttachments: []wgpu.RenderPassColorAttachment{
 			{
-				View:       ws.currentView,
+				View:       ws.renderView(),
 				LoadOp:     gputypes.LoadOpClear,
 				StoreOp:    gputypes.StoreOpStore,
 				ClearValue: ws.pendingClearColor,
@@ -1023,7 +1494,7 @@ func (r *Renderer) DrawTriangle(clearR, clearG, clearB, clearA float64) error {
 	renderPass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
 		ColorAttachments: []wgpu.RenderPassColorAttachment{
 			{
-				View:       ws.currentView,
+				View:       ws.renderView(),
 				LoadOp:     gputypes.LoadOpClear,
 				StoreOp:    gputypes.StoreOpStore,
 				ClearValue: gputypes.Color{R: clearR, G: clearG, B: clearB, A: clearA},
@@ -1313,7 +1784,7 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 	renderPass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
 		ColorAttachments: []wgpu.RenderPassColorAttachment{
 			{
-				View:       ws.currentView,
+				View:       ws.renderView(),
 				LoadOp:     loadOp,
 				StoreOp:    gputypes.StoreOpStore,
 				ClearValue: clearValue,
@@ -1575,6 +2046,8 @@ func (r *Renderer) Destroy() {
 		delete(r.texBindGroupCache, view)
 	}
 
+	r.destroyBlitPipeline()
+
 	// Release textured quad pipeline resources (reverse order)
 	if r.texQuadUniformBindGrp != nil {
 		r.texQuadUniformBindGrp.Release()
@@ -1642,9 +2115,51 @@ func (r *Renderer) ReleaseInstance() {
 	}
 }
 
+// destroyBlitPipeline releases the dedicated composition blit pipeline
+// resources. Extracted from Destroy to keep cyclomatic complexity bounded.
+func (r *Renderer) destroyBlitPipeline() {
+	if r.blitUniformBindGrp != nil {
+		r.blitUniformBindGrp.Release()
+		r.blitUniformBindGrp = nil
+	}
+	if r.blitUniformBuf != nil {
+		r.blitUniformBuf.Release()
+		r.blitUniformBuf = nil
+	}
+	if r.blitSampler != nil {
+		r.blitSampler.Release()
+		r.blitSampler = nil
+	}
+	if r.blitPipelineLayout != nil {
+		r.blitPipelineLayout.Release()
+		r.blitPipelineLayout = nil
+	}
+	if r.blitTextureLayout != nil {
+		r.blitTextureLayout.Release()
+		r.blitTextureLayout = nil
+	}
+	if r.blitUniformLayout != nil {
+		r.blitUniformLayout.Release()
+		r.blitUniformLayout = nil
+	}
+	if r.blitShader != nil {
+		r.blitShader.Release()
+		r.blitShader = nil
+	}
+	if r.blitPipeline != nil {
+		r.blitPipeline.Release()
+		r.blitPipeline = nil
+	}
+	if r.compositePipeline != nil {
+		r.compositePipeline.Release()
+		r.compositePipeline = nil
+	}
+}
+
 // destroy releases all resources owned by this window surface.
 func (ws *RenderTarget) destroy() {
 	ws.discardFrameEncoder()
+	ws.releaseCompositionTexture()
 	if ws.currentView != nil {
 		ws.currentView.Release()
 		ws.currentView = nil


### PR DESCRIPTION
## Summary

Compositor-owned render target (ADR-067) — fundamental architecture redesign.

- Compositor (gogpu) owns composition texture; drawing library (gg) renders into provided view
- Two pipelines: `blitPipeline` (passthrough) + `compositePipeline` (MSAA alpha blend)
- Overlay draws on swapchain after blit — never accumulates, fade works on idle content
- SurfaceCompositor implementation + damage scissor + compositor blit resources
- 20+ tests for overlay lifecycle, damage scissor, compositor resources
- deps: gpucontext v0.26.0 → v0.27.0

## Test plan

- [x] Build + test + lint clean (GOWORK=off)
- [x] Cross-platform build (linux, darwin)
- [x] Visual: gg-only 60fps, g3d+gg 60fps, g3d+ui, ui gallery, overlay fade, transparent 4 backends
