### PR TITLE
feat(wayland): add one-shot presentation sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **One-shot presentation synchronization** — `Context.RequestPresentationSync()` gates rendering after the next successfully presented frame without enabling continuous compositor pacing. Wayland supports forced `wl_surface.frame` callbacks for GPU and software presentation, including secondary windows; failed presentations cancel and retain the request for retry.
+
 ### Fixed
 
 - **macOS: `SetMenu` leaf items invisible on menu bar** (#449) — `applyMenu` added bare `NSMenuItems` to the main menu bar; macOS only renders items with submenus. Role-based leaf items (About, Quit, Preferences) are now routed to the App Menu submenu automatically. Non-role leaf items log a warning.

--- a/app.go
+++ b/app.go
@@ -1315,8 +1315,33 @@ func (a *App) Quit() {
 // On all other platforms, this always returns true.
 func (a *App) frameCallbackReady() bool {
 	if fg, ok := a.platWindow.(platform.FrameGater); ok {
-		return fg.FrameCallbackReady()
+		if !fg.FrameCallbackReady() {
+			return false
+		}
 	}
+
+	// Preserve the single-window fast path. Secondary windows are scanned only
+	// after one of them has actually prepared compositor frame gating.
+	if a.renderer == nil || !a.renderer.secondaryFrameGatePending.Load() {
+		return true
+	}
+	if a.windowManager == nil {
+		a.renderer.secondaryFrameGatePending.Store(false)
+		return true
+	}
+
+	a.windowManager.mu.RLock()
+	defer a.windowManager.mu.RUnlock()
+	for _, id := range a.windowManager.order {
+		w := a.windowManager.windows[id]
+		if w == nil || !w.visible || w.platWindow == nil {
+			continue
+		}
+		if fg, ok := w.platWindow.(platform.FrameGater); ok && !fg.FrameCallbackReady() {
+			return false
+		}
+	}
+	a.renderer.secondaryFrameGatePending.Store(false)
 	return true
 }
 

--- a/app_run_coverage_test.go
+++ b/app_run_coverage_test.go
@@ -240,6 +240,88 @@ func TestApp_FrameCallbackReady_FrameGater(t *testing.T) {
 	}
 }
 
+func TestApp_FrameCallbackReady_SecondaryFrameGater(t *testing.T) {
+	primaryPlatform := &mockFrameGaterWindow{ready: true}
+	secondaryPlatform := &mockFrameGaterWindow{ready: false}
+	renderer := &Renderer{primary: &RenderTarget{}}
+	renderer.secondaryFrameGatePending.Store(true)
+	manager := newWindowManager()
+	manager.add(&Window{id: 1, platWindow: primaryPlatform, visible: true})
+	manager.add(&Window{id: 2, platWindow: secondaryPlatform, visible: true})
+	app := &App{
+		platWindow:    primaryPlatform,
+		renderer:      renderer,
+		windowManager: manager,
+	}
+
+	if app.frameCallbackReady() {
+		t.Fatal("frameCallbackReady ignored a pending secondary callback")
+	}
+	if !renderer.secondaryFrameGatePending.Load() {
+		t.Fatal("secondary gate marker was cleared while a callback was pending")
+	}
+
+	secondaryPlatform.ready = true
+	if !app.frameCallbackReady() {
+		t.Fatal("frameCallbackReady remained closed after all callbacks completed")
+	}
+	if renderer.secondaryFrameGatePending.Load() {
+		t.Fatal("secondary gate marker remained set after all callbacks completed")
+	}
+}
+
+func TestApp_FrameCallbackReady_SecondaryFastPath(t *testing.T) {
+	primaryPlatform := &mockFrameGaterWindow{ready: true}
+	secondaryPlatform := &mockFrameGaterWindow{ready: false}
+	renderer := &Renderer{primary: &RenderTarget{}}
+	manager := newWindowManager()
+	manager.add(&Window{id: 1, platWindow: primaryPlatform, visible: true})
+	manager.add(&Window{id: 2, platWindow: secondaryPlatform, visible: true})
+	app := &App{
+		platWindow:    primaryPlatform,
+		renderer:      renderer,
+		windowManager: manager,
+	}
+
+	if !app.frameCallbackReady() {
+		t.Fatal("inactive secondary gate affected the normal rendering path")
+	}
+}
+
+func TestApp_FrameCallbackReady_ClearsOrphanedSecondaryGate(t *testing.T) {
+	renderer := &Renderer{}
+	renderer.secondaryFrameGatePending.Store(true)
+	app := &App{renderer: renderer}
+
+	if !app.frameCallbackReady() {
+		t.Fatal("orphaned secondary gate blocked rendering")
+	}
+	if renderer.secondaryFrameGatePending.Load() {
+		t.Fatal("orphaned secondary gate marker was not cleared")
+	}
+}
+
+func TestApp_FrameCallbackReady_SkipsWindowsWithoutPendingGates(t *testing.T) {
+	renderer := &Renderer{}
+	renderer.secondaryFrameGatePending.Store(true)
+	manager := newWindowManager()
+	manager.order = []WindowID{1, 2, 3, 4}
+	manager.windows[2] = &Window{id: 2, platWindow: &mockFrameGaterWindow{ready: false}}
+	manager.windows[3] = &Window{id: 3, visible: true}
+	manager.windows[4] = &Window{id: 4, platWindow: &mockWindow{}, visible: true}
+	app := &App{
+		renderer:      renderer,
+		windowManager: manager,
+	}
+
+	if !app.frameCallbackReady() {
+		t.Fatal("window without an active frame gate blocked rendering")
+	}
+	if renderer.secondaryFrameGatePending.Load() {
+		t.Fatal("inactive secondary gate marker was not cleared")
+	}
+}
+
 // =============================================================================
 // SetAppName
 // =============================================================================

--- a/context.go
+++ b/context.go
@@ -57,6 +57,20 @@ func (c *Context) activeSurface() *RenderTarget {
 	return c.renderer.primary
 }
 
+// RequestPresentationSync asks the platform compositor to acknowledge the next
+// successfully presented frame before another frame is rendered. It is useful
+// for infrequent visual state transitions in applications that otherwise
+// render without compositor pacing. Repeated calls before that presentation
+// are idempotent.
+//
+// Call this during OnDraw, before the frame is presented. This method neither
+// requests a redraw nor forces an otherwise empty OnDraw to present; the request
+// remains pending until a later frame is presented. Platforms that already
+// synchronize every frame need no additional work.
+func (c *Context) RequestPresentationSync() {
+	c.activeSurface().presentationSyncRequested = true
+}
+
 // RegisterDamageSource registers a named damage source with the compositor.
 // Each independent renderer (gg, g3d, video, compose) registers once at init
 // and reports per-frame damage through the returned DamageReporter.
@@ -374,7 +388,14 @@ func (r *ContextRenderTarget) WriteSurfacePixels(data []byte, width, height uint
 	if ws == nil || ws.surface == nil {
 		return fmt.Errorf("gogpu: no active surface")
 	}
+	syncAttempt, syncedBeforePresent := syncFrameBeforePixelPresent(ws)
+	lockDisplay(ws.platWindow)
 	err := ws.surface.PresentPixels(data, width, height, compositor.UnionAllSources(ws.damageSources))
+	unlockDisplay(ws.platWindow)
+	finishPresentationSync(ws, syncAttempt, err == nil)
+	if err == nil && !syncedBeforePresent {
+		syncFrameAfterPixelPresent(ws)
+	}
 	for _, ds := range ws.damageSources {
 		ds.Reset()
 	}

--- a/context_presentation_sync_test.go
+++ b/context_presentation_sync_test.go
@@ -1,0 +1,369 @@
+package gogpu
+
+import (
+	"testing"
+
+	"github.com/gogpu/gogpu/internal/compositor"
+	"github.com/gogpu/gogpu/internal/platform"
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+	_ "github.com/gogpu/wgpu/hal/software"
+)
+
+type countingFrameWindow struct {
+	mockWindow
+	regularSyncs int
+}
+
+func (w *countingFrameWindow) SyncFrame() { w.regularSyncs++ }
+
+type countingPresentationWindow struct {
+	countingFrameWindow
+	prepareCalls []bool
+	prepareOK    bool
+	cancelCalls  int
+}
+
+func (w *countingPresentationWindow) PrepareFrameSync(force bool) bool {
+	w.prepareCalls = append(w.prepareCalls, force)
+	return w.prepareOK
+}
+
+func (w *countingPresentationWindow) CancelFrameSync() { w.cancelCalls++ }
+
+type steadyStatePresentationWindow struct{ mockWindow }
+
+func (w *steadyStatePresentationWindow) PrepareFrameSync(bool) bool { return false }
+func (w *steadyStatePresentationWindow) CancelFrameSync()           {}
+
+func newPixelPresentationTestContext(
+	t *testing.T,
+	window platform.PlatformWindow,
+) (*Context, *RenderTarget) {
+	t.Helper()
+	instance, err := wgpu.CreateInstance(nil)
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+	surface, err := instance.CreateSurfaceFromTarget(wgpu.HeadlessSurfaceTarget{})
+	if err != nil {
+		instance.Release()
+		t.Fatalf("CreateSurfaceFromTarget: %v", err)
+	}
+	adapter, err := instance.RequestAdapter(&wgpu.RequestAdapterOptions{
+		CompatibleSurface:    surface,
+		ForceFallbackAdapter: true,
+	})
+	if err != nil {
+		surface.Release()
+		instance.Release()
+		t.Fatalf("RequestAdapter: %v", err)
+	}
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		adapter.Release()
+		surface.Release()
+		instance.Release()
+		t.Fatalf("RequestDevice: %v", err)
+	}
+	if err := surface.Configure(device, &wgpu.SurfaceConfiguration{
+		Width:       1,
+		Height:      1,
+		Format:      gputypes.TextureFormatRGBA8Unorm,
+		Usage:       gputypes.TextureUsageRenderAttachment,
+		PresentMode: gputypes.PresentModeFifo,
+		AlphaMode:   gputypes.CompositeAlphaModeOpaque,
+	}); err != nil {
+		adapter.Release()
+		surface.Release()
+		device.Release()
+		instance.Release()
+		t.Fatalf("Configure: %v", err)
+	}
+	renderer := &Renderer{device: device}
+	target := &RenderTarget{
+		renderer:   renderer,
+		platWindow: window,
+		surface:    surface,
+		width:      1,
+		height:     1,
+		state:      SurfaceConfigured,
+	}
+	renderer.primary = target
+	t.Cleanup(func() {
+		surface.Unconfigure()
+		device.Release()
+		surface.Release()
+		adapter.Release()
+		instance.Release()
+	})
+	return newContext(renderer, 1), target
+}
+
+func TestContextRequestPresentationSyncTargetsActiveSurface(t *testing.T) {
+	primary := &RenderTarget{}
+	secondary := &RenderTarget{}
+	renderer := &Renderer{primary: primary}
+
+	primaryContext := newContext(renderer, 1)
+	primaryContext.RequestPresentationSync()
+	primaryContext.RequestPresentationSync()
+	if !primary.presentationSyncRequested {
+		t.Fatal("primary surface did not retain presentation sync request")
+	}
+	if secondary.presentationSyncRequested {
+		t.Fatal("secondary surface unexpectedly retained presentation sync request")
+	}
+
+	newContextForSurface(renderer, secondary, 1).RequestPresentationSync()
+	if !secondary.presentationSyncRequested {
+		t.Fatal("target surface did not retain presentation sync request")
+	}
+}
+
+func TestPresentationSyncRequestSurvivesEmptyFrame(t *testing.T) {
+	target := newTestWindowSurface()
+	newContext(target.renderer, 1).RequestPresentationSync()
+
+	target.prepareLazyAcquire()
+	target.resetLazyState()
+
+	if !target.presentationSyncRequested {
+		t.Fatal("empty frame consumed the presentation sync request")
+	}
+}
+
+func TestPresentationSyncUsesOneShotPlatformPath(t *testing.T) {
+	window := &countingPresentationWindow{prepareOK: true}
+	target := &RenderTarget{
+		platWindow:                window,
+		presentationSyncRequested: true,
+	}
+
+	attempt := syncFrameForPresent(target)
+
+	if len(window.prepareCalls) != 1 || !window.prepareCalls[0] || window.regularSyncs != 0 {
+		t.Fatalf("sync calls = regular %d, prepare %v; want 0, [true]", window.regularSyncs, window.prepareCalls)
+	}
+	if target.presentationSyncRequested {
+		t.Fatal("consumed presentation sync request remained pending")
+	}
+	if !attempt.consumedRequest || !attempt.cancelable {
+		t.Fatalf("sync attempt = %+v, want consumed and cancelable", attempt)
+	}
+}
+
+func TestPresentationSyncUsesNormalFramePolicyWithoutRequest(t *testing.T) {
+	window := &countingPresentationWindow{prepareOK: true}
+	target := &RenderTarget{platWindow: window}
+
+	attempt := syncFrameForPresent(target)
+
+	if len(window.prepareCalls) != 1 || window.prepareCalls[0] || window.regularSyncs != 0 {
+		t.Fatalf("sync calls = regular %d, prepare %v; want 0, [false]", window.regularSyncs, window.prepareCalls)
+	}
+	if attempt.consumedRequest || !attempt.cancelable {
+		t.Fatalf("sync attempt = %+v, want normal cancelable preparation", attempt)
+	}
+}
+
+func TestPresentationSyncFallsBackToNormalPlatformSync(t *testing.T) {
+	window := &countingFrameWindow{}
+	target := &RenderTarget{
+		platWindow:                window,
+		presentationSyncRequested: true,
+	}
+
+	attempt := syncFrameForPresent(target)
+
+	if window.regularSyncs != 1 {
+		t.Fatalf("regular sync calls = %d, want 1", window.regularSyncs)
+	}
+	if target.presentationSyncRequested {
+		t.Fatal("fallback presentation sync request remained pending")
+	}
+	if !attempt.consumedRequest || attempt.cancelable {
+		t.Fatalf("sync attempt = %+v, want consumed fallback", attempt)
+	}
+}
+
+func TestPresentationSyncRetainsRequestWhenPreparationFails(t *testing.T) {
+	window := &countingPresentationWindow{}
+	target := &RenderTarget{
+		platWindow:                window,
+		presentationSyncRequested: true,
+	}
+
+	attempt := syncFrameForPresent(target)
+
+	if len(window.prepareCalls) != 1 || !window.prepareCalls[0] {
+		t.Fatalf("prepare calls = %v, want [true]", window.prepareCalls)
+	}
+	if !target.presentationSyncRequested {
+		t.Fatal("failed preparation consumed the presentation sync request")
+	}
+	if attempt != (presentationSyncAttempt{}) {
+		t.Fatalf("sync attempt = %+v after failed preparation, want zero", attempt)
+	}
+}
+
+func TestPresentationSyncPresentationFailureCancelsAndRestoresRequest(t *testing.T) {
+	window := &countingPresentationWindow{prepareOK: true}
+	target := &RenderTarget{
+		platWindow:                window,
+		presentationSyncRequested: true,
+	}
+
+	attempt := syncFrameForPresent(target)
+	finishPresentationSync(target, attempt, false)
+
+	if window.cancelCalls != 1 {
+		t.Fatalf("cancel calls = %d, want 1", window.cancelCalls)
+	}
+	if !target.presentationSyncRequested {
+		t.Fatal("failed presentation did not restore the one-shot request")
+	}
+}
+
+func TestNormalPresentationFailureCancelsPreparedFramePolicy(t *testing.T) {
+	window := &countingPresentationWindow{prepareOK: true}
+	target := &RenderTarget{platWindow: window}
+
+	attempt := syncFrameForPresent(target)
+	finishPresentationSync(target, attempt, false)
+
+	if window.cancelCalls != 1 {
+		t.Fatalf("cancel calls = %d, want 1", window.cancelCalls)
+	}
+	if target.presentationSyncRequested {
+		t.Fatal("normal frame policy created a one-shot request")
+	}
+}
+
+func TestPresentationSyncSuccessfulPresentationConsumesRequest(t *testing.T) {
+	window := &countingPresentationWindow{prepareOK: true}
+	target := &RenderTarget{
+		platWindow:                window,
+		presentationSyncRequested: true,
+	}
+
+	attempt := syncFrameForPresent(target)
+	finishPresentationSync(target, attempt, true)
+
+	if window.cancelCalls != 0 {
+		t.Fatalf("cancel calls = %d, want 0", window.cancelCalls)
+	}
+	if target.presentationSyncRequested {
+		t.Fatal("successful presentation restored a consumed request")
+	}
+}
+
+func TestWriteSurfacePixelsUsesPrePresentSync(t *testing.T) {
+	window := &countingPresentationWindow{prepareOK: true}
+	ctx, target := newPixelPresentationTestContext(t, window)
+	damage := compositor.NewDamageSource("test", 0)
+	damage.ReportDamage()
+	target.damageSources = []*compositor.DamageSource{damage}
+	texture, err := target.renderer.device.CreateTexture(&wgpu.TextureDescriptor{
+		Size:          wgpu.Extent3D{Width: 1, Height: 1, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     gputypes.TextureDimension2D,
+		Format:        gputypes.TextureFormatRGBA8Unorm,
+		Usage:         gputypes.TextureUsageRenderAttachment,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	t.Cleanup(texture.Release)
+	target.currentView, err = target.renderer.device.CreateTextureView(texture, nil)
+	if err != nil {
+		t.Fatalf("CreateTextureView: %v", err)
+	}
+	ctx.RequestPresentationSync()
+
+	if err := ctx.RenderTarget().WriteSurfacePixels([]byte{1, 2, 3, 4}, 1, 1); err != nil {
+		t.Fatalf("WriteSurfacePixels: %v", err)
+	}
+	if len(window.prepareCalls) != 1 || !window.prepareCalls[0] {
+		t.Fatalf("prepare calls = %v, want [true]", window.prepareCalls)
+	}
+	if target.presentationSyncRequested {
+		t.Fatal("successful pixel presentation retained the request")
+	}
+	if !target.pixelPresented {
+		t.Fatal("successful direct presentation did not update frame lifecycle")
+	}
+	if target.currentView != nil {
+		t.Fatal("successful direct presentation retained the stale surface view")
+	}
+	if damage.Full || len(damage.Rects) != 0 {
+		t.Fatal("successful direct presentation retained reported damage")
+	}
+}
+
+func TestWriteSurfacePixelsRequiresActiveSurface(t *testing.T) {
+	ctx := newContext(&Renderer{}, 1)
+	if err := ctx.RenderTarget().WriteSurfacePixels(nil, 1, 1); err == nil {
+		t.Fatal("WriteSurfacePixels succeeded without an active surface")
+	}
+}
+
+func TestWriteSurfacePixelsFailureCancelsAndRestoresSync(t *testing.T) {
+	window := &countingPresentationWindow{prepareOK: true}
+	ctx, target := newPixelPresentationTestContext(t, window)
+	ctx.RequestPresentationSync()
+
+	if err := ctx.RenderTarget().WriteSurfacePixels(nil, 1, 1); err == nil {
+		t.Fatal("WriteSurfacePixels succeeded with an undersized pixel buffer")
+	}
+	if window.cancelCalls != 1 {
+		t.Fatalf("cancel calls = %d, want 1", window.cancelCalls)
+	}
+	if !target.presentationSyncRequested {
+		t.Fatal("failed pixel presentation did not restore the sync request")
+	}
+	if target.pixelPresented {
+		t.Fatal("failed direct presentation updated frame lifecycle")
+	}
+}
+
+func TestWriteSurfacePixelsUsesPostPresentFallback(t *testing.T) {
+	window := &countingFrameWindow{}
+	ctx, target := newPixelPresentationTestContext(t, window)
+	ctx.RequestPresentationSync()
+
+	if err := ctx.RenderTarget().WriteSurfacePixels([]byte{1, 2, 3, 4}, 1, 1); err != nil {
+		t.Fatalf("WriteSurfacePixels: %v", err)
+	}
+	if window.regularSyncs != 1 {
+		t.Fatalf("regular sync calls = %d, want 1", window.regularSyncs)
+	}
+	if target.presentationSyncRequested {
+		t.Fatal("successful fallback pixel presentation retained the request")
+	}
+}
+
+func TestPresentationSyncMarksSecondaryFrameGate(t *testing.T) {
+	window := &countingPresentationWindow{prepareOK: true}
+	renderer := &Renderer{}
+	primary := &RenderTarget{renderer: renderer}
+	secondary := &RenderTarget{renderer: renderer, platWindow: window}
+	renderer.primary = primary
+
+	syncFrameForPresent(secondary)
+
+	if !renderer.secondaryFrameGatePending.Load() {
+		t.Fatal("secondary compositor callback did not mark the application gate")
+	}
+}
+
+func BenchmarkPresentationSyncSteadyState(b *testing.B) {
+	window := &steadyStatePresentationWindow{}
+	target := &RenderTarget{platWindow: window}
+	b.ReportAllocs()
+
+	for b.Loop() {
+		syncFrameForPresent(target)
+	}
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -365,6 +365,23 @@ type FrameGater interface {
 	FrameCallbackReady() bool
 }
 
+// PresentationSyncer is an optional transactional interface for platforms
+// whose compositor synchronization must be prepared before presentation.
+// It lets the renderer force synchronization for one frame independently of
+// the platform's normal frame-pacing policy and cancel the preparation if
+// presentation fails.
+type PresentationSyncer interface {
+	// PrepareFrameSync prepares compositor synchronization for the next
+	// presentation. When force is false, the platform's normal pacing policy
+	// applies. It returns true only when a synchronization request was prepared
+	// by this call and can therefore be canceled.
+	PrepareFrameSync(force bool) bool
+
+	// CancelFrameSync cancels the synchronization request most recently
+	// prepared by PrepareFrameSync.
+	CancelFrameSync()
+}
+
 type MenuRole int
 
 const (

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -827,12 +827,30 @@ func (w *waylandPlatformWindow) CursorMode() int {
 }
 
 // SyncFrame on Wayland requests the next frame callback from the compositor.
-// Called after present on the render thread. The frame callback gates the
+// Called before present on the render thread. The frame callback gates the
 // next render: FrameCallbackReady() returns false until the compositor fires
 // the done event (FRAME-001 / BUG-WL-006, winit pattern).
 func (w *waylandPlatformWindow) SyncFrame() {
-	if libwl := w.libwayland(); libwl != nil && wayland.FrameCallbackEnabled() {
-		libwl.RequestFrameCallback()
+	w.PrepareFrameSync(false)
+}
+
+// PrepareFrameSync requests compositor acknowledgement before the next surface
+// commit. A forced request bypasses GOGPU_WAYLAND_FRAME_CALLBACK=0 for one
+// presentation. The bool reports whether this call created a callback that can
+// be canceled if presentation fails.
+func (w *waylandPlatformWindow) PrepareFrameSync(force bool) bool {
+	if !force && !wayland.FrameCallbackEnabled() {
+		return false
+	}
+	libwl := w.libwayland()
+	return libwl != nil && libwl.RequestFrameCallback()
+}
+
+// CancelFrameSync rolls back a callback prepared for a presentation that did
+// not commit successfully.
+func (w *waylandPlatformWindow) CancelFrameSync() {
+	if libwl := w.libwayland(); libwl != nil {
+		libwl.CancelFrameCallback()
 	}
 }
 
@@ -910,9 +928,12 @@ func (w *waylandPlatformWindow) DisplayUnlock() {
 // event (FRAME-001 / BUG-WL-006, winit 3-state pattern).
 func (w *waylandPlatformWindow) FrameCallbackReady() bool {
 	libwl := w.libwayland()
-	if libwl == nil || !wayland.FrameCallbackEnabled() {
-		return true // Not initialized or gating disabled
+	if libwl == nil {
+		return true
 	}
+	// Usually no callback exists when continuous gating is disabled, so the
+	// state is ready. A one-shot presentation sync must still gate while its
+	// callback is pending.
 	return libwl.FrameCallbackReady()
 }
 

--- a/internal/platform/wayland/libwayland.go
+++ b/internal/platform/wayland/libwayland.go
@@ -107,6 +107,9 @@ type LibwaylandHandle struct {
 	// Prevents render loop from outrunning the compositor's presentation rate.
 	// 0=None, 1=Requested, 2=Received. Atomic — no mutex needed for reads.
 	frameCallbackState int32
+	// frameCallbackProxy is the in-flight wl_callback, or zero. It lets a
+	// failed presentation cancel a request that was prepared before commit.
+	frameCallbackProxy atomic.Uintptr
 	// frameCallbackReady is set to true when the compositor fires done.
 	// Consumed by ConsumeFrameCallbackReady to trigger RequestRedraw.
 	frameCallbackReady atomic.Bool
@@ -384,6 +387,8 @@ func (h *LibwaylandHandle) Close() {
 	if h == nil {
 		return
 	}
+
+	h.CancelFrameCallback()
 
 	// Remove from per-proxy callback maps before destroying proxies.
 	h.UnregisterXdgProxies()

--- a/internal/platform/wayland/libwayland_frame.go
+++ b/internal/platform/wayland/libwayland_frame.go
@@ -113,6 +113,7 @@ func frameCallbackDoneCb(data, callback, callbackData uintptr) {
 	if h == nil {
 		return
 	}
+	h.frameCallbackProxy.Store(0)
 
 	slog.Debug("wl_surface.frame done", "callback_data", uint32(callbackData))
 
@@ -128,18 +129,19 @@ func frameCallbackDoneCb(data, callback, callbackData uintptr) {
 }
 
 // RequestFrameCallback sends a wl_surface.frame request to the compositor.
-// Idempotent: if state is already Requested, this is a no-op.
+// It returns true only when this call created a new callback. If state is
+// already Requested, it is an idempotent no-op and returns false.
 //
-// Must be called from the render thread (after present) or main thread.
+// Must be called from the render thread (before present) or main thread.
 // The C libwayland calls require displayMu, which is acquired internally.
 //
 // Follows the winit pattern (state.rs:273-282): only send frame() if
 // current state is None or Received (never double-request).
-func (h *LibwaylandHandle) RequestFrameCallback() {
+func (h *LibwaylandHandle) RequestFrameCallback() bool {
 	// Fast path: already requested — no-op (idempotent, winit pattern).
 	state := atomic.LoadInt32(&h.frameCallbackState)
 	if state == FrameCallbackRequested {
-		return
+		return false
 	}
 
 	initFrameCallbackIface()
@@ -150,7 +152,7 @@ func (h *LibwaylandHandle) RequestFrameCallback() {
 	// Double-check under lock (another thread may have raced).
 	state = atomic.LoadInt32(&h.frameCallbackState)
 	if state == FrameCallbackRequested {
-		return
+		return false
 	}
 
 	// wl_surface.frame (opcode 3) creates a new wl_callback.
@@ -158,7 +160,7 @@ func (h *LibwaylandHandle) RequestFrameCallback() {
 	callback, err := h.marshalConstructor(h.surface, 3, unsafe.Pointer(&frameCallbackIface.iface))
 	if err != nil {
 		slog.Warn("wayland: wl_surface.frame failed", "err", err)
-		return
+		return false
 	}
 
 	// Register callback → handle mapping for the done handler.
@@ -174,8 +176,9 @@ func (h *LibwaylandHandle) RequestFrameCallback() {
 		delete(frameCallbackHandles, callback)
 		frameCallbackHandlesMu.Unlock()
 		h.proxyDestroy(callback)
-		return
+		return false
 	}
+	h.frameCallbackProxy.Store(callback)
 
 	// wl_surface.frame is double-buffered (Wayland spec: "The frame request
 	// will take effect on the next wl_surface.commit"). RequestFrameCallback
@@ -196,6 +199,38 @@ func (h *LibwaylandHandle) RequestFrameCallback() {
 	runtime.KeepAlive(&frameCallbackIface.listener)
 
 	slog.Debug("wl_surface.frame requested")
+	return true
+}
+
+// CancelFrameCallback cancels an in-flight callback prepared for a surface
+// commit that failed. The display lock excludes the done callback, which runs
+// during dispatch while the same lock is held.
+func (h *LibwaylandHandle) CancelFrameCallback() {
+	if h == nil {
+		return
+	}
+	h.displayMu.Lock()
+	defer h.displayMu.Unlock()
+
+	if callback := h.detachFrameCallback(); callback != 0 {
+		h.proxyDestroy(callback)
+	}
+}
+
+// detachFrameCallback removes the current callback from Go-side routing and
+// resets the frame gate. The caller must hold displayMu and destroy the returned
+// proxy, if non-zero. Kept separate from the FFI destroy for state-machine tests.
+func (h *LibwaylandHandle) detachFrameCallback() uintptr {
+	callback := h.frameCallbackProxy.Swap(0)
+	if callback == 0 {
+		return 0
+	}
+	frameCallbackHandlesMu.Lock()
+	delete(frameCallbackHandles, callback)
+	frameCallbackHandlesMu.Unlock()
+	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackNone)
+	h.frameCallbackReady.Store(false)
+	return callback
 }
 
 // FrameCallbackReady reports whether the render loop may submit a frame.

--- a/internal/platform/wayland/libwayland_frame_test.go
+++ b/internal/platform/wayland/libwayland_frame_test.go
@@ -149,6 +149,15 @@ func TestFrameCallbackReadyStateTransitions(t *testing.T) {
 	}
 }
 
+func TestRequestFrameCallbackAlreadyPendingIsNotPrepared(t *testing.T) {
+	h := &LibwaylandHandle{}
+	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackRequested)
+
+	if h.RequestFrameCallback() {
+		t.Fatal("already-pending callback was reported as newly prepared")
+	}
+}
+
 // TestFrameCallbackDoneCbRouting verifies that the done callback correctly
 // routes to the LibwaylandHandle via the per-proxy map.
 func TestFrameCallbackDoneCbRouting(t *testing.T) {
@@ -178,6 +187,40 @@ func TestFrameCallbackDoneCbRouting(t *testing.T) {
 	frameCallbackHandlesMu.Lock()
 	delete(frameCallbackHandles, fakeProxy)
 	frameCallbackHandlesMu.Unlock()
+}
+
+func TestDetachFrameCallbackResetsGateAndRouting(t *testing.T) {
+	h := &LibwaylandHandle{}
+	fakeProxy := uintptr(0xCAFE_BABE)
+	h.frameCallbackProxy.Store(fakeProxy)
+	atomic.StoreInt32(&h.frameCallbackState, FrameCallbackRequested)
+	h.frameCallbackReady.Store(true)
+	frameCallbackHandlesMu.Lock()
+	frameCallbackHandles[fakeProxy] = h
+	frameCallbackHandlesMu.Unlock()
+
+	if got := h.detachFrameCallback(); got != fakeProxy {
+		t.Fatalf("detached proxy = %#x, want %#x", got, fakeProxy)
+	}
+	if got := h.frameCallbackProxy.Load(); got != 0 {
+		t.Fatalf("current callback proxy = %#x, want 0", got)
+	}
+	if got := atomic.LoadInt32(&h.frameCallbackState); got != FrameCallbackNone {
+		t.Fatalf("frame callback state = %d, want None", got)
+	}
+	if h.frameCallbackReady.Load() {
+		t.Fatal("canceled frame callback retained its ready signal")
+	}
+	frameCallbackHandlesMu.Lock()
+	_, routed := frameCallbackHandles[fakeProxy]
+	frameCallbackHandlesMu.Unlock()
+	if routed {
+		t.Fatal("canceled frame callback remained in the routing table")
+	}
+
+	if got := h.detachFrameCallback(); got != 0 {
+		t.Fatalf("second detach returned %#x, want 0", got)
+	}
 }
 
 // TestFrameCallbackGateNotTrigger documents the gate-not-trigger contract

--- a/renderer.go
+++ b/renderer.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/gogpu/gogpu/gpu/backend/native"
@@ -82,6 +83,11 @@ type RenderTarget struct {
 	// transparent requests CompositeAlphaModePremultiplied for this surface
 	// when the adapter advertises support (ADR-060, gogpu#361).
 	transparent bool
+
+	// presentationSyncRequested asks the platform to gate the frame following
+	// the next successful present until the compositor acknowledges it. It is
+	// retained across empty or failed frames.
+	presentationSyncRequested bool
 
 	// damageSources holds all registered damage reporters for this surface.
 	// Each independent renderer (gg, g3d, video, compose) registers one source
@@ -236,6 +242,11 @@ type Renderer struct {
 	// currentSurface is the RenderTarget being drawn in the current frame.
 	// Set by the multi-window frame loop before each window's draw callback.
 	currentSurface *RenderTarget
+
+	// secondaryFrameGatePending avoids scanning the window list in the common
+	// single-window path. It is set only when a secondary platform window
+	// actually prepares compositor frame gating.
+	secondaryFrameGatePending atomic.Bool
 }
 
 // newRenderer creates and initializes a new renderer.
@@ -640,9 +651,6 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 		ws.discardFrameEncoder()
 		ws.pixelPresented = false
 		ws.hasPendingClear = false
-		if ws.platWindow != nil {
-			ws.platWindow.SyncFrame()
-		}
 		ws.releaseFrame()
 		return false
 	}
@@ -671,12 +679,88 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	// Request frame callback BEFORE present (winit pre_present_notify pattern).
 	// Wayland spec: "The frame request will take effect on the next commit."
 	// The present's internal wl_surface.commit activates it atomically.
-	if ws.platWindow != nil {
-		ws.platWindow.SyncFrame()
-	}
-	reconfigured := ws.present()
+	syncAttempt := syncFrameForPresent(ws)
+	reconfigured, presented := ws.present()
+	finishPresentationSync(ws, syncAttempt, presented)
 	ws.releaseFrame()
 	return reconfigured
+}
+
+type presentationSyncAttempt struct {
+	consumedRequest bool
+	cancelable      bool
+}
+
+// syncFrameForPresent applies the platform's normal frame policy, unless the
+// surface has a pending one-shot request. Platforms with pre-present semantics
+// report whether they actually prepared a cancelable synchronization request.
+func syncFrameForPresent(ws *RenderTarget) presentationSyncAttempt {
+	if ws == nil || ws.platWindow == nil {
+		return presentationSyncAttempt{}
+	}
+	force := ws.presentationSyncRequested
+	if syncer, ok := ws.platWindow.(platform.PresentationSyncer); ok {
+		prepared := syncer.PrepareFrameSync(force)
+		if prepared {
+			markSecondaryFrameGatePending(ws)
+		}
+		if force && !prepared {
+			// A failed preparation must not consume the request. This also covers
+			// an unexpected already-pending callback; the frame gate normally
+			// prevents rendering in that state.
+			return presentationSyncAttempt{}
+		}
+		ws.presentationSyncRequested = false
+		return presentationSyncAttempt{consumedRequest: force, cancelable: prepared}
+	}
+
+	ws.platWindow.SyncFrame()
+	if force {
+		ws.presentationSyncRequested = false
+	}
+	return presentationSyncAttempt{consumedRequest: force}
+}
+
+// syncFrameBeforePixelPresent prepares frame synchronization only on platforms
+// that require it before the surface commit (Wayland). Other platforms retain
+// their existing post-present SyncFrame timing.
+func syncFrameBeforePixelPresent(ws *RenderTarget) (presentationSyncAttempt, bool) {
+	if ws == nil || ws.platWindow == nil {
+		return presentationSyncAttempt{}, false
+	}
+	if _, ok := ws.platWindow.(platform.PresentationSyncer); !ok {
+		return presentationSyncAttempt{}, false
+	}
+	return syncFrameForPresent(ws), true
+}
+
+func syncFrameAfterPixelPresent(ws *RenderTarget) {
+	if ws == nil || ws.platWindow == nil {
+		return
+	}
+	ws.platWindow.SyncFrame()
+	ws.presentationSyncRequested = false
+}
+
+func finishPresentationSync(ws *RenderTarget, attempt presentationSyncAttempt, presented bool) {
+	if ws == nil || presented {
+		return
+	}
+	if attempt.cancelable {
+		if syncer, ok := ws.platWindow.(platform.PresentationSyncer); ok {
+			syncer.CancelFrameSync()
+		}
+	}
+	if attempt.consumedRequest {
+		ws.presentationSyncRequested = true
+	}
+}
+
+func markSecondaryFrameGatePending(ws *RenderTarget) {
+	if ws == nil || ws.renderer == nil || ws == ws.renderer.primary {
+		return
+	}
+	ws.renderer.secondaryFrameGatePending.Store(true)
 }
 
 // pollSubmissions performs non-blocking submission tracking: frees GPU resources
@@ -697,10 +781,11 @@ func (r *Renderer) pollSubmissions() {
 // wl_display_flush during vkQueuePresentKHR. The display lock serializes this with
 // the main thread's DispatchDefaultQueue (ADR-041 Phase 2).
 //
-// Returns true if the surface was outdated and reconfigured — caller re-renders.
-func (ws *RenderTarget) present() (reconfigured bool) {
+// Returns whether the surface was outdated and reconfigured and whether the
+// submitted frame was successfully presented.
+func (ws *RenderTarget) present() (reconfigured, presented bool) {
 	if ws.currentSurfaceTexture == nil {
-		return false
+		return false, false
 	}
 	finalDamage := compositor.UnionAllSources(ws.damageSources)
 	lockDisplay(ws.platWindow)
@@ -710,7 +795,7 @@ func (ws *RenderTarget) present() (reconfigured bool) {
 		ds.Reset()
 	}
 	if err == nil {
-		return false
+		return false, true
 	}
 	// Mirror recoverFromAcquireError: outdated is expected (resize/DPI/monitor),
 	// not an error — reconfigure and signal the caller to re-render.
@@ -720,19 +805,19 @@ func (ws *RenderTarget) present() (reconfigured bool) {
 			if cfgErr := ws.configure(ws.renderer.device, ws.renderer.adapter); cfgErr != nil {
 				slog.Error("gogpu: reconfigure after outdated failed", "err", cfgErr)
 				ws.state = SurfaceLost
-				return false
+				return false, false
 			}
-			return true
+			return true, false
 		}
-		return false
+		return false, false
 	}
 	if errors.Is(err, wgpu.ErrSurfaceLost) {
 		slog.Error("gogpu: surface lost on present", "err", err)
 		ws.state = SurfaceLost
-		return false
+		return false, false
 	}
 	slog.Error("PRESENT ERROR", "err", err)
-	return false
+	return false, false
 }
 
 // setTransactionPresent toggles Core Animation transaction-based present on


### PR DESCRIPTION
## Summary

- add Context.RequestPresentationSync for infrequent compositor-paced frames
- let Wayland force one wl_surface.frame callback independently of continuous frame gating
- retain requests across empty or failed frames and roll back prepared callbacks when presentation fails
- cover both swapchain and direct software-pixel presentation paths
- gate callbacks from secondary windows without adding a window-list scan to the normal single-window path
- keep normal uncapped presentation immediately after the acknowledged frame

## Motivation

Continuous-rendering applications may disable global Wayland frame callbacks to preserve uncapped rendering. Some visual state transitions still need temporary compositor pacing. In a downstream game client, replacing an empty UI root with a character-selection UI could leave the new window invisible with callbacks disabled. Enabling callbacks fixed the transition but permanently capped rendering at the compositor refresh rate.

This API lets a caller synchronize only transition frames. The downstream integration requests one synchronized present per transition frame until the republished UI is included, then stops requesting them.

## Implementation

RequestPresentationSync latches an idempotent flag on the Context's active RenderTarget. The request survives an empty draw and is consumed by the next successful presentation.

The renderer uses an optional transactional PresentationSyncer before presentation. Wayland can prepare a callback even when GOGPU_WAYLAND_FRAME_CALLBACK=0; if swapchain or software presentation fails, the callback is canceled and a forced request is retained for retry. Other platforms keep their existing SyncFrame behavior.

Secondary callbacks set a renderer-level atomic marker. The app scans visible windows only while that marker is active, keeping the ordinary single-window path free of window-manager locking.

## Validation

- CGO_ENABLED=0 go test ./...
- go test -race ./...
- go vet ./...
- Linux, Windows/amd64, and macOS/arm64 builds
- presentation/frame-callback tests repeated 100 times
- steady-state sync microbenchmark: approximately 2.8-3.1 ns/op, 0 allocations
- visually verified with a v0.44.6 backport on Wayland: the UI transition is reliable and steady-state FPS remains uncapped

Local staticcheck reports only four pre-existing U1000 findings on main, unrelated to this change.
