### PR TITLE
feat: add native desktop print backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Built on [gogpu/wgpu](https://github.com/gogpu/wgpu) — the unified Go WebGPU p
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal), Browser/WASM (WebGPU) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), 0% CPU when idle (lazy acquire), zero-copy surface rendering, damage-aware presentation |
 | **Input Models** | Three coexisting models: callbacks (`EventSource`), state polling (`Input()`, Ebiten-style), SDL-style event queue (`PollInputEvent()`) |
-| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, runtime window resize (`RequestSize`), mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), OS drag-and-drop: incoming (all 4 desktop platforms) + outgoing drag source (`StartDrag`, all 5 platforms), GPU adapter power preference, native macOS window tabbing, native system menus (macOS + Windows), native file dialogs (macOS + Windows + Linux D-Bus/zenity/kdialog) |
+| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, runtime window resize (`RequestSize`), mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), OS drag-and-drop: incoming (all 4 desktop platforms) + outgoing drag source (`StartDrag`, all 5 platforms), GPU adapter power preference, native macOS window tabbing, native system menus (macOS + Windows), native file dialogs (macOS + Windows + Linux D-Bus/zenity/kdialog), additive native print contract (backend-neutral; implementations staged separately) |
 | **Scroll** | ScrollPhase + IsMomentum for macOS trackpad momentum detection (ADR-032), pixel/line/page delta modes |
 | **Sound** | 12 UI sound types (UWP ElementSoundPlayer parity): Click, Invoke, Focus, Navigate, Show/Hide, feedback. winmm, NSSound, canberra |
 | **Compute** | Full compute shader support |
@@ -309,6 +309,27 @@ if app.ReduceMotion() { /* disable animations */ }
 if app.HighContrast() { /* increase contrast */ }
 fontMul := app.FontScale() // user's font size preference
 ```
+
+### Native printing contract
+
+Applications provide complete PDF/document bytes and can submit them to the
+future native print backends without coupling UI code to an operating system:
+
+```go
+job, err := app.Print(ctx, gogpu.NewPDFDocument("report.pdf", pdfBytes), gogpu.PrintOptions{})
+if err != nil {
+	// Invalid input or this platform has no print backend yet.
+	return err
+}
+if err := <-job.Done(); err != nil {
+	// context.Canceled means cancellation; other errors are native/spool errors.
+	return err
+}
+```
+
+See [docs/PRINTING.md](docs/PRINTING.md) for parent-window, ownership, and
+lifecycle semantics. This contract does not generate documents or claim native
+backend support yet.
 
 ### macOS System Menu
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Built on [gogpu/wgpu](https://github.com/gogpu/wgpu) — the unified Go WebGPU p
 | **Platforms** | Windows (Vulkan/DX12/GLES), Linux X11/Wayland (Vulkan/GLES), macOS (Metal), Browser/WASM (WebGPU) |
 | **Rendering** | Event-driven three-state model (idle/animating/continuous), 0% CPU when idle (lazy acquire), zero-copy surface rendering, damage-aware presentation |
 | **Input Models** | Three coexisting models: callbacks (`EventSource`), state polling (`Input()`, Ebiten-style), SDL-style event queue (`PollInputEvent()`) |
-| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, runtime window resize (`RequestSize`), mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), OS drag-and-drop: incoming (all 4 desktop platforms) + outgoing drag source (`StartDrag`, all 5 platforms), GPU adapter power preference, native macOS window tabbing, native system menus (macOS + Windows), native file dialogs (macOS + Windows + Linux D-Bus/zenity/kdialog), additive native print contract (backend-neutral; implementations staged separately) |
+| **Graphics** | Windowing, input handling, multi-keyboard layout (X11 XKB + Wayland xkbcommon), AltGr/international text input (unified xkbcommon, ADR-029), key repeat on all platforms (Wayland client-side timer, ADR-033), texture loading, frameless windows, runtime window resize (`RequestSize`), mouse grab / pointer lock (Win32 + X11 + Wayland, SDL parity), OS drag-and-drop: incoming (all 4 desktop platforms) + outgoing drag source (`StartDrag`, all 5 platforms), GPU adapter power preference, native macOS window tabbing, native system menus (macOS + Windows), native file dialogs (macOS + Windows + Linux D-Bus/zenity/kdialog), native print contract and desktop backends (Windows/macOS/Linux portal) |
 | **Scroll** | ScrollPhase + IsMomentum for macOS trackpad momentum detection (ADR-032), pixel/line/page delta modes |
 | **Sound** | 12 UI sound types (UWP ElementSoundPlayer parity): Click, Invoke, Focus, Navigate, Show/Hide, feedback. winmm, NSSound, canberra |
 | **Compute** | Full compute shader support |
@@ -313,12 +313,12 @@ fontMul := app.FontScale() // user's font size preference
 ### Native printing contract
 
 Applications provide complete PDF/document bytes and can submit them to the
-future native print backends without coupling UI code to an operating system:
+desktop native print backends without coupling UI code to an operating system:
 
 ```go
 job, err := app.Print(ctx, gogpu.NewPDFDocument("report.pdf", pdfBytes), gogpu.PrintOptions{})
 if err != nil {
-	// Invalid input or this platform has no print backend yet.
+	// Invalid input, unavailable native services, or an unsupported platform.
 	return err
 }
 if err := <-job.Done(); err != nil {
@@ -328,8 +328,9 @@ if err := <-job.Done(); err != nil {
 ```
 
 See [docs/PRINTING.md](docs/PRINTING.md) for parent-window, ownership, and
-lifecycle semantics. This contract does not generate documents or claim native
-backend support yet.
+lifecycle semantics. The desktop backends accept PDF input through Windows
+PrintDlgEx/GDI, macOS PDFKit/AppKit, and the Linux xdg-desktop-portal; browser
+printing remains unsupported.
 
 ### macOS System Menu
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -721,6 +721,7 @@ inherit the logger configuration when registered.
 | **GPU Backends** | Vulkan, DX12, GLES, Software | Metal, Software | Vulkan, GLES, Software | Vulkan, GLES | WebGPU |
 | **Input** | Keyboard, mouse, pointer lock | Keyboard, mouse | Keyboard, mouse, pointer lock | Keyboard, mouse, pointer lock, CSD | Planned |
 | **File Dialogs** | ✅ IFileOpenDialog COM | ✅ NSOpenPanel/NSSavePanel | ✅ D-Bus portal + zenity/kdialog | ✅ D-Bus portal + zenity/kdialog | Stub |
+| **Native Printing** | Contract only | Contract only | Contract only | Contract only | Unsupported |
 | **Native Menus** | ✅ Win32 HMENU | ✅ NSMenu | ✅ D-Bus AppMenu (KDE/Unity) | ✅ D-Bus AppMenu (KDE/Unity) | — |
 | **Clipboard** | ✅ | ✅ | ✅ ICCCM | ✅ wl_data_device | ✅ Clipboard API |
 | **Drag & Drop (in)** | ✅ WM_DROPFILES | ✅ NSDragging | ✅ XDND v5 | ✅ wl_data_device | — |
@@ -730,5 +731,6 @@ inherit the logger configuration when registered.
 ## See Also
 
 - [README.md](../README.md) — Quick start guide
+- [PRINTING.md](PRINTING.md) — Native printing contract and lifecycle semantics
 - [CHANGELOG.md](../CHANGELOG.md) — Version history
 - [Examples](../examples/) — Code examples

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -721,7 +721,7 @@ inherit the logger configuration when registered.
 | **GPU Backends** | Vulkan, DX12, GLES, Software | Metal, Software | Vulkan, GLES, Software | Vulkan, GLES | WebGPU |
 | **Input** | Keyboard, mouse, pointer lock | Keyboard, mouse | Keyboard, mouse, pointer lock | Keyboard, mouse, pointer lock, CSD | Planned |
 | **File Dialogs** | ✅ IFileOpenDialog COM | ✅ NSOpenPanel/NSSavePanel | ✅ D-Bus portal + zenity/kdialog | ✅ D-Bus portal + zenity/kdialog | Stub |
-| **Native Printing** | Contract only | Contract only | Contract only | Contract only | Unsupported |
+| **Native Printing** | ✅ PrintDlgEx/GDI | ✅ PDFKit/AppKit | ✅ xdg-desktop-portal | ✅ xdg-desktop-portal | Unsupported |
 | **Native Menus** | ✅ Win32 HMENU | ✅ NSMenu | ✅ D-Bus AppMenu (KDE/Unity) | ✅ D-Bus AppMenu (KDE/Unity) | — |
 | **Clipboard** | ✅ | ✅ | ✅ ICCCM | ✅ wl_data_device | ✅ Clipboard API |
 | **Drag & Drop (in)** | ✅ WM_DROPFILES | ✅ NSDragging | ✅ XDND v5 | ✅ wl_data_device | — |

--- a/docs/PRINTING.md
+++ b/docs/PRINTING.md
@@ -37,12 +37,11 @@ if err := <-job.Done(); err != nil {
 - Passing a canceled context, or calling `PrintJob.Cancel`, requests
   cancellation. A canceled job reports `context.Canceled`; cancellation is
   idempotent and has no effect after completion.
-- Validation, unsupported platforms, and setup failures are returned by
-  `App.Print` and do not create a job. Native dialog/spool failures are
+- Validation and unavailable print services are returned by `App.Print` and do
+  not create a job (`ErrPrintUnsupported`); native dialog/spool failures are
   reported through `Done`.
 
 The platform capability is the optional `internal/platform.PrintManager`
-interface. Existing backends intentionally do not implement it yet; native
-Windows, macOS, and Linux portal work can be added independently without
-changing this contract. Browser remains unsupported until it has a matching
-print API.
+interface. Windows uses the native PrintDlgEx/GDI path, macOS uses PDFKit and
+AppKit, and Linux X11/Wayland use xdg-desktop-portal. Browser remains
+unsupported until it has a matching print API.

--- a/docs/PRINTING.md
+++ b/docs/PRINTING.md
@@ -1,0 +1,48 @@
+# Native printing contract
+
+`App.Print` is the backend-neutral seam for native print dialogs and spoolers.
+It accepts a complete document; gogpu does not render pages or generate PDF
+bytes. `NewPDFDocument` is the portable helper for the common PDF case.
+Platform implementations own format-specific rendering/spooling (for example,
+Windows may render PDF before submitting a printer job).
+
+```go
+document := gogpu.NewPDFDocument("invoice.pdf", pdfBytes)
+job, err := app.Print(ctx, document, gogpu.PrintOptions{
+	Title:      "Print invoice",
+	PageRanges: []gogpu.PrintPageRange{{From: 1, To: 2}},
+	Copies:     1,
+})
+if err != nil {
+	// Request was not accepted (invalid input or no native backend).
+	return err
+}
+if err := <-job.Done(); err != nil {
+	// context.Canceled means the user/caller canceled; another error is a
+	// native dialog or spool failure.
+	return err
+}
+```
+
+## Ownership and lifecycle
+
+- `PrintDocument` contains the final bytes and MIME type. `App.Print` copies
+  bytes and page ranges before invoking the asynchronous backend; callers may
+  reuse their input after `Print` returns.
+- `PrintOptions.Parent` identifies the owning `WindowID`. Zero selects the
+  primary window when available, otherwise the application parent. A native
+  implementation must keep that relationship until the job reaches `Done`.
+- The request is accepted synchronously, but the dialog/spool operation is
+  asynchronous. `Done` receives exactly one terminal error and then closes.
+- Passing a canceled context, or calling `PrintJob.Cancel`, requests
+  cancellation. A canceled job reports `context.Canceled`; cancellation is
+  idempotent and has no effect after completion.
+- Validation, unsupported platforms, and setup failures are returned by
+  `App.Print` and do not create a job. Native dialog/spool failures are
+  reported through `Done`.
+
+The platform capability is the optional `internal/platform.PrintManager`
+interface. Existing backends intentionally do not implement it yet; native
+Windows, macOS, and Linux portal work can be added independently without
+changing this contract. Browser remains unsupported until it has a matching
+print API.

--- a/docs/PRINTING.md
+++ b/docs/PRINTING.md
@@ -3,8 +3,10 @@
 `App.Print` is the backend-neutral seam for native print dialogs and spoolers.
 It accepts a complete document; gogpu does not render pages or generate PDF
 bytes. `NewPDFDocument` is the portable helper for the common PDF case.
-Platform implementations own format-specific rendering/spooling (for example,
-Windows may render PDF before submitting a printer job).
+Windows sends raw PDF bytes through the GDI `PASSTHROUGH` escape and does not
+render them. Only compatible PostScript/PCL or virtual PDF printer drivers that
+accept the raw document format can print it; typical consumer inkjet drivers
+may fail.
 
 ```go
 document := gogpu.NewPDFDocument("invoice.pdf", pdfBytes)

--- a/internal/platform/darwin/mainthread.go
+++ b/internal/platform/darwin/mainthread.go
@@ -1,0 +1,142 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/go-webgpu/goffi/ffi"
+)
+
+// ErrMainThreadDispatch reports that a Cocoa operation could not be queued on
+// the process' main thread.
+var ErrMainThreadDispatch = errors.New("darwin: main-thread dispatch unavailable")
+
+var mainThreadTasks struct {
+	once    sync.Once
+	class   Class
+	invoke  SEL
+	perform SEL
+	err     error
+	tasks   sync.Map // uintptr(NSObject) -> func()
+}
+
+// IsMainThread reports whether the current goroutine is running on AppKit's
+// main thread. Unlike runtime.LockOSThread, this check is valid for callers
+// that arrive from a background goroutine and is implemented by Foundation's
+// NSThread class.
+func IsMainThread() bool {
+	threadClass := GetClass("NSThread")
+	if threadClass == 0 {
+		return false
+	}
+	return ID(threadClass).GetBool(RegisterSelector("isMainThread"))
+}
+
+func initMainThreadTasks() error {
+	mainThreadTasks.once.Do(func() {
+		if err := initRuntime(); err != nil {
+			mainThreadTasks.err = err
+			return
+		}
+		initSelectors()
+		initClasses()
+		super := classes.NSObject
+		if super == 0 {
+			mainThreadTasks.err = ErrMainThreadDispatch
+			return
+		}
+
+		// A small NSObject subclass lets us use the documented
+		// performSelectorOnMainThread:withObject:waitUntilDone: API without
+		// introducing a C/CGO dispatch shim. The callback is retained in a Go
+		// map keyed by the target object's address; no Go pointer crosses the
+		// Objective-C boundary.
+		cls := AllocateClassPair(super, "GoGPUMainThreadTask")
+		if cls == 0 {
+			// Tests and embedders can initialize this package more than once in
+			// one process. Reuse a class registered by an earlier initializer.
+			cls = GetClass("GoGPUMainThreadTask")
+		}
+		if cls == 0 {
+			mainThreadTasks.err = ErrMainThreadDispatch
+			return
+		}
+
+		invoke := RegisterSelector("gogpuPerform:")
+		imp := ffi.NewCallback(func(self, _, _ uintptr) uintptr {
+			if value, ok := mainThreadTasks.tasks.LoadAndDelete(self); ok {
+				value.(func())()
+			}
+			// The object was allocated solely for this invocation. Release the
+			// initial retain after the callback has run.
+			ID(self).Send(selectors.release)
+			return 0
+		})
+		if !ClassAddMethod(cls, invoke, imp, "v@:@") {
+			// If another package registered the same class concurrently, the
+			// existing method is sufficient; otherwise report the failure.
+			if GetClass("GoGPUMainThreadTask") == 0 {
+				mainThreadTasks.err = ErrMainThreadDispatch
+				return
+			}
+		}
+		if GetClass("GoGPUMainThreadTask") == 0 {
+			RegisterClassPair(cls)
+		}
+		mainThreadTasks.class = cls
+		mainThreadTasks.invoke = invoke
+		mainThreadTasks.perform = RegisterSelector(
+			"performSelectorOnMainThread:withObject:waitUntilDone:")
+	})
+	return mainThreadTasks.err
+}
+
+// PerformOnMain invokes fn on AppKit's main thread. If wait is true, the
+// caller blocks until fn has returned; otherwise the function returns after
+// the invocation has been queued. The asynchronous form is used for modal
+// print operations so App.Print can return its PrintJob before the panel is
+// dismissed. performSelectorOnMainThread also works while AppKit is inside a
+// nested sheet/modal event loop, which is required for cancellation.
+func PerformOnMain(fn func(), wait bool) error {
+	if fn == nil {
+		return nil
+	}
+	if wait && IsMainThread() {
+		fn()
+		return nil
+	}
+	if err := initMainThreadTasks(); err != nil {
+		return err
+	}
+	if mainThreadTasks.class == 0 || mainThreadTasks.perform == 0 {
+		return ErrMainThreadDispatch
+	}
+
+	target := ID(mainThreadTasks.class).Send(selectors.alloc).Send(selectors.init)
+	if target == 0 {
+		return ErrMainThreadDispatch
+	}
+
+	var done chan struct{}
+	if wait {
+		done = make(chan struct{})
+		mainThreadTasks.tasks.Store(target.Ptr(), func() {
+			defer close(done)
+			fn()
+		})
+	} else {
+		mainThreadTasks.tasks.Store(target.Ptr(), fn)
+	}
+
+	waitArg := uintptr(0)
+	if wait {
+		waitArg = 1
+	}
+	target.SendPtrs(mainThreadTasks.perform, mainThreadTasks.invoke.SELPtr(), 0, waitArg)
+	if wait {
+		<-done
+	}
+	return nil
+}

--- a/internal/platform/darwin/objc.go
+++ b/internal/platform/darwin/objc.go
@@ -500,6 +500,16 @@ func (id ID) SendPtr(sel SEL, arg uintptr) ID {
 	return msgSend(id, sel, arg)
 }
 
+// SendPtrs sends a message with a variable number of pointer-sized arguments.
+// Objective-C uses pointer-sized registers for object, selector, integer, and
+// boolean arguments on the supported 64-bit macOS ABIs, so this helper is used
+// for selectors whose argument count is not covered by the fixed-arity helpers.
+// It is intentionally limited by msgSend to six arguments, which keeps all
+// call sites on the existing dynamically prepared FFI path.
+func (id ID) SendPtrs(sel SEL, args ...uintptr) ID {
+	return msgSend(id, sel, args...)
+}
+
 // Send5Ptr calls objc_msgSend with three additional pointer arguments.
 func (id ID) Send5Ptr(sel SEL, arg0, arg1, arg2 uintptr) ID {
 	if id == 0 || sel == 0 {

--- a/internal/platform/darwin/print.go
+++ b/internal/platform/darwin/print.go
@@ -1,0 +1,514 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/go-webgpu/goffi/ffi"
+)
+
+var (
+	ErrPrintMainThread = errors.New("darwin: print operation requires the main thread")
+	ErrPrintSetup      = errors.New("darwin: print operation setup failed")
+)
+
+// PrintPageRange is an inclusive, one-based range. Ranges are normalized and
+// merged before PDFKit receives the document.
+type PrintPageRange struct {
+	From int
+	To   int
+}
+
+// PrintRequest is the native-facing macOS print request. Data is copied by
+// the caller-facing App.Print contract before this type is constructed.
+type PrintRequest struct {
+	Name       string
+	Data       []byte
+	Title      string
+	Copies     int
+	PageRanges []PrintPageRange
+}
+
+var pdfKitState struct {
+	once sync.Once
+	err  error
+	lib  unsafe.Pointer
+}
+
+func initPDFKit() error {
+	pdfKitState.once.Do(func() {
+		if err := initRuntime(); err != nil {
+			pdfKitState.err = err
+			return
+		}
+		pdfKitState.lib, pdfKitState.err = ffi.LoadLibrary(
+			"/System/Library/Frameworks/PDFKit.framework/PDFKit")
+	})
+	return pdfKitState.err
+}
+
+var printDelegateState struct {
+	once      sync.Once
+	class     Class
+	didRun    SEL
+	err       error
+	callbacks sync.Map // uintptr(contextInfo) -> *PrintHandle
+}
+
+var nextPrintToken atomic.Uint64
+
+func initPrintDelegate() error {
+	printDelegateState.once.Do(func() {
+		if err := initRuntime(); err != nil {
+			printDelegateState.err = err
+			return
+		}
+		initSelectors()
+		initClasses()
+		super := classes.NSObject
+		if super == 0 {
+			printDelegateState.err = ErrPrintSetup
+			return
+		}
+		cls := AllocateClassPair(super, "GoGPUPrintDelegate")
+		if cls == 0 {
+			cls = GetClass("GoGPUPrintDelegate")
+		}
+		if cls == 0 {
+			printDelegateState.err = ErrPrintSetup
+			return
+		}
+		didRun := RegisterSelector("gogpuPrintOperationDidRun:success:contextInfo:")
+		imp := ffi.NewCallback(func(_self, _sel, _operation, success, contextInfo uintptr) uintptr {
+			value, ok := printDelegateState.callbacks.LoadAndDelete(contextInfo)
+			if !ok {
+				return 0
+			}
+			h := value.(*PrintHandle)
+			h.mu.Lock()
+			done := h.done
+			h.mu.Unlock()
+			if done != nil {
+				done(success != 0)
+			}
+			return 0
+		})
+		if !ClassAddMethod(cls, didRun, imp, "v@:@B^v") {
+			if GetClass("GoGPUPrintDelegate") == 0 {
+				printDelegateState.err = ErrPrintSetup
+				return
+			}
+		}
+		if GetClass("GoGPUPrintDelegate") == 0 {
+			RegisterClassPair(cls)
+		}
+		printDelegateState.class = cls
+		printDelegateState.didRun = didRun
+	})
+	return printDelegateState.err
+}
+
+// PrintHandle owns all retained PDFKit/AppKit objects for one accepted print
+// operation. Its callback runs after NSPrintOperation has finished or the
+// user has dismissed the print panel. Close must happen before the caller's
+// PrintJob.Done terminal value is published.
+type PrintHandle struct {
+	mu sync.Mutex
+
+	document      ID
+	filtered      ID
+	printInfo     ID
+	operation     ID
+	delegate      ID
+	parent        ID
+	callbackToken uintptr
+	started       bool
+	closed        bool
+	done          func(success bool)
+
+	closeOnce sync.Once
+}
+
+// NewPrintHandle parses the complete PDF with PDFKit and prepares an
+// NSPrintOperation. It does not show the native print panel; Run starts the
+// asynchronous modal operation. Call on AppKit's main thread.
+func NewPrintHandle(request PrintRequest, parent ID) (*PrintHandle, error) {
+	if !IsMainThread() {
+		return nil, ErrPrintMainThread
+	}
+	if request.Copies < 0 {
+		return nil, fmt.Errorf("%w: negative copies", ErrPrintSetup)
+	}
+	for _, r := range request.PageRanges {
+		if r.From <= 0 || r.To < r.From {
+			return nil, fmt.Errorf("%w: page range %d-%d", ErrPrintSetup, r.From, r.To)
+		}
+	}
+	if len(request.Data) == 0 {
+		return nil, fmt.Errorf("%w: empty PDF data", ErrPrintSetup)
+	}
+	if err := initPDFKit(); err != nil {
+		return nil, fmt.Errorf("%w: PDFKit: %v", ErrPrintSetup, err)
+	}
+	initSelectors()
+	initClasses()
+
+	pdfClass := GetClass("PDFDocument")
+	printInfoClass := GetClass("NSPrintInfo")
+	if pdfClass == 0 || printInfoClass == 0 {
+		return nil, fmt.Errorf("%w: PDFDocument/NSPrintInfo unavailable", ErrPrintSetup)
+	}
+
+	dataClass := GetClass("NSData")
+	if dataClass == 0 {
+		return nil, fmt.Errorf("%w: NSData unavailable", ErrPrintSetup)
+	}
+	dataSel := RegisterSelector("dataWithBytes:length:")
+	data := ID(dataClass).SendPtrs(dataSel,
+		uintptr(unsafe.Pointer(&request.Data[0])), uintptr(len(request.Data)))
+	runtime.KeepAlive(request.Data)
+	if data == 0 {
+		return nil, fmt.Errorf("%w: NSData creation failed", ErrPrintSetup)
+	}
+
+	allocSel := selectors.alloc
+	initWithDataSel := RegisterSelector("initWithData:")
+	document := ID(pdfClass).Send(allocSel).SendPtr(initWithDataSel, data.Ptr())
+	if document == 0 {
+		return nil, fmt.Errorf("%w: PDFDocument rejected data", ErrPrintSetup)
+	}
+
+	selected := document
+	filtered, err := filterPDFDocument(document, request.PageRanges)
+	if err != nil {
+		document.Send(selectors.release)
+		return nil, err
+	}
+	if filtered != document {
+		selected = filtered
+	}
+
+	printInfo, err := newPrintInfo(request.Copies)
+	if err != nil {
+		if filtered != document {
+			filtered.Send(selectors.release)
+		}
+		document.Send(selectors.release)
+		return nil, err
+	}
+
+	// kPDFPrintPageScaleToFit = 1; autoRotate = YES. PDFDocument's print
+	// operation paginates every selected page and displays the native panel.
+	operation := selected.SendPtrs(
+		RegisterSelector("printOperationForPrintInfo:scalingMode:autoRotate:"),
+		printInfo.Ptr(), 1, 1)
+	if operation == 0 {
+		printInfo.Send(selectors.release)
+		if filtered != document {
+			filtered.Send(selectors.release)
+		}
+		document.Send(selectors.release)
+		return nil, fmt.Errorf("%w: PDFDocument could not create NSPrintOperation", ErrPrintSetup)
+	}
+	// The PDFDocument factory returns an autoreleased operation. Retain it for
+	// the lifetime of the asynchronous print job.
+	operation.Send(selectors.retain)
+
+	if request.Title != "" || request.Name != "" {
+		title := request.Title
+		if title == "" {
+			title = request.Name
+		}
+		if nsTitle := NewNSString(title); nsTitle != nil {
+			operation.SendPtr(RegisterSelector("setJobTitle:"), nsTitle.ID().Ptr())
+			nsTitle.Release()
+		}
+	}
+	// Keep the callback on the main thread. Setting this to true would allow
+	// AppKit to invoke the delegate on a detached printing thread, which would
+	// move resource release and Done publication off the documented lifecycle.
+	operation.SendBool(RegisterSelector("setCanSpawnSeparateThread:"), false)
+
+	if err := initPrintDelegate(); err != nil {
+		operation.Send(selectors.release)
+		printInfo.Send(selectors.release)
+		if filtered != document {
+			filtered.Send(selectors.release)
+		}
+		document.Send(selectors.release)
+		return nil, fmt.Errorf("%w: delegate: %v", ErrPrintSetup, err)
+	}
+	delegate := ID(printDelegateState.class).Send(selectors.alloc).Send(selectors.init)
+	if delegate == 0 {
+		operation.Send(selectors.release)
+		printInfo.Send(selectors.release)
+		if filtered != document {
+			filtered.Send(selectors.release)
+		}
+		document.Send(selectors.release)
+		return nil, fmt.Errorf("%w: delegate allocation failed", ErrPrintSetup)
+	}
+
+	h := &PrintHandle{
+		document:  document,
+		filtered:  filtered,
+		printInfo: printInfo,
+		operation: operation,
+		delegate:  delegate,
+		parent:    parent,
+	}
+	if parent != 0 {
+		parent.Send(selectors.retain)
+	}
+	return h, nil
+}
+
+// Run starts the modal print panel and returns immediately after AppKit has
+// accepted it. The callback receives true only when the native operation
+// completed successfully. Run must execute on the main thread.
+func (h *PrintHandle) Run(done func(success bool)) error {
+	if h == nil {
+		return ErrPrintSetup
+	}
+	if !IsMainThread() {
+		return ErrPrintMainThread
+	}
+	h.mu.Lock()
+	if h.closed || h.started {
+		h.mu.Unlock()
+		return fmt.Errorf("%w: operation already started", ErrPrintSetup)
+	}
+	h.started = true
+	h.done = done
+	token := nextPrintToken.Add(1)
+	if token == 0 {
+		token = nextPrintToken.Add(1)
+	}
+	h.callbackToken = uintptr(token)
+	printDelegateState.callbacks.Store(h.callbackToken, h)
+	h.mu.Unlock()
+
+	// runOperationModalForWindow:delegate:didRunSelector:contextInfo: is a
+	// void-returning method; SendPtrs supplies its four pointer-sized args.
+	h.operation.SendPtrs(
+		RegisterSelector("runOperationModalForWindow:delegate:didRunSelector:contextInfo:"),
+		h.parent.Ptr(), h.delegate.Ptr(), printDelegateState.didRun.SELPtr(), h.callbackToken)
+	return nil
+}
+
+// Cancel asks the current print panel to close. NSPrintOperation does not
+// expose a cancellation method; once the panel is gone the terminal callback
+// still reports false and the platform job maps a caller cancellation to
+// context.Canceled. Callers may invoke this from any goroutine.
+func (h *PrintHandle) Cancel() {
+	if h == nil {
+		return
+	}
+	if !IsMainThread() {
+		_ = PerformOnMain(h.Cancel, false)
+		return
+	}
+	h.mu.Lock()
+	if h.closed || !h.started {
+		h.mu.Unlock()
+		return
+	}
+	op := h.operation
+	h.mu.Unlock()
+	if op == 0 {
+		return
+	}
+	panel := op.Send(RegisterSelector("printPanel"))
+	if panel != 0 {
+		panel.SendPtr(RegisterSelector("cancel:"), 0)
+	}
+}
+
+// Close releases all native resources retained by NewPrintHandle. It is
+// idempotent and must run before the platform publishes PrintJob.Done.
+func (h *PrintHandle) Close() {
+	if h == nil {
+		return
+	}
+	if !IsMainThread() {
+		_ = PerformOnMain(h.Close, true)
+		return
+	}
+	h.closeOnce.Do(func() {
+		h.mu.Lock()
+		h.closed = true
+		token := h.callbackToken
+		document, filtered, info, operation, delegate, parent :=
+			h.document, h.filtered, h.printInfo, h.operation, h.delegate, h.parent
+		h.document, h.filtered, h.printInfo, h.operation, h.delegate, h.parent = 0, 0, 0, 0, 0, 0
+		h.mu.Unlock()
+		if token != 0 {
+			printDelegateState.callbacks.Delete(token)
+		}
+		if operation != 0 {
+			operation.Send(selectors.release)
+		}
+		if info != 0 {
+			info.Send(selectors.release)
+		}
+		if filtered != 0 && filtered != document {
+			filtered.Send(selectors.release)
+		}
+		if document != 0 {
+			document.Send(selectors.release)
+		}
+		if delegate != 0 {
+			delegate.Send(selectors.release)
+		}
+		if parent != 0 {
+			parent.Send(selectors.release)
+		}
+	})
+}
+
+func newPrintInfo(copies int) (ID, error) {
+	infoClass := GetClass("NSPrintInfo")
+	if infoClass == 0 {
+		return 0, fmt.Errorf("%w: NSPrintInfo unavailable", ErrPrintSetup)
+	}
+	shared := ID(infoClass).Send(RegisterSelector("sharedPrintInfo"))
+	if shared == 0 {
+		return 0, fmt.Errorf("%w: shared NSPrintInfo unavailable", ErrPrintSetup)
+	}
+	if copies == 0 {
+		copy := shared.Send(RegisterSelector("copy"))
+		if copy == 0 {
+			return 0, fmt.Errorf("%w: NSPrintInfo copy failed", ErrPrintSetup)
+		}
+		return copy, nil
+	}
+
+	dictionary := shared.Send(RegisterSelector("dictionary"))
+	mutable := dictionary.Send(RegisterSelector("mutableCopy"))
+	if mutable == 0 {
+		return 0, fmt.Errorf("%w: NSPrintInfo dictionary copy failed", ErrPrintSetup)
+	}
+	number := ID(GetClass("NSNumber")).SendPtrs(RegisterSelector("numberWithInteger:"), uintptr(copies))
+	key := NewNSString("NSPrintCopies")
+	if number == 0 || key == nil {
+		mutable.Send(selectors.release)
+		return 0, fmt.Errorf("%w: NSPrintCopies value failed", ErrPrintSetup)
+	}
+	mutable.SendPtrs(RegisterSelector("setObject:forKey:"), number.Ptr(), key.ID().Ptr())
+	key.Release()
+	info := ID(infoClass).Send(selectors.alloc).SendPtrs(
+		RegisterSelector("initWithDictionary:"), mutable.Ptr())
+	mutable.Send(selectors.release)
+	if info == 0 {
+		return 0, fmt.Errorf("%w: NSPrintInfo initialization failed", ErrPrintSetup)
+	}
+	return info, nil
+}
+
+func filterPDFDocument(document ID, ranges []PrintPageRange) (ID, error) {
+	if len(ranges) == 0 {
+		return document, nil
+	}
+	count := document.GetUint64(RegisterSelector("pageCount"))
+	merged := normalizePrintRanges(ranges)
+	if count == 0 {
+		return 0, fmt.Errorf("%w: PDF contains no pages", ErrPrintSetup)
+	}
+
+	selectedCount := uint64(0)
+	for page := uint64(1); page <= count; page++ {
+		if printPageSelected(int(page), merged) {
+			selectedCount++
+		}
+	}
+	if selectedCount == 0 {
+		return 0, fmt.Errorf("%w: page ranges select no pages", ErrPrintSetup)
+	}
+	if selectedCount == count && printPageSelected(1, merged) {
+		all := true
+		for page := uint64(1); page <= count; page++ {
+			if !printPageSelected(int(page), merged) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return document, nil
+		}
+	}
+
+	pdfClass := GetClass("PDFDocument")
+	filtered := ID(pdfClass).Send(selectors.alloc).Send(selectors.init)
+	if filtered == 0 {
+		return 0, fmt.Errorf("%w: filtered PDFDocument allocation failed", ErrPrintSetup)
+	}
+	pageAt := RegisterSelector("pageAtIndex:")
+	insert := RegisterSelector("insertPage:atIndex:")
+	index := uint64(0)
+	for page := uint64(1); page <= count; page++ {
+		if !printPageSelected(int(page), merged) {
+			continue
+		}
+		pdfPage := document.SendPtrs(pageAt, uintptr(page-1))
+		if pdfPage == 0 {
+			filtered.Send(selectors.release)
+			return 0, fmt.Errorf("%w: PDF page %d unavailable", ErrPrintSetup, page)
+		}
+		filtered.SendPtrs(insert, pdfPage.Ptr(), uintptr(index))
+		index++
+	}
+	return filtered, nil
+}
+
+func normalizePrintRanges(ranges []PrintPageRange) []PrintPageRange {
+	copyRanges := append([]PrintPageRange(nil), ranges...)
+	sort.Slice(copyRanges, func(i, j int) bool {
+		if copyRanges[i].From == copyRanges[j].From {
+			return copyRanges[i].To < copyRanges[j].To
+		}
+		return copyRanges[i].From < copyRanges[j].From
+	})
+	merged := make([]PrintPageRange, 0, len(copyRanges))
+	for _, r := range copyRanges {
+		if r.To < r.From {
+			continue
+		}
+		if len(merged) == 0 {
+			merged = append(merged, r)
+			continue
+		}
+		last := &merged[len(merged)-1]
+		if r.From > last.To {
+			// Avoid last.To+1 overflow for a direct internal caller passing the
+			// largest representable page number.
+			maxInt := int(^uint(0) >> 1)
+			if last.To == maxInt || r.From != last.To+1 {
+				merged = append(merged, r)
+				continue
+			}
+		}
+		if r.To > last.To {
+			last.To = r.To
+		}
+	}
+	return merged
+}
+
+func printPageSelected(page int, ranges []PrintPageRange) bool {
+	for _, r := range ranges {
+		if page < r.From {
+			return false
+		}
+		if page <= r.To {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/platform/darwin/print.go
+++ b/internal/platform/darwin/print.go
@@ -139,6 +139,8 @@ type PrintHandle struct {
 // NewPrintHandle parses the complete PDF with PDFKit and prepares an
 // NSPrintOperation. It does not show the native print panel; Run starts the
 // asynchronous modal operation. Call on AppKit's main thread.
+//
+//nolint:gocognit // PDFKit/AppKit setup must retain and unwind one native lifecycle.
 func NewPrintHandle(request PrintRequest, parent ID) (*PrintHandle, error) {
 	if !IsMainThread() {
 		return nil, ErrPrintMainThread
@@ -155,7 +157,7 @@ func NewPrintHandle(request PrintRequest, parent ID) (*PrintHandle, error) {
 		return nil, fmt.Errorf("%w: empty PDF data", ErrPrintSetup)
 	}
 	if err := initPDFKit(); err != nil {
-		return nil, fmt.Errorf("%w: PDFKit: %v", ErrPrintSetup, err)
+		return nil, fmt.Errorf("%w: PDFKit: %w", ErrPrintSetup, err)
 	}
 	initSelectors()
 	initClasses()
@@ -243,7 +245,7 @@ func NewPrintHandle(request PrintRequest, parent ID) (*PrintHandle, error) {
 			filtered.Send(selectors.release)
 		}
 		document.Send(selectors.release)
-		return nil, fmt.Errorf("%w: delegate: %v", ErrPrintSetup, err)
+		return nil, fmt.Errorf("%w: delegate: %w", ErrPrintSetup, err)
 	}
 	delegate := ID(printDelegateState.class).Send(selectors.alloc).Send(selectors.init)
 	if delegate == 0 {
@@ -383,11 +385,11 @@ func newPrintInfo(copies int) (ID, error) {
 		return 0, fmt.Errorf("%w: shared NSPrintInfo unavailable", ErrPrintSetup)
 	}
 	if copies == 0 {
-		copy := shared.Send(RegisterSelector("copy"))
-		if copy == 0 {
+		printInfoCopy := shared.Send(RegisterSelector("copy"))
+		if printInfoCopy == 0 {
 			return 0, fmt.Errorf("%w: NSPrintInfo copy failed", ErrPrintSetup)
 		}
-		return copy, nil
+		return printInfoCopy, nil
 	}
 
 	dictionary := shared.Send(RegisterSelector("dictionary"))

--- a/internal/platform/darwin/print.go
+++ b/internal/platform/darwin/print.go
@@ -3,6 +3,7 @@
 package darwin
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -130,6 +131,7 @@ type PrintHandle struct {
 	parent        ID
 	callbackToken uintptr
 	started       bool
+	canceled      bool
 	closed        bool
 	done          func(success bool)
 
@@ -182,7 +184,11 @@ func NewPrintHandle(request PrintRequest, parent ID) (*PrintHandle, error) {
 
 	allocSel := selectors.alloc
 	initWithDataSel := RegisterSelector("initWithData:")
-	document := ID(pdfClass).Send(allocSel).SendPtr(initWithDataSel, data.Ptr())
+	documentAlloc := ID(pdfClass).Send(allocSel)
+	if documentAlloc == 0 {
+		return nil, fmt.Errorf("%w: PDFDocument allocation failed", ErrPrintSetup)
+	}
+	document := documentAlloc.SendPtr(initWithDataSel, data.Ptr())
 	if document == 0 {
 		return nil, fmt.Errorf("%w: PDFDocument rejected data", ErrPrintSetup)
 	}
@@ -247,7 +253,17 @@ func NewPrintHandle(request PrintRequest, parent ID) (*PrintHandle, error) {
 		document.Send(selectors.release)
 		return nil, fmt.Errorf("%w: delegate: %w", ErrPrintSetup, err)
 	}
-	delegate := ID(printDelegateState.class).Send(selectors.alloc).Send(selectors.init)
+	delegateAlloc := ID(printDelegateState.class).Send(selectors.alloc)
+	if delegateAlloc == 0 {
+		operation.Send(selectors.release)
+		printInfo.Send(selectors.release)
+		if filtered != document {
+			filtered.Send(selectors.release)
+		}
+		document.Send(selectors.release)
+		return nil, fmt.Errorf("%w: delegate allocation failed", ErrPrintSetup)
+	}
+	delegate := delegateAlloc.Send(selectors.init)
 	if delegate == 0 {
 		operation.Send(selectors.release)
 		printInfo.Send(selectors.release)
@@ -284,8 +300,16 @@ func (h *PrintHandle) Run(done func(success bool)) error {
 	}
 	h.mu.Lock()
 	if h.closed || h.started {
+		if h.closed {
+			h.mu.Unlock()
+			return context.Canceled
+		}
 		h.mu.Unlock()
 		return fmt.Errorf("%w: operation already started", ErrPrintSetup)
+	}
+	if h.canceled {
+		h.mu.Unlock()
+		return context.Canceled
 	}
 	h.started = true
 	h.done = done
@@ -318,7 +342,12 @@ func (h *PrintHandle) Cancel() {
 		return
 	}
 	h.mu.Lock()
-	if h.closed || !h.started {
+	if h.closed {
+		h.mu.Unlock()
+		return
+	}
+	h.canceled = true
+	if !h.started {
 		h.mu.Unlock()
 		return
 	}
@@ -401,11 +430,19 @@ func newPrintInfo(copies int) (ID, error) {
 	key := NewNSString("NSPrintCopies")
 	if number == 0 || key == nil {
 		mutable.Send(selectors.release)
+		if key != nil {
+			key.Release()
+		}
 		return 0, fmt.Errorf("%w: NSPrintCopies value failed", ErrPrintSetup)
 	}
 	mutable.SendPtrs(RegisterSelector("setObject:forKey:"), number.Ptr(), key.ID().Ptr())
 	key.Release()
-	info := ID(infoClass).Send(selectors.alloc).SendPtrs(
+	infoAlloc := ID(infoClass).Send(selectors.alloc)
+	if infoAlloc == 0 {
+		mutable.Send(selectors.release)
+		return 0, fmt.Errorf("%w: NSPrintInfo allocation failed", ErrPrintSetup)
+	}
+	info := infoAlloc.SendPtrs(
 		RegisterSelector("initWithDictionary:"), mutable.Ptr())
 	mutable.Send(selectors.release)
 	if info == 0 {
@@ -447,7 +484,11 @@ func filterPDFDocument(document ID, ranges []PrintPageRange) (ID, error) {
 	}
 
 	pdfClass := GetClass("PDFDocument")
-	filtered := ID(pdfClass).Send(selectors.alloc).Send(selectors.init)
+	filteredAlloc := ID(pdfClass).Send(selectors.alloc)
+	if filteredAlloc == 0 {
+		return 0, fmt.Errorf("%w: filtered PDFDocument allocation failed", ErrPrintSetup)
+	}
+	filtered := filteredAlloc.Send(selectors.init)
 	if filtered == 0 {
 		return 0, fmt.Errorf("%w: filtered PDFDocument allocation failed", ErrPrintSetup)
 	}

--- a/internal/platform/darwin/print_test.go
+++ b/internal/platform/darwin/print_test.go
@@ -1,0 +1,52 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizePrintRangesSortsMergesAndDropsInvalid(t *testing.T) {
+	got := normalizePrintRanges([]PrintPageRange{
+		{From: 8, To: 9},
+		{From: 2, To: 3},
+		{From: 4, To: 6},
+		{From: 6, To: 8},
+		{From: 12, To: 11},
+		{From: 20, To: 20},
+	})
+	want := []PrintPageRange{{From: 2, To: 9}, {From: 20, To: 20}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizePrintRanges() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPrintPageSelectedUsesInclusiveOneBasedRanges(t *testing.T) {
+	ranges := []PrintPageRange{{From: 2, To: 3}, {From: 7, To: 7}}
+	for page, want := range map[int]bool{
+		1: false,
+		2: true,
+		3: true,
+		4: false,
+		6: false,
+		7: true,
+		8: false,
+	} {
+		if got := printPageSelected(page, ranges); got != want {
+			t.Errorf("printPageSelected(%d) = %v, want %v", page, got, want)
+		}
+	}
+}
+
+func TestNormalizePrintRangesHandlesLargestPageNumber(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	got := normalizePrintRanges([]PrintPageRange{
+		{From: maxInt, To: maxInt},
+		{From: maxInt - 2, To: maxInt - 1},
+	})
+	want := []PrintPageRange{{From: maxInt - 2, To: maxInt}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizePrintRanges() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/platform/dbus_linux.go
+++ b/internal/platform/dbus_linux.go
@@ -526,9 +526,10 @@ func dbusParseHdrFields(hdrData []byte, msg *dbusMsg) {
 			if err != nil {
 				break
 			}
-			if code == dbusFieldReplySerial {
+			switch code {
+			case dbusFieldReplySerial:
 				msg.ReplyTo = v
-			} else if code == dbusFieldUnixFds {
+			case dbusFieldUnixFds:
 				msg.UnixFDs = v
 			}
 		case "g":

--- a/internal/platform/dbus_linux.go
+++ b/internal/platform/dbus_linux.go
@@ -2,8 +2,9 @@
 
 // Minimal hand-written D-Bus session bus client.
 //
-// Covers exactly the wire shapes needed by org.freedesktop.portal.FileChooser
-// (ADR-036) and reusable for future D-Bus portals (ADR-040).
+// Covers the wire shapes needed by org.freedesktop.portal.FileChooser and
+// org.freedesktop.portal.Print (ADR-036/040), with Unix FD passing for portal
+// document submission and no external D-Bus dependency.
 //
 // Wire format summary:
 //
@@ -17,6 +18,7 @@
 package platform
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -29,6 +31,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // errPortalUnavailable is returned by portalOpenFile/portalSaveFile when the
@@ -57,6 +61,10 @@ const (
 	dbusFieldDest        byte = 6
 	dbusFieldSender      byte = 7
 	dbusFieldSignature   byte = 8
+	// dbusFieldUnixFds announces the number of file descriptors attached to a
+	// message through SCM_RIGHTS.  The body refers to those descriptors by a
+	// zero-based index using the D-Bus `h` type.
+	dbusFieldUnixFds byte = 9
 )
 
 // dbusSerial is a process-global counter used to generate unique portal request tokens.
@@ -73,6 +81,7 @@ type dbusMsg struct {
 	ErrorName string // ERROR_NAME header field (non-empty only for dbusMsgError)
 	Sender    string
 	Sig       string // body signature
+	UnixFDs   uint32 // UNIX_FDS header field (number of attached descriptors)
 	Body      []byte
 }
 
@@ -87,17 +96,40 @@ type dbusConn struct {
 // dbusConnect opens the session bus socket, performs SASL EXTERNAL authentication,
 // and sends the mandatory Hello method call to obtain our unique bus name.
 func dbusConnect() (*dbusConn, error) {
+	return dbusConnectContext(context.Background())
+}
+
+// dbusConnectContext is dbusConnect with a cancellation-aware Unix dial.  The
+// authentication/Hello exchange is still bounded by the same short deadline
+// used by dbusConnect, so a portal that is present but unresponsive cannot
+// hold StartPrint indefinitely.
+func dbusConnectContext(ctx context.Context) (*dbusConn, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	addr := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
 	if addr == "" {
 		return nil, fmt.Errorf("dbus: DBUS_SESSION_BUS_ADDRESS not set")
 	}
 
-	raw, err := dbusDialAddr(addr)
+	raw, err := dbusDialAddrContext(ctx, addr)
 	if err != nil {
 		return nil, fmt.Errorf("dbus: dial: %w", err)
 	}
 
 	c := &dbusConn{rw: raw}
+	if err := ctx.Err(); err != nil {
+		raw.Close()
+		return nil, err
+	}
+	// auth() has no context parameter because it is also used by the existing
+	// file chooser path.  A bounded socket deadline keeps this setup phase
+	// cancellable in practice while the dial itself observes ctx directly.
+	setupDeadline := time.Now().Add(5 * time.Second)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(setupDeadline) {
+		setupDeadline = ctxDeadline
+	}
+	raw.SetDeadline(setupDeadline)
 	if err := c.auth(); err != nil {
 		raw.Close()
 		return nil, fmt.Errorf("dbus: auth: %w", err)
@@ -105,7 +137,11 @@ func dbusConnect() (*dbusConn, error) {
 
 	// Bound the Hello round-trip; clear the deadline so that the caller
 	// (portal dialog) can set its own longer deadline via waitResponse.
-	c.rw.SetDeadline(time.Now().Add(5 * time.Second))
+	deadline := time.Now().Add(5 * time.Second)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	c.rw.SetDeadline(deadline)
 	name, err := c.hello()
 	c.rw.SetDeadline(time.Time{})
 	if err != nil {
@@ -125,6 +161,17 @@ func dbusConnect() (*dbusConn, error) {
 // unix:abstract=... (Linux abstract namespace, '\x00' prefix).
 // Multiple addresses separated by ';' are tried in order.
 func dbusDialAddr(addr string) (net.Conn, error) {
+	return dbusDialAddrContext(context.Background(), addr)
+}
+
+// dbusDialAddrContext is the context-aware counterpart to dbusDialAddr.  A
+// D-Bus session address may contain several transports; each Unix transport
+// is attempted in order until one succeeds.
+func dbusDialAddrContext(ctx context.Context, addr string) (net.Conn, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	dialer := &net.Dialer{}
 	for _, transport := range strings.Split(addr, ";") {
 		if !strings.HasPrefix(transport, "unix:") {
 			continue
@@ -132,16 +179,18 @@ func dbusDialAddr(addr string) (net.Conn, error) {
 		params := dbusParseParams(transport[len("unix:"):])
 
 		if path, ok := params["path"]; ok {
-			if conn, err := net.Dial("unix", path); err == nil {
+			if conn, err := dialer.DialContext(ctx, "unix", path); err == nil {
 				return conn, nil
 			}
 		}
 		if abstract, ok := params["abstract"]; ok {
-			uaddr := &net.UnixAddr{Net: "unix", Name: "\x00" + abstract}
-			if conn, err := net.DialUnix("unix", nil, uaddr); err == nil {
+			if conn, err := dialer.DialContext(ctx, "unix", "\x00"+abstract); err == nil {
 				return conn, nil
 			}
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 	return nil, fmt.Errorf("dbus: unreachable bus address %q", addr)
 }
@@ -211,9 +260,34 @@ func (c *dbusConn) hello() (string, error) {
 // sendCall encodes a D-Bus METHOD_CALL message, writes it to the connection, and
 // returns the serial number used (needed to match the eventual METHOD_RETURN).
 func (c *dbusConn) sendCall(dest, path, iface, member, sig string, body []byte) (uint32, error) {
+	return c.sendCallWithFDs(dest, path, iface, member, sig, body, nil)
+}
+
+// sendCallWithFDs is sendCall with optional Unix file descriptors attached via
+// SCM_RIGHTS.  D-Bus represents each descriptor in the body as an `h` value
+// containing its zero-based index and announces the count in the UNIX_FDS
+// header field.  The portal Print API uses this to receive the document.
+func (c *dbusConn) sendCallWithFDs(dest, path, iface, member, sig string, body []byte, fds []int) (uint32, error) {
 	c.serial++
-	raw := dbusEncodeMsg(dbusMsgCall, c.serial, dest, path, iface, member, sig, body)
-	_, err := c.rw.Write(raw)
+	raw := dbusEncodeMsgWithFDs(dbusMsgCall, c.serial, dest, path, iface, member, sig, body, uint32(len(fds)))
+	var err error
+	if len(fds) == 0 {
+		var n int
+		n, err = c.rw.Write(raw)
+		if err == nil && n != len(raw) {
+			err = io.ErrShortWrite
+		}
+	} else {
+		conn, ok := c.rw.(*net.UnixConn)
+		if !ok {
+			return c.serial, fmt.Errorf("dbus: UnixFDs require UnixConn, got %T", c.rw)
+		}
+		n, _, writeErr := conn.WriteMsgUnix(raw, unix.UnixRights(fds...), nil)
+		err = writeErr
+		if err == nil && n != len(raw) {
+			err = io.ErrShortWrite
+		}
+	}
 	return c.serial, err
 }
 
@@ -227,6 +301,19 @@ func (c *dbusConn) sendCall(dest, path, iface, member, sig string, body []byte) 
 // Returns nil, nil if the portal reports that the user canceled (response code 1).
 // A 5-minute deadline guards against a hung or crashed portal daemon.
 func (c *dbusConn) waitResponse(callSerial uint32, handlePath string) ([]string, error) {
+	body, err := c.waitResponseBody(callSerial, handlePath)
+	if err != nil {
+		return nil, err
+	}
+	return decodePortalResponse(body)
+}
+
+// waitResponseBody waits for an xdg-desktop-portal Request.Response signal and
+// returns its raw ua{sv} body.  Keeping response decoding separate lets the
+// Print portal consume its token while the existing FileChooser path continues
+// to decode URI results.  Signals may arrive before the method return, so the
+// first matching signal is buffered until the return is observed.
+func (c *dbusConn) waitResponseBody(callSerial uint32, handlePath string) ([]byte, error) {
 	c.rw.SetDeadline(time.Now().Add(5 * time.Minute))
 	var early *dbusMsg // Response signal buffered before METHOD_RETURN
 	gotReturn := false
@@ -244,7 +331,7 @@ func (c *dbusConn) waitResponse(callSerial uint32, handlePath string) ([]string,
 				if msg.Type == dbusMsgReturn {
 					gotReturn = true
 					if early != nil {
-						return decodePortalResponse(early.Body)
+						return early.Body, nil
 					}
 				}
 			} else if msg.Type == dbusMsgSignal &&
@@ -258,7 +345,7 @@ func (c *dbusConn) waitResponse(callSerial uint32, handlePath string) ([]string,
 		if msg.Type == dbusMsgSignal &&
 			msg.Path == handlePath &&
 			msg.Member == "Response" {
-			return decodePortalResponse(msg.Body)
+			return msg.Body, nil
 		}
 	}
 }
@@ -362,6 +449,8 @@ func dbusParseHdrFields(hdrData []byte, msg *dbusMsg) {
 			}
 			if code == dbusFieldReplySerial {
 				msg.ReplyTo = v
+			} else if code == dbusFieldUnixFds {
+				msg.UnixFDs = v
 			}
 		case "g":
 			g, err := d.readSig()
@@ -452,6 +541,11 @@ func (b *msgBuf) variantStr(v string) { b.sig("s"); b.str(v) }
 // variantBool encodes a D-Bus variant v(b): signature "b" followed by the bool value.
 func (b *msgBuf) variantBool(v bool) { b.sig("b"); b.bool32(v) }
 
+// variantU32 encodes a D-Bus variant v(u): signature "u" followed by the
+// unsigned 32-bit value.  The Print portal returns its prepared settings token
+// in this form and accepts it on the subsequent Print call.
+func (b *msgBuf) variantU32(v uint32) { b.sig("u"); b.u32(v) }
+
 // variantByteArray encodes a D-Bus variant v(ay): signature "ay" followed by the byte slice.
 func (b *msgBuf) variantByteArray(v []byte) {
 	b.sig("ay")
@@ -507,6 +601,14 @@ func dbusAssembleMsg(msgType, flags byte, serial uint32, hdrBytes, body []byte) 
 // The fixed 16-byte header, variable header fields, 8-byte-boundary padding,
 // and body are concatenated into a single slice ready to write to the socket.
 func dbusEncodeMsg(msgType byte, serial uint32, dest, path, iface, member, bodySig string, body []byte) []byte {
+	return dbusEncodeMsgWithFDs(msgType, serial, dest, path, iface, member, bodySig, body, 0)
+}
+
+// dbusEncodeMsgWithFDs is dbusEncodeMsg with an optional UNIX_FDS header field.
+// The descriptors themselves are attached by sendCallWithFDs; this function
+// only emits the D-Bus metadata required for the receiver to interpret `h`
+// values in the body.
+func dbusEncodeMsgWithFDs(msgType byte, serial uint32, dest, path, iface, member, bodySig string, body []byte, unixFDCount uint32) []byte {
 	hdr := newMsgBuf(16) // header fields start at absolute offset 16
 	dbusWriteHdrField(hdr, dbusFieldPath, "o", func() { hdr.str(path) })
 	if iface != "" {
@@ -516,6 +618,9 @@ func dbusEncodeMsg(msgType byte, serial uint32, dest, path, iface, member, bodyS
 	dbusWriteHdrField(hdr, dbusFieldDest, "s", func() { hdr.str(dest) })
 	if bodySig != "" {
 		dbusWriteHdrField(hdr, dbusFieldSignature, "g", func() { hdr.sig(bodySig) })
+	}
+	if unixFDCount > 0 {
+		dbusWriteHdrField(hdr, dbusFieldUnixFds, "u", func() { hdr.u32(unixFDCount) })
 	}
 	return dbusAssembleMsg(msgType, 0, serial, hdr.data, body)
 }

--- a/internal/platform/dbus_linux.go
+++ b/internal/platform/dbus_linux.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -88,9 +89,10 @@ type dbusMsg struct {
 // dbusConn is a D-Bus session bus connection that has completed SASL auth and
 // the Hello handshake.  Close rw when done.
 type dbusConn struct {
-	rw     net.Conn
-	serial uint32
-	name   string // unique bus name assigned by Hello (e.g. ":1.42")
+	rw      net.Conn
+	serial  uint32
+	name    string     // unique bus name assigned by Hello (e.g. ":1.42")
+	writeMu sync.Mutex // serializes complete D-Bus writes and serial allocation
 }
 
 // dbusConnect opens the session bus socket, performs SASL EXTERNAL authentication,
@@ -122,6 +124,20 @@ func dbusConnectContext(ctx context.Context) (*dbusConn, error) {
 		raw.Close()
 		return nil, err
 	}
+	// Authentication and Hello are synchronous wire exchanges.  Close the
+	// socket from a short-lived watcher when the caller cancels so either phase
+	// returns promptly instead of waiting for its five-second deadline.
+	stopCancel := make(chan struct{})
+	if done := ctx.Done(); done != nil {
+		go func() {
+			select {
+			case <-done:
+				_ = raw.Close()
+			case <-stopCancel:
+			}
+		}()
+	}
+	defer close(stopCancel)
 	// auth() has no context parameter because it is also used by the existing
 	// file chooser path.  A bounded socket deadline keeps this setup phase
 	// cancellable in practice while the dial itself observes ctx directly.
@@ -263,11 +279,46 @@ func (c *dbusConn) sendCall(dest, path, iface, member, sig string, body []byte) 
 	return c.sendCallWithFDs(dest, path, iface, member, sig, body, nil)
 }
 
+// sendCallContext makes the setup-phase method call interruptible.  A portal
+// connection is not handed to a PrintJob until PreparePrint has been written,
+// so there is no cancellation watcher that can close a blocked write yet.  On
+// context cancellation, closing the socket unblocks the writer and prevents a
+// request that cannot be tracked from outliving its temporary document.
+func (c *dbusConn) sendCallContext(ctx context.Context, dest, path, iface, member, sig string, body []byte) (uint32, error) {
+	if ctx == nil {
+		return c.sendCall(dest, path, iface, member, sig, body)
+	}
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
+	type result struct {
+		serial uint32
+		err    error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		serial, err := c.sendCall(dest, path, iface, member, sig, body)
+		resultCh <- result{serial: serial, err: err}
+	}()
+	select {
+	case result := <-resultCh:
+		return result.serial, result.err
+	case <-ctx.Done():
+		_ = c.rw.Close()
+		return 0, ctx.Err()
+	}
+}
+
 // sendCallWithFDs is sendCall with optional Unix file descriptors attached via
 // SCM_RIGHTS.  D-Bus represents each descriptor in the body as an `h` value
 // containing its zero-based index and announces the count in the UNIX_FDS
 // header field.  The portal Print API uses this to receive the document.
 func (c *dbusConn) sendCallWithFDs(dest, path, iface, member, sig string, body []byte, fds []int) (uint32, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 	c.serial++
 	raw := dbusEncodeMsgWithFDs(dbusMsgCall, c.serial, dest, path, iface, member, sig, body, uint32(len(fds)))
 	var err error
@@ -289,6 +340,34 @@ func (c *dbusConn) sendCallWithFDs(dest, path, iface, member, sig string, body [
 		}
 	}
 	return c.serial, err
+}
+
+// closeRequest asks the portal to end a user interaction.  Cancellation also
+// closes the session socket, which is the fallback when a concurrent write is
+// in progress; TryLock keeps the cancellation path from waiting behind a
+// blocked D-Bus write that the socket close is about to interrupt.
+func (c *dbusConn) closeRequest(handlePath string) {
+	if c == nil || c.rw == nil || handlePath == "" || !c.writeMu.TryLock() {
+		return
+	}
+	defer c.writeMu.Unlock()
+	c.serial++
+	raw := dbusEncodeMsg(
+		dbusMsgCall,
+		c.serial,
+		"org.freedesktop.portal.Desktop",
+		handlePath,
+		"org.freedesktop.portal.Request",
+		"Close",
+		"",
+		nil,
+	)
+	// Never let cancellation wait indefinitely for a portal socket reader.  A
+	// subsequent connection close still aborts the request when this best-effort
+	// Close call cannot be delivered.
+	_ = c.rw.SetWriteDeadline(time.Now().Add(100 * time.Millisecond))
+	_, _ = c.rw.Write(raw)
+	_ = c.rw.SetWriteDeadline(time.Time{})
 }
 
 // waitResponse reads incoming messages and waits in two stages:

--- a/internal/platform/print.go
+++ b/internal/platform/print.go
@@ -1,6 +1,15 @@
 package platform
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrPrintUnavailable means that the selected native print service is not
+// available in the current process/session.  The public App.Print boundary
+// maps this setup condition to gogpu.ErrPrintUnsupported while preserving
+// backend detail for direct platform callers.
+var ErrPrintUnavailable = errors.New("gogpu: native printing unavailable")
 
 // PrintDocument is the platform-layer representation of a complete document.
 // The app layer copies Data before passing a request to an asynchronous

--- a/internal/platform/print.go
+++ b/internal/platform/print.go
@@ -1,0 +1,56 @@
+package platform
+
+import "context"
+
+// PrintDocument is the platform-layer representation of a complete document.
+// The app layer copies Data before passing a request to an asynchronous
+// backend, so implementations own the request bytes for the duration of a
+// PrintJob.
+type PrintDocument struct {
+	Name     string
+	MIMEType string
+	Data     []byte
+}
+
+// PrintPageRange is an inclusive, one-based page range.
+type PrintPageRange struct {
+	From int
+	To   int
+}
+
+// PrintOptions describes native UI ownership and document settings.
+type PrintOptions struct {
+	// Parent identifies the owning platform window. Zero means the application
+	// parent when there is no primary window ID available.
+	Parent WindowID
+	Title  string
+	// PageRanges is empty for all pages; ranges are inclusive and one-based.
+	PageRanges []PrintPageRange
+	// Copies is zero for the platform default (one copy).
+	Copies int
+}
+
+// PrintRequest is the immutable request accepted by a native print backend.
+type PrintRequest struct {
+	Document PrintDocument
+	Options  PrintOptions
+}
+
+// PrintJob is an asynchronous native print operation. Done receives exactly
+// one terminal error and then closes: nil means success, context.Canceled
+// means cancellation, and any other error means a platform/spool failure.
+type PrintJob interface {
+	Done() <-chan error
+	Cancel()
+}
+
+// PrintManager is an optional PlatformManager capability. It is deliberately
+// separate from PlatformManager so existing platform implementations remain
+// source-compatible until their native print backend is ready.
+//
+// Implementations must honor ctx cancellation, keep the parent relationship
+// for the lifetime of the native operation, and release all native resources
+// before sending the terminal value on PrintJob.Done.
+type PrintManager interface {
+	StartPrint(ctx context.Context, request PrintRequest) (PrintJob, error)
+}

--- a/internal/platform/print_darwin.go
+++ b/internal/platform/print_darwin.go
@@ -11,9 +11,6 @@ import (
 )
 
 var (
-	// ErrPrintUnavailable means the AppKit application has not been initialized
-	// (or was already torn down) when a print request arrived.
-	ErrPrintUnavailable = errors.New("gogpu: macOS print backend unavailable")
 	// ErrPrintUnsupportedMIME means this backend cannot consume the submitted
 	// document format. PDFKit is the first native format supported by P1M.
 	ErrPrintUnsupportedMIME = errors.New("gogpu: macOS print backend unsupported document type")
@@ -27,6 +24,8 @@ var (
 	// public App.Print validator.
 	ErrPrintInvalidOptions = errors.New("gogpu: macOS print options invalid")
 )
+
+const darwinPrintMIMETypePDF = "application/pdf"
 
 var _ PrintManager = (*darwinPlatform)(nil)
 
@@ -44,7 +43,7 @@ func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if request.Document.MIMEType != "application/pdf" {
+	if request.Document.MIMEType != darwinPrintMIMETypePDF {
 		return nil, fmt.Errorf("%w: %q", ErrPrintUnsupportedMIME, request.Document.MIMEType)
 	}
 	if len(request.Document.Data) == 0 {
@@ -94,7 +93,7 @@ func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (
 	if darwin.IsMainThread() {
 		setup()
 	} else if err := darwin.PerformOnMain(setup, true); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrPrintUnavailable, err)
+		return nil, fmt.Errorf("%w: %w", ErrPrintUnavailable, err)
 	}
 	if setupErr != nil {
 		return nil, setupErr
@@ -135,7 +134,7 @@ func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (
 	}
 	if err := darwin.PerformOnMain(run, false); err != nil {
 		handle.Close()
-		return nil, fmt.Errorf("%w: %v", ErrPrintUnavailable, err)
+		return nil, fmt.Errorf("%w: %w", ErrPrintUnavailable, err)
 	}
 	watchPrintContext(ctx, job)
 	return job, nil
@@ -165,7 +164,7 @@ func (p *darwinPlatform) printParent(parent WindowID) (darwin.ID, error) {
 		if p.primary == nil || p.primary.window == nil {
 			// nil docWindow requests an application-modal print panel, which is
 			// valid when a caller submits a document before creating a window.
-			return 0, nil
+			return 0, nil //nolint:nilnil // zero parent intentionally requests an application-modal panel.
 		}
 		return p.primary.window.NSID(), nil
 	}

--- a/internal/platform/print_darwin.go
+++ b/internal/platform/print_darwin.go
@@ -74,7 +74,16 @@ func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (
 		setupErr error
 	)
 	setup := func() {
-		parent, setupErr = p.printParent(request.Options.Parent)
+		// Retain the parent while setup crosses the platform lock boundary. A
+		// window may be destroyed concurrently after printParent returns; the
+		// temporary retain keeps the NSWindow alive until NewPrintHandle has
+		// installed its own lifetime retain.
+		p.mu.RLock()
+		parent, setupErr = p.printParentLocked(request.Options.Parent)
+		if setupErr == nil && parent != 0 {
+			parent.Send(darwin.RegisterSelector("retain"))
+		}
+		p.mu.RUnlock()
 		if setupErr != nil {
 			return
 		}
@@ -85,6 +94,11 @@ func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (
 			Copies:     request.Options.Copies,
 			PageRanges: toDarwinPrintRanges(request.Options.PageRanges),
 		}, parent)
+		if parent != 0 {
+			// NewPrintHandle retains the parent for the asynchronous operation;
+			// release only the lookup retain above, including on setup errors.
+			parent.Send(darwin.RegisterSelector("release"))
+		}
 	}
 
 	// AppKit's main-thread check is cheap and avoids a needless selector hop
@@ -101,6 +115,10 @@ func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (
 	if handle == nil {
 		return nil, ErrPrintUnavailable
 	}
+	if err := ctx.Err(); err != nil {
+		handle.Close()
+		return nil, err
+	}
 
 	job.setCancel(func() {
 		// NSPPrintOperation has no public cancel method. Sending cancel: to its
@@ -109,9 +127,14 @@ func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (
 		// the caller's cancellation request to context.Canceled.
 		_ = darwin.PerformOnMain(handle.Cancel, false)
 	})
+	// Install the context watcher before queueing Run.  Otherwise a context
+	// that is canceled while the asynchronous main-thread invocation is still
+	// pending can miss the pre-start cancellation check and launch a panel
+	// after the caller has already withdrawn the request.
+	watchPrintContext(ctx, job)
 
 	run := func() {
-		if job.canceled() {
+		if ctx.Err() != nil || job.canceled() {
 			handle.Close()
 			job.complete(context.Canceled)
 			return
@@ -134,9 +157,9 @@ func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (
 	}
 	if err := darwin.PerformOnMain(run, false); err != nil {
 		handle.Close()
+		job.complete(fmt.Errorf("%w: %w", ErrPrintUnavailable, err))
 		return nil, fmt.Errorf("%w: %w", ErrPrintUnavailable, err)
 	}
-	watchPrintContext(ctx, job)
 	return job, nil
 }
 
@@ -157,6 +180,13 @@ func (p *darwinPlatform) printParent(parent WindowID) (darwin.ID, error) {
 	}
 	p.mu.RLock()
 	defer p.mu.RUnlock()
+	return p.printParentLocked(parent)
+}
+
+func (p *darwinPlatform) printParentLocked(parent WindowID) (darwin.ID, error) {
+	if p == nil {
+		return 0, ErrPrintUnavailable
+	}
 	if p.app == nil || !p.app.IsInitialized() {
 		return 0, ErrPrintUnavailable
 	}
@@ -166,11 +196,19 @@ func (p *darwinPlatform) printParent(parent WindowID) (darwin.ID, error) {
 			// valid when a caller submits a document before creating a window.
 			return 0, nil //nolint:nilnil // zero parent intentionally requests an application-modal panel.
 		}
-		return p.primary.window.NSID(), nil
+		id := p.primary.window.NSWindow()
+		if id == 0 {
+			return 0, fmt.Errorf("%w: primary window has no NSWindow", ErrPrintParentUnavailable)
+		}
+		return id, nil
 	}
 	for _, w := range p.windows {
 		if w != nil && w.id == parent && w.window != nil {
-			return w.window.NSID(), nil
+			id := w.window.NSWindow()
+			if id == 0 {
+				return 0, fmt.Errorf("%w: window %d has no NSWindow", ErrPrintParentUnavailable, parent)
+			}
+			return id, nil
 		}
 	}
 	return 0, fmt.Errorf("%w: %d", ErrPrintParentUnavailable, parent)

--- a/internal/platform/print_darwin.go
+++ b/internal/platform/print_darwin.go
@@ -1,0 +1,178 @@
+//go:build darwin
+
+package platform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gogpu/gogpu/internal/platform/darwin"
+)
+
+var (
+	// ErrPrintUnavailable means the AppKit application has not been initialized
+	// (or was already torn down) when a print request arrived.
+	ErrPrintUnavailable = errors.New("gogpu: macOS print backend unavailable")
+	// ErrPrintUnsupportedMIME means this backend cannot consume the submitted
+	// document format. PDFKit is the first native format supported by P1M.
+	ErrPrintUnsupportedMIME = errors.New("gogpu: macOS print backend unsupported document type")
+	// ErrPrintInvalidDocument means the accepted document payload is empty or
+	// otherwise cannot be handed to PDFKit.
+	ErrPrintInvalidDocument = errors.New("gogpu: macOS print document invalid")
+	// ErrPrintParentUnavailable means a non-zero parent WindowID no longer maps
+	// to a live macOS window owned by this platform manager.
+	ErrPrintParentUnavailable = errors.New("gogpu: macOS print parent unavailable")
+	// ErrPrintInvalidOptions protects direct internal callers that bypass the
+	// public App.Print validator.
+	ErrPrintInvalidOptions = errors.New("gogpu: macOS print options invalid")
+)
+
+var _ PrintManager = (*darwinPlatform)(nil)
+
+// StartPrint implements the optional macOS native print capability. PDFKit
+// consumes the caller-supplied complete PDF and creates an NSPrintOperation;
+// AppKit owns the print panel and spooling lifecycle. Setup is performed on
+// the main thread synchronously so malformed documents and missing native
+// objects are returned as acceptance errors. The modal operation itself is
+// queued asynchronously, allowing the caller to receive a PrintJob before the
+// panel is dismissed.
+func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (PrintJob, error) {
+	if ctx == nil {
+		return nil, context.Canceled
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if request.Document.MIMEType != "application/pdf" {
+		return nil, fmt.Errorf("%w: %q", ErrPrintUnsupportedMIME, request.Document.MIMEType)
+	}
+	if len(request.Document.Data) == 0 {
+		return nil, fmt.Errorf("%w: empty document", ErrPrintInvalidDocument)
+	}
+	if request.Options.Copies < 0 {
+		return nil, fmt.Errorf("%w: negative copies", ErrPrintInvalidOptions)
+	}
+	for _, r := range request.Options.PageRanges {
+		if r.From <= 0 || r.To < r.From {
+			return nil, fmt.Errorf("%w: page range %d-%d", ErrPrintInvalidOptions, r.From, r.To)
+		}
+	}
+	if p == nil {
+		return nil, ErrPrintUnavailable
+	}
+	p.mu.RLock()
+	app := p.app
+	p.mu.RUnlock()
+	if app == nil || !app.IsInitialized() {
+		return nil, ErrPrintUnavailable
+	}
+
+	job := newPrintJob()
+	var (
+		parent   darwin.ID
+		handle   *darwin.PrintHandle
+		setupErr error
+	)
+	setup := func() {
+		parent, setupErr = p.printParent(request.Options.Parent)
+		if setupErr != nil {
+			return
+		}
+		handle, setupErr = darwin.NewPrintHandle(darwin.PrintRequest{
+			Name:       request.Document.Name,
+			Data:       request.Document.Data,
+			Title:      request.Options.Title,
+			Copies:     request.Options.Copies,
+			PageRanges: toDarwinPrintRanges(request.Options.PageRanges),
+		}, parent)
+	}
+
+	// AppKit's main-thread check is cheap and avoids a needless selector hop
+	// from normal App.Print calls made inside OnUpdate/OnDraw. Background callers
+	// wait only for setup; the actual modal operation is always asynchronous.
+	if darwin.IsMainThread() {
+		setup()
+	} else if err := darwin.PerformOnMain(setup, true); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrPrintUnavailable, err)
+	}
+	if setupErr != nil {
+		return nil, setupErr
+	}
+	if handle == nil {
+		return nil, ErrPrintUnavailable
+	}
+
+	job.setCancel(func() {
+		// NSPPrintOperation has no public cancel method. Sending cancel: to its
+		// panel is the documented AppKit action and is safe only on the main
+		// thread. If the panel is already gone, the terminal callback still maps
+		// the caller's cancellation request to context.Canceled.
+		_ = darwin.PerformOnMain(handle.Cancel, false)
+	})
+
+	run := func() {
+		if job.canceled() {
+			handle.Close()
+			job.complete(context.Canceled)
+			return
+		}
+		if err := handle.Run(func(success bool) {
+			handle.Close()
+			if success {
+				job.complete(nil)
+				return
+			}
+			// NSPrintOperation reports false for either user cancellation or a
+			// native/spool failure. AppKit does not expose a separate terminal
+			// error for this API; false is therefore the native cancellation
+			// boundary required by the backend-neutral contract.
+			job.complete(context.Canceled)
+		}); err != nil {
+			handle.Close()
+			job.complete(err)
+		}
+	}
+	if err := darwin.PerformOnMain(run, false); err != nil {
+		handle.Close()
+		return nil, fmt.Errorf("%w: %v", ErrPrintUnavailable, err)
+	}
+	watchPrintContext(ctx, job)
+	return job, nil
+}
+
+func toDarwinPrintRanges(ranges []PrintPageRange) []darwin.PrintPageRange {
+	if len(ranges) == 0 {
+		return nil
+	}
+	out := make([]darwin.PrintPageRange, len(ranges))
+	for i, r := range ranges {
+		out[i] = darwin.PrintPageRange{From: r.From, To: r.To}
+	}
+	return out
+}
+
+func (p *darwinPlatform) printParent(parent WindowID) (darwin.ID, error) {
+	if p == nil {
+		return 0, ErrPrintUnavailable
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.app == nil || !p.app.IsInitialized() {
+		return 0, ErrPrintUnavailable
+	}
+	if parent == 0 {
+		if p.primary == nil || p.primary.window == nil {
+			// nil docWindow requests an application-modal print panel, which is
+			// valid when a caller submits a document before creating a window.
+			return 0, nil
+		}
+		return p.primary.window.NSID(), nil
+	}
+	for _, w := range p.windows {
+		if w != nil && w.id == parent && w.window != nil {
+			return w.window.NSID(), nil
+		}
+	}
+	return 0, fmt.Errorf("%w: %d", ErrPrintParentUnavailable, parent)
+}

--- a/internal/platform/print_darwin_test.go
+++ b/internal/platform/print_darwin_test.go
@@ -1,0 +1,47 @@
+//go:build darwin
+
+package platform
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestDarwinStartPrintRejectsPreCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := (&darwinPlatform{}).StartPrint(ctx, PrintRequest{
+		Document: PrintDocument{MIMEType: "application/pdf", Data: []byte("pdf")},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("StartPrint() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDarwinStartPrintRejectsUnsupportedOrInvalidInputBeforeNativeSetup(t *testing.T) {
+	backend := &darwinPlatform{}
+	if _, err := backend.StartPrint(context.Background(), PrintRequest{
+		Document: PrintDocument{MIMEType: "text/plain", Data: []byte("text")},
+	}); !errors.Is(err, ErrPrintUnsupportedMIME) {
+		t.Fatalf("unsupported MIME error = %v, want ErrPrintUnsupportedMIME", err)
+	}
+	if _, err := backend.StartPrint(context.Background(), PrintRequest{
+		Document: PrintDocument{MIMEType: "application/pdf", Data: []byte("pdf")},
+		Options:  PrintOptions{PageRanges: []PrintPageRange{{From: 0, To: 1}}},
+	}); !errors.Is(err, ErrPrintInvalidOptions) {
+		t.Fatalf("invalid range error = %v, want ErrPrintInvalidOptions", err)
+	}
+}
+
+func TestDarwinStartPrintRejectsUnavailableParentWithoutCreatingJob(t *testing.T) {
+	job, err := (&darwinPlatform{}).StartPrint(context.Background(), PrintRequest{
+		Document: PrintDocument{MIMEType: "application/pdf", Data: []byte("pdf")},
+	})
+	if job != nil {
+		t.Fatal("unavailable backend returned a PrintJob")
+	}
+	if !errors.Is(err, ErrPrintUnavailable) {
+		t.Fatalf("unavailable backend error = %v, want ErrPrintUnavailable", err)
+	}
+}

--- a/internal/platform/print_job.go
+++ b/internal/platform/print_job.go
@@ -38,11 +38,13 @@ func (j *printJob) setCancel(fn func()) {
 		return
 	}
 	j.cancelFn = fn
-	canceled := j.cancelRequested
-	j.mu.Unlock()
-	if canceled && fn != nil {
+	if j.cancelRequested && fn != nil {
+		// Keep the lifecycle lock held while running a late-installed hook.  A
+		// concurrent completion must not publish Done (and release the native
+		// handle) before this hook has finished touching it.
 		fn()
 	}
+	j.mu.Unlock()
 }
 
 // clearCancel removes the native cancellation hook once the backend has
@@ -63,10 +65,13 @@ func (j *printJob) Cancel() {
 	}
 	j.cancelRequested = true
 	fn := j.cancelFn
-	j.mu.Unlock()
 	if fn != nil {
+		// Cancellation hooks are bounded native abort/close calls. Serialize them
+		// with completion so a hook cannot run after the backend has released and
+		// possibly recycled its native resource.
 		fn()
 	}
+	j.mu.Unlock()
 }
 
 func (j *printJob) canceled() bool {

--- a/internal/platform/print_job.go
+++ b/internal/platform/print_job.go
@@ -1,0 +1,101 @@
+package platform
+
+import (
+	"context"
+	"sync"
+)
+
+// printJob is the backend-independent lifecycle half of a native print job.
+// Platform implementations provide the cancellation hook and call complete
+// only after their native operation has released all retained resources.
+// Keeping this state machine in a common file makes cancellation and exactly
+// one terminal Done value deterministic on every platform.
+type printJob struct {
+	done     chan error
+	finished chan struct{}
+
+	mu              sync.Mutex
+	terminal        bool
+	cancelRequested bool
+	cancelFn        func()
+}
+
+func newPrintJob() *printJob {
+	return &printJob{
+		done:     make(chan error, 1),
+		finished: make(chan struct{}),
+	}
+}
+
+func (j *printJob) Done() <-chan error { return j.done }
+
+// setCancel installs the native cancellation hook. If cancellation won the
+// race with native setup, the hook is invoked immediately after installation.
+func (j *printJob) setCancel(fn func()) {
+	j.mu.Lock()
+	if j.terminal {
+		j.mu.Unlock()
+		return
+	}
+	j.cancelFn = fn
+	canceled := j.cancelRequested
+	j.mu.Unlock()
+	if canceled && fn != nil {
+		fn()
+	}
+}
+
+func (j *printJob) Cancel() {
+	j.mu.Lock()
+	if j.terminal || j.cancelRequested {
+		j.mu.Unlock()
+		return
+	}
+	j.cancelRequested = true
+	fn := j.cancelFn
+	j.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+func (j *printJob) canceled() bool {
+	j.mu.Lock()
+	canceled := j.cancelRequested
+	j.mu.Unlock()
+	return canceled
+}
+
+// complete publishes exactly one terminal result and closes Done. A caller
+// cancellation always wins over a concurrent native success callback.
+func (j *printJob) complete(err error) {
+	j.mu.Lock()
+	if j.terminal {
+		j.mu.Unlock()
+		return
+	}
+	if j.cancelRequested {
+		err = context.Canceled
+	}
+	j.terminal = true
+	j.done <- err
+	close(j.done)
+	close(j.finished)
+	j.mu.Unlock()
+}
+
+// watchPrintContext turns context cancellation into the same idempotent
+// native cancellation path as PrintJob.Cancel. The watcher exits once the
+// backend has published its terminal result.
+func watchPrintContext(ctx context.Context, job *printJob) {
+	if ctx == nil {
+		return
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			job.Cancel()
+		case <-job.finished:
+		}
+	}()
+}

--- a/internal/platform/print_job.go
+++ b/internal/platform/print_job.go
@@ -45,6 +45,16 @@ func (j *printJob) setCancel(fn func()) {
 	}
 }
 
+// clearCancel removes the native cancellation hook once the backend has
+// released the resource it protects.  A terminal job ignores later Cancel
+// calls, but clearing the hook before completion also prevents a concurrent
+// cancellation from touching a recycled native handle during cleanup.
+func (j *printJob) clearCancel() {
+	j.mu.Lock()
+	j.cancelFn = nil
+	j.mu.Unlock()
+}
+
 func (j *printJob) Cancel() {
 	j.mu.Lock()
 	if j.terminal || j.cancelRequested {

--- a/internal/platform/print_job_test.go
+++ b/internal/platform/print_job_test.go
@@ -1,0 +1,107 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPrintJobCancelIsIdempotentAndTerminal(t *testing.T) {
+	job := newPrintJob()
+	var calls atomic.Int32
+	job.setCancel(func() { calls.Add(1) })
+
+	job.Cancel()
+	job.Cancel()
+	job.complete(errors.New("native success raced cancellation"))
+
+	if got := <-job.Done(); !errors.Is(got, context.Canceled) {
+		t.Fatalf("Done() = %v, want context.Canceled", got)
+	}
+	if _, open := <-job.Done(); open {
+		t.Fatal("Done channel should close after one terminal value")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("cancel hook calls = %d, want 1", got)
+	}
+}
+
+func TestPrintJobCompletionWinsBeforeCancellation(t *testing.T) {
+	job := newPrintJob()
+	var calls atomic.Int32
+	job.setCancel(func() { calls.Add(1) })
+	job.complete(nil)
+	job.Cancel()
+
+	if got := <-job.Done(); got != nil {
+		t.Fatalf("Done() = %v, want nil", got)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("cancel hook calls = %d, want 0 after completion", got)
+	}
+}
+
+func TestPrintJobCancellationBeforeNativeHook(t *testing.T) {
+	job := newPrintJob()
+	job.Cancel()
+	called := make(chan struct{})
+	job.setCancel(func() { close(called) })
+
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Fatal("cancel hook was not called after late installation")
+	}
+	job.complete(nil)
+	if got := <-job.Done(); !errors.Is(got, context.Canceled) {
+		t.Fatalf("Done() = %v, want context.Canceled", got)
+	}
+}
+
+func TestWatchPrintContextCancelsJob(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	job := newPrintJob()
+	hookCalled := make(chan struct{})
+	job.setCancel(func() { close(hookCalled) })
+	watchPrintContext(ctx, job)
+	cancel()
+
+	select {
+	case <-hookCalled:
+	case <-time.After(time.Second):
+		t.Fatal("context cancellation did not reach native hook")
+	}
+	job.complete(nil)
+	if got := <-job.Done(); !errors.Is(got, context.Canceled) {
+		t.Fatalf("Done() = %v, want context.Canceled", got)
+	}
+}
+
+func TestPrintJobConcurrentCancelCallsOneHook(t *testing.T) {
+	job := newPrintJob()
+	var calls atomic.Int32
+	job.setCancel(func() { calls.Add(1) })
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			job.Cancel()
+		}()
+	}
+	wg.Wait()
+	job.complete(nil)
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("cancel hook calls = %d, want 1", got)
+	}
+	if got := <-job.Done(); !errors.Is(got, context.Canceled) {
+		t.Fatalf("Done() = %v, want context.Canceled", got)
+	}
+}

--- a/internal/platform/print_job_test.go
+++ b/internal/platform/print_job_test.go
@@ -105,3 +105,41 @@ func TestPrintJobConcurrentCancelCallsOneHook(t *testing.T) {
 		t.Fatalf("Done() = %v, want context.Canceled", got)
 	}
 }
+
+func TestPrintJobCompletionWaitsForCancellationHook(t *testing.T) {
+	job := newPrintJob()
+	hookStarted := make(chan struct{})
+	releaseHook := make(chan struct{})
+	job.setCancel(func() {
+		close(hookStarted)
+		<-releaseHook
+	})
+
+	go job.Cancel()
+	select {
+	case <-hookStarted:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation hook did not start")
+	}
+
+	completed := make(chan struct{})
+	go func() {
+		job.complete(nil)
+		close(completed)
+	}()
+	select {
+	case <-completed:
+		t.Fatal("completion published while cancellation hook was still running")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseHook)
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("completion remained blocked after cancellation hook returned")
+	}
+	if got := <-job.Done(); !errors.Is(got, context.Canceled) {
+		t.Fatalf("Done() = %v, want context.Canceled", got)
+	}
+}

--- a/internal/platform/print_linux.go
+++ b/internal/platform/print_linux.go
@@ -26,7 +26,7 @@ import (
 const linuxPrintMIMETypePDF = "application/pdf"
 
 var (
-	errLinuxPrintUnsupported = errors.New("gogpu: Linux portal printing unavailable")
+	errLinuxPrintUnsupported = ErrPrintUnavailable
 	errLinuxPrintMIME        = errors.New("gogpu: Linux portal printing supports PDF documents only")
 )
 
@@ -199,7 +199,7 @@ func startLinuxPortalPrint(ctx context.Context, request PrintRequest, parent str
 	}
 
 	job := &linuxPrintJob{
-		done:          make(chan error, 1),
+		printJob:      newPrintJob(),
 		ctx:           operationCtx,
 		cancel:        cancel,
 		conn:          conn,
@@ -208,9 +208,12 @@ func startLinuxPortalPrint(ctx context.Context, request PrintRequest, parent str
 		preparePath:   dbusHandlePath(conn.name, prepareToken),
 		parent:        parent,
 		title:         request.Options.Title,
-		watchDone:     make(chan struct{}),
 	}
-	go job.watchCancellation()
+	job.setCancel(func() {
+		cancel()
+		job.closeConn()
+	})
+	watchPrintContext(ctx, job.printJob)
 	go job.run()
 	return job, nil
 }
@@ -258,14 +261,13 @@ func closeLinuxPrintDocument(f *os.File) {
 }
 
 type linuxPrintJob struct {
-	done   chan error
+	*printJob
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	mu        sync.Mutex
-	conn      *dbusConn
-	document  *os.File
-	watchDone chan struct{}
+	mu       sync.Mutex
+	conn     *dbusConn
+	document *os.File
 
 	prepareSerial uint32
 	preparePath   string
@@ -273,19 +275,6 @@ type linuxPrintJob struct {
 	title         string
 
 	finishOnce sync.Once
-	watchOnce  sync.Once
-}
-
-func (j *linuxPrintJob) Done() <-chan error { return j.done }
-
-// Cancel is idempotent.  Closing the D-Bus socket interrupts a blocked portal
-// response read; the run goroutine then performs resource cleanup before
-// publishing context.Canceled on Done.
-func (j *linuxPrintJob) Cancel() {
-	if j.cancel != nil {
-		j.cancel()
-	}
-	j.closeConn()
 }
 
 func (j *linuxPrintJob) closeConn() {
@@ -294,14 +283,6 @@ func (j *linuxPrintJob) closeConn() {
 	j.mu.Unlock()
 	if conn != nil && conn.rw != nil {
 		_ = conn.rw.Close()
-	}
-}
-
-func (j *linuxPrintJob) watchCancellation() {
-	select {
-	case <-j.ctx.Done():
-		j.closeConn()
-	case <-j.watchDone:
 	}
 }
 
@@ -367,7 +348,6 @@ func (j *linuxPrintJob) contextualError(err error) error {
 
 func (j *linuxPrintJob) finish(err error) {
 	j.finishOnce.Do(func() {
-		j.watchOnce.Do(func() { close(j.watchDone) })
 		j.mu.Lock()
 		conn := j.conn
 		document := j.document
@@ -381,8 +361,8 @@ func (j *linuxPrintJob) finish(err error) {
 		if j.cancel != nil {
 			j.cancel()
 		}
-		j.done <- err
-		close(j.done)
+		j.clearCancel()
+		j.complete(err)
 	})
 }
 

--- a/internal/platform/print_linux.go
+++ b/internal/platform/print_linux.go
@@ -175,7 +175,7 @@ func startLinuxPortalPrint(ctx context.Context, request PrintRequest, parent str
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		return nil, fmt.Errorf("%w: connect session bus: %v", errLinuxPrintUnsupported, err)
+		return nil, fmt.Errorf("%w: connect session bus: %w", errLinuxPrintUnsupported, err)
 	}
 
 	prepareToken := dbusNewToken()
@@ -195,7 +195,7 @@ func startLinuxPortalPrint(ctx context.Context, request PrintRequest, parent str
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		return nil, fmt.Errorf("%w: send PreparePrint: %v", errLinuxPrintUnsupported, err)
+		return nil, fmt.Errorf("%w: send PreparePrint: %w", errLinuxPrintUnsupported, err)
 	}
 
 	job := &linuxPrintJob{

--- a/internal/platform/print_linux.go
+++ b/internal/platform/print_linux.go
@@ -1,0 +1,557 @@
+//go:build linux
+
+package platform
+
+// Linux native printing through xdg-desktop-portal.
+//
+// The portal print protocol is intentionally kept in this file instead of
+// pulling in a D-Bus dependency.  StartPrint performs the short setup phase
+// synchronously (session-bus connection and PreparePrint method call), then a
+// job goroutine waits for the user's response, submits the caller-owned PDF via
+// a temporary read-only file descriptor, and waits for the terminal response.
+// A temporary file remains open until the Print request's response arrives;
+// this is required because the portal may read the descriptor asynchronously.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const linuxPrintMIMETypePDF = "application/pdf"
+
+var (
+	errLinuxPrintUnsupported = errors.New("gogpu: Linux portal printing unavailable")
+	errLinuxPrintMIME        = errors.New("gogpu: Linux portal printing supports PDF documents only")
+)
+
+// StartPrint implements PrintManager for X11.  The X11 XID is the portal's
+// parent-window token; an empty parent is used when the app has no window yet.
+func (p *x11Platform) StartPrint(ctx context.Context, request PrintRequest) (PrintJob, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+	parent, err := p.printParentWindow(request.Options.Parent)
+	if err != nil {
+		return nil, err
+	}
+	return startLinuxPortalPrint(ctx, request, parent)
+}
+
+// StartPrint implements PrintManager for Wayland.  This backend does not own
+// an xdg-foreign exporter, so a valid parent window is intentionally passed as
+// an empty portal identifier.  xdg-desktop-portal specifies that empty
+// parent_window is valid when no suitable xdg-foreign handle is available.
+func (p *waylandPlatform) StartPrint(ctx context.Context, request PrintRequest) (PrintJob, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+	parent, err := p.printParentWindow(request.Options.Parent)
+	if err != nil {
+		return nil, err
+	}
+	return startLinuxPortalPrint(ctx, request, parent)
+}
+
+var (
+	_ PrintManager = (*x11Platform)(nil)
+	_ PrintManager = (*waylandPlatform)(nil)
+)
+
+func (p *x11Platform) printParentWindow(id WindowID) (string, error) {
+	if p == nil || p.inner == nil {
+		if id == 0 {
+			return "", nil
+		}
+		return "", fmt.Errorf("x11: parent window %d is unavailable", id)
+	}
+	if id == 0 {
+		id = p.primaryWindowID
+	}
+	if id == 0 {
+		return "", nil
+	}
+	if id == p.primaryWindowID {
+		_, xid := p.inner.GetHandle()
+		if xid == 0 {
+			return "", fmt.Errorf("x11: parent window %d has no XID", id)
+		}
+		return "x11:" + strconv.FormatUint(uint64(xid), 16), nil
+	}
+
+	p.secondaryMu.RLock()
+	defer p.secondaryMu.RUnlock()
+	for _, sec := range p.secondaries {
+		if sec.winID != id || sec.platform == nil {
+			continue
+		}
+		_, xid := sec.platform.GetHandle()
+		if xid == 0 {
+			return "", fmt.Errorf("x11: parent window %d has no XID", id)
+		}
+		return "x11:" + strconv.FormatUint(uint64(xid), 16), nil
+	}
+	return "", fmt.Errorf("x11: parent window %d is unknown", id)
+}
+
+func (p *waylandPlatform) printParentWindow(id WindowID) (string, error) {
+	if p == nil {
+		if id == 0 {
+			return "", nil
+		}
+		return "", fmt.Errorf("wayland: parent window %d is unavailable", id)
+	}
+	if id == 0 {
+		id = p.primaryWindowID
+	}
+	if id == 0 {
+		return "", nil
+	}
+	if id == p.primaryWindowID {
+		if p.libwl == nil || p.libwl.Surface() == 0 {
+			return "", fmt.Errorf("wayland: parent window %d is unavailable", id)
+		}
+		return "", nil
+	}
+
+	p.secondaryMu.RLock()
+	defer p.secondaryMu.RUnlock()
+	for _, sec := range p.secondaries {
+		if sec.winID == id && sec.libwl != nil && sec.libwl.Surface() != 0 {
+			return "", nil
+		}
+	}
+	return "", fmt.Errorf("wayland: parent window %d is unknown", id)
+}
+
+// startLinuxPortalPrint performs the synchronous setup portion of the portal
+// operation.  If the session bus or portal cannot be reached before a request
+// is submitted, no PrintJob is returned; callers can safely report unsupported
+// printing rather than opening a second, unrelated dialog fallback.
+func startLinuxPortalPrint(ctx context.Context, request PrintRequest, parent string) (PrintJob, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: nil context", errLinuxPrintUnsupported)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if request.Document.MIMEType != linuxPrintMIMETypePDF {
+		return nil, fmt.Errorf("%w: %q", errLinuxPrintMIME, request.Document.MIMEType)
+	}
+	if len(request.Document.Data) == 0 {
+		return nil, fmt.Errorf("%w: empty document", errLinuxPrintMIME)
+	}
+	if request.Options.Copies < 0 {
+		return nil, errors.New("print: copies must not be negative")
+	}
+	for _, r := range request.Options.PageRanges {
+		if r.From <= 0 || r.To < r.From {
+			return nil, fmt.Errorf("print: invalid page range %d-%d", r.From, r.To)
+		}
+	}
+	if os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
+		return nil, fmt.Errorf("%w: DBUS_SESSION_BUS_ADDRESS is not set", errLinuxPrintUnsupported)
+	}
+
+	document, err := createLinuxPrintDocument(request.Document.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	operationCtx, cancel := context.WithCancel(ctx)
+	conn, err := dbusConnectContext(operationCtx)
+	if err != nil {
+		cancel()
+		closeLinuxPrintDocument(document)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("%w: connect session bus: %v", errLinuxPrintUnsupported, err)
+	}
+
+	prepareToken := dbusNewToken()
+	prepareBody := encodePortalPreparePrintBody(parent, request.Options.Title, request, prepareToken)
+	prepareSerial, err := conn.sendCall(
+		"org.freedesktop.portal.Desktop",
+		"/org/freedesktop/portal/desktop",
+		"org.freedesktop.portal.Print",
+		"PreparePrint",
+		"ssa{sv}a{sv}a{sv}",
+		prepareBody,
+	)
+	if err != nil {
+		conn.rw.Close()
+		cancel()
+		closeLinuxPrintDocument(document)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("%w: send PreparePrint: %v", errLinuxPrintUnsupported, err)
+	}
+
+	job := &linuxPrintJob{
+		done:          make(chan error, 1),
+		ctx:           operationCtx,
+		cancel:        cancel,
+		conn:          conn,
+		document:      document,
+		prepareSerial: prepareSerial,
+		preparePath:   dbusHandlePath(conn.name, prepareToken),
+		parent:        parent,
+		title:         request.Options.Title,
+		watchDone:     make(chan struct{}),
+	}
+	go job.watchCancellation()
+	go job.run()
+	return job, nil
+}
+
+// createLinuxPrintDocument materializes the complete document in a private
+// temporary file.  The portal receives the open descriptor, not a path, so the
+// file remains inaccessible to unrelated users and works in sandboxes.
+func createLinuxPrintDocument(data []byte) (*os.File, error) {
+	f, err := os.CreateTemp("", "gogpu-print-*.pdf")
+	if err != nil {
+		return nil, fmt.Errorf("print: create temporary document: %w", err)
+	}
+	if err := f.Chmod(0600); err != nil {
+		closeLinuxPrintDocument(f)
+		return nil, fmt.Errorf("print: protect temporary document: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		closeLinuxPrintDocument(f)
+		return nil, fmt.Errorf("print: write temporary document: %w", err)
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		closeLinuxPrintDocument(f)
+		return nil, fmt.Errorf("print: rewind temporary document: %w", err)
+	}
+	name := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(name)
+		return nil, fmt.Errorf("print: close writable temporary document: %w", err)
+	}
+	readOnly, err := os.Open(name)
+	if err != nil {
+		_ = os.Remove(name)
+		return nil, fmt.Errorf("print: reopen temporary document: %w", err)
+	}
+	return readOnly, nil
+}
+
+func closeLinuxPrintDocument(f *os.File) {
+	if f == nil {
+		return
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+}
+
+type linuxPrintJob struct {
+	done   chan error
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu        sync.Mutex
+	conn      *dbusConn
+	document  *os.File
+	watchDone chan struct{}
+
+	prepareSerial uint32
+	preparePath   string
+	parent        string
+	title         string
+
+	finishOnce sync.Once
+	watchOnce  sync.Once
+}
+
+func (j *linuxPrintJob) Done() <-chan error { return j.done }
+
+// Cancel is idempotent.  Closing the D-Bus socket interrupts a blocked portal
+// response read; the run goroutine then performs resource cleanup before
+// publishing context.Canceled on Done.
+func (j *linuxPrintJob) Cancel() {
+	if j.cancel != nil {
+		j.cancel()
+	}
+	j.closeConn()
+}
+
+func (j *linuxPrintJob) closeConn() {
+	j.mu.Lock()
+	conn := j.conn
+	j.mu.Unlock()
+	if conn != nil && conn.rw != nil {
+		_ = conn.rw.Close()
+	}
+}
+
+func (j *linuxPrintJob) watchCancellation() {
+	select {
+	case <-j.ctx.Done():
+		j.closeConn()
+	case <-j.watchDone:
+	}
+}
+
+func (j *linuxPrintJob) run() {
+	defer func() {
+		if err := j.ctx.Err(); err != nil {
+			j.finish(err)
+		}
+	}()
+
+	j.mu.Lock()
+	conn := j.conn
+	document := j.document
+	prepareSerial := j.prepareSerial
+	preparePath := j.preparePath
+	j.mu.Unlock()
+
+	body, err := conn.waitResponseBody(prepareSerial, preparePath)
+	if err != nil {
+		j.finish(j.contextualError(err))
+		return
+	}
+	preparedToken, err := decodePortalPreparePrintResponse(body)
+	if err != nil {
+		j.finish(j.contextualError(err))
+		return
+	}
+	if err := j.ctx.Err(); err != nil {
+		j.finish(err)
+		return
+	}
+
+	printToken := dbusNewToken()
+	printBody := encodePortalPrintBody(j.parent, j.title, 0, printToken, preparedToken)
+	printSerial, err := conn.sendCallWithFDs(
+		"org.freedesktop.portal.Desktop",
+		"/org/freedesktop/portal/desktop",
+		"org.freedesktop.portal.Print",
+		"Print",
+		"ssha{sv}",
+		printBody,
+		[]int{int(document.Fd())},
+	)
+	if err != nil {
+		j.finish(j.contextualError(fmt.Errorf("print: send Print: %w", err)))
+		return
+	}
+	printPath := dbusHandlePath(conn.name, printToken)
+	body, err = conn.waitResponseBody(printSerial, printPath)
+	if err != nil {
+		j.finish(j.contextualError(err))
+		return
+	}
+	j.finish(j.contextualError(decodePortalPrintResponse(body)))
+}
+
+func (j *linuxPrintJob) contextualError(err error) error {
+	if ctxErr := j.ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
+}
+
+func (j *linuxPrintJob) finish(err error) {
+	j.finishOnce.Do(func() {
+		j.watchOnce.Do(func() { close(j.watchDone) })
+		j.mu.Lock()
+		conn := j.conn
+		document := j.document
+		j.conn = nil
+		j.document = nil
+		j.mu.Unlock()
+		if conn != nil && conn.rw != nil {
+			_ = conn.rw.Close()
+		}
+		closeLinuxPrintDocument(document)
+		if j.cancel != nil {
+			j.cancel()
+		}
+		j.done <- err
+		close(j.done)
+	})
+}
+
+// encodePortalPreparePrintBody produces the portal's
+// ssa{sv}a{sv}a{sv} arguments: parent, title, initial print settings, page
+// setup, and options.  Settings are hints only; PreparePrint's response token
+// is authoritative for the subsequent Print call.
+func encodePortalPreparePrintBody(parent, title string, request PrintRequest, token string) []byte {
+	b := newMsgBuf(0)
+	b.str(parent)
+	b.str(title)
+	encodePortalPrintSettings(b, request)
+	encodeEmptyPortalDict(b)
+	encodePortalDict(b, func() {
+		portalDictEntryStr(b, "handle_token", token)
+	})
+	return b.data
+}
+
+// encodePortalPrintBody produces the portal's ssha{sv} arguments.  fdIndex is
+// the descriptor index in the SCM_RIGHTS control message (always zero for the
+// single document descriptor used here).
+func encodePortalPrintBody(parent, title string, fdIndex uint32, handleToken string, preparedToken uint32) []byte {
+	b := newMsgBuf(0)
+	b.str(parent)
+	b.str(title)
+	b.u32(fdIndex) // `h`: index into the attached Unix FD array
+	encodePortalDict(b, func() {
+		portalDictEntryStr(b, "handle_token", handleToken)
+		portalDictEntryU32(b, "token", preparedToken)
+	})
+	return b.data
+}
+
+func encodePortalPrintSettings(b *msgBuf, request PrintRequest) {
+	lp, cp := b.arrayStart(8)
+	if request.Options.Copies > 0 {
+		portalDictEntryStr(b, "n-copies", strconv.Itoa(request.Options.Copies))
+	}
+	if ranges := portalPageRanges(request.Options.PageRanges); ranges != "" {
+		portalDictEntryStr(b, "print-pages", "ranges")
+		portalDictEntryStr(b, "page-ranges", ranges)
+	}
+	if name := linuxPrintOutputBasename(request.Document.Name); name != "" {
+		portalDictEntryStr(b, "output-basename", name)
+	}
+	b.arrayEnd(lp, cp)
+}
+
+// linuxPrintOutputBasename keeps the user-facing name as a safe basename for
+// the portal's print-to-file hint.  Empty, root, and dot path names carry no
+// useful basename and are omitted rather than sending an invalid hint.
+func linuxPrintOutputBasename(name string) string {
+	name = filepath.Base(name)
+	if name == "" || name == "." || name == ".." || name == string(filepath.Separator) {
+		return ""
+	}
+	return name
+}
+
+func encodeEmptyPortalDict(b *msgBuf) {
+	lp, cp := b.arrayStart(8)
+	b.arrayEnd(lp, cp)
+}
+
+func encodePortalDict(b *msgBuf, entries func()) {
+	lp, cp := b.arrayStart(8)
+	entries()
+	b.arrayEnd(lp, cp)
+}
+
+func portalDictEntryStr(b *msgBuf, key, value string) {
+	b.padTo(8)
+	b.str(key)
+	b.variantStr(value)
+}
+
+func portalDictEntryU32(b *msgBuf, key string, value uint32) {
+	b.padTo(8)
+	b.str(key)
+	b.variantU32(value)
+}
+
+// portalPageRanges translates the public one-based inclusive ranges to the
+// portal's comma-separated zero-based representation.  A one-page range is
+// emitted as a single number (rather than "n-n").
+func portalPageRanges(ranges []PrintPageRange) string {
+	if len(ranges) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(ranges))
+	for _, r := range ranges {
+		from, to := r.From-1, r.To-1
+		if from == to {
+			parts = append(parts, strconv.Itoa(from))
+		} else {
+			parts = append(parts, strconv.Itoa(from)+"-"+strconv.Itoa(to))
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+// decodePortalPreparePrintResponse extracts the token from a successful
+// ua{sv} response.  Response code 1 is the portal's user-canceled outcome and
+// is normalized to context.Canceled for PrintJob.Done.
+func decodePortalPreparePrintResponse(body []byte) (uint32, error) {
+	d := newMsgDecoder(body, 0)
+	code, err := d.readU32()
+	if err != nil {
+		return 0, fmt.Errorf("print: decode PreparePrint response code: %w", err)
+	}
+	if code == 1 {
+		return 0, context.Canceled
+	}
+	if code != 0 {
+		return 0, fmt.Errorf("print: portal PreparePrint response code %d", code)
+	}
+	arrayLen, err := d.readU32()
+	if err != nil {
+		return 0, fmt.Errorf("print: decode PreparePrint results: %w", err)
+	}
+	if err := d.alignTo(8); err != nil {
+		return 0, err
+	}
+	end := d.pos + int(arrayLen)
+	var token uint32
+	foundToken := false
+	for d.pos < end {
+		if err := d.alignTo(8); err != nil {
+			return 0, err
+		}
+		key, err := d.readStr()
+		if err != nil {
+			return 0, err
+		}
+		vsig, err := d.readSig()
+		if err != nil {
+			return 0, err
+		}
+		if key == "token" && vsig == "u" {
+			token, err = d.readU32()
+			if err != nil {
+				return 0, err
+			}
+			foundToken = true
+			continue
+		}
+		if err := d.skipValue(vsig); err != nil {
+			return 0, err
+		}
+	}
+	if !foundToken {
+		return 0, errors.New("print: PreparePrint response did not contain a token")
+	}
+	return token, nil
+}
+
+func decodePortalPrintResponse(body []byte) error {
+	d := newMsgDecoder(body, 0)
+	code, err := d.readU32()
+	if err != nil {
+		return fmt.Errorf("print: decode Print response code: %w", err)
+	}
+	switch code {
+	case 0:
+		return nil
+	case 1:
+		return context.Canceled
+	default:
+		return fmt.Errorf("print: portal Print response code %d", code)
+	}
+}

--- a/internal/platform/print_linux.go
+++ b/internal/platform/print_linux.go
@@ -180,7 +180,7 @@ func startLinuxPortalPrint(ctx context.Context, request PrintRequest, parent str
 
 	prepareToken := dbusNewToken()
 	prepareBody := encodePortalPreparePrintBody(parent, request.Options.Title, request, prepareToken)
-	prepareSerial, err := conn.sendCall(
+	prepareSerial, err := conn.sendCallContext(operationCtx,
 		"org.freedesktop.portal.Desktop",
 		"/org/freedesktop/portal/desktop",
 		"org.freedesktop.portal.Print",
@@ -210,6 +210,7 @@ func startLinuxPortalPrint(ctx context.Context, request PrintRequest, parent str
 		title:         request.Options.Title,
 	}
 	job.setCancel(func() {
+		job.closeRequests()
 		cancel()
 		job.closeConn()
 	})
@@ -271,6 +272,7 @@ type linuxPrintJob struct {
 
 	prepareSerial uint32
 	preparePath   string
+	printPath     string
 	parent        string
 	title         string
 
@@ -283,6 +285,20 @@ func (j *linuxPrintJob) closeConn() {
 	j.mu.Unlock()
 	if conn != nil && conn.rw != nil {
 		_ = conn.rw.Close()
+	}
+}
+
+func (j *linuxPrintJob) closeRequests() {
+	j.mu.Lock()
+	conn := j.conn
+	preparePath, printPath := j.preparePath, j.printPath
+	j.mu.Unlock()
+	if conn == nil {
+		return
+	}
+	conn.closeRequest(preparePath)
+	if printPath != preparePath {
+		conn.closeRequest(printPath)
 	}
 }
 
@@ -331,6 +347,9 @@ func (j *linuxPrintJob) run() {
 		return
 	}
 	printPath := dbusHandlePath(conn.name, printToken)
+	j.mu.Lock()
+	j.printPath = printPath
+	j.mu.Unlock()
 	body, err = conn.waitResponseBody(printSerial, printPath)
 	if err != nil {
 		j.finish(j.contextualError(err))

--- a/internal/platform/print_linux_test.go
+++ b/internal/platform/print_linux_test.go
@@ -261,7 +261,7 @@ func TestDBusSendCallWithFDsPassesDescriptor(t *testing.T) {
 	if len(passed) != 1 {
 		t.Fatalf("passed descriptors = %d, want 1", len(passed))
 	}
-	defer unix.Close(passed[0])
+	_ = unix.Close(passed[0])
 }
 
 func TestDBusSendCallContextClosesBlockedSetupWrite(t *testing.T) {

--- a/internal/platform/print_linux_test.go
+++ b/internal/platform/print_linux_test.go
@@ -1,0 +1,415 @@
+//go:build linux
+
+package platform
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestPortalPageRanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		ranges []PrintPageRange
+		want   string
+	}{
+		{name: "all", want: ""},
+		{name: "single page", ranges: []PrintPageRange{{From: 1, To: 1}}, want: "0"},
+		{name: "inclusive conversion", ranges: []PrintPageRange{{From: 1, To: 3}, {From: 5, To: 5}, {From: 8, To: 9}}, want: "0-2,4,7-8"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := portalPageRanges(tt.ranges); got != tt.want {
+				t.Fatalf("portalPageRanges(%v) = %q, want %q", tt.ranges, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinuxPrintOutputBasename(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "reports/invoice.pdf", want: "invoice.pdf"},
+		{name: "", want: ""},
+		{name: ".", want: ""},
+		{name: "..", want: ""},
+		{name: "/", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := linuxPrintOutputBasename(tt.name); got != tt.want {
+				t.Fatalf("linuxPrintOutputBasename(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncodePortalPreparePrintBody(t *testing.T) {
+	request := PrintRequest{
+		Document: PrintDocument{Name: "reports/invoice.pdf", MIMEType: linuxPrintMIMETypePDF, Data: []byte("pdf")},
+		Options: PrintOptions{
+			Parent:     12,
+			Title:      "Invoice",
+			PageRanges: []PrintPageRange{{From: 2, To: 4}},
+			Copies:     2,
+		},
+	}
+	body := encodePortalPreparePrintBody("x11:2a", "Invoice", request, "gogpu_prepare")
+	d := newMsgDecoder(body, 0)
+	parent, err := d.readStr()
+	if err != nil || parent != "x11:2a" {
+		t.Fatalf("parent = %q (err=%v), want x11:2a", parent, err)
+	}
+	title, err := d.readStr()
+	if err != nil || title != "Invoice" {
+		t.Fatalf("title = %q (err=%v), want Invoice", title, err)
+	}
+	settings, err := readPortalDict(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSettings := map[string]string{
+		"n-copies":        "2",
+		"print-pages":     "ranges",
+		"page-ranges":     "1-3",
+		"output-basename": "invoice.pdf",
+	}
+	if !reflect.DeepEqual(settings, wantSettings) {
+		t.Fatalf("settings = %#v, want %#v", settings, wantSettings)
+	}
+	pageSetup, err := readPortalDict(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pageSetup) != 0 {
+		t.Fatalf("page setup = %#v, want empty", pageSetup)
+	}
+	options, err := readPortalDict(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if options["handle_token"] != "gogpu_prepare" {
+		t.Fatalf("options = %#v, want handle_token", options)
+	}
+}
+
+func TestEncodePortalPrintBody(t *testing.T) {
+	body := encodePortalPrintBody("x11:2a", "Invoice", 0, "gogpu_print", 77)
+	d := newMsgDecoder(body, 0)
+	if got, _ := d.readStr(); got != "x11:2a" {
+		t.Fatalf("parent = %q, want x11:2a", got)
+	}
+	if got, _ := d.readStr(); got != "Invoice" {
+		t.Fatalf("title = %q, want Invoice", got)
+	}
+	fdIndex, err := d.readU32()
+	if err != nil || fdIndex != 0 {
+		t.Fatalf("fd index = %d (err=%v), want 0", fdIndex, err)
+	}
+	options, err := readPortalDictTyped(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if options["handle_token"] != "gogpu_print" || options["token"] != "77" {
+		t.Fatalf("options = %#v, want handle_token/token", options)
+	}
+}
+
+func TestDecodePortalPreparePrintResponse(t *testing.T) {
+	b := newMsgBuf(0)
+	b.u32(0)
+	lp, cp := b.arrayStart(8)
+	b.padTo(8)
+	b.str("settings")
+	b.variantStr("ignored")
+	b.padTo(8)
+	b.str("token")
+	b.variantU32(42)
+	b.arrayEnd(lp, cp)
+
+	token, err := decodePortalPreparePrintResponse(b.data)
+	if err != nil || token != 42 {
+		t.Fatalf("token = %d (err=%v), want 42", token, err)
+	}
+
+	canceled := newMsgBuf(0)
+	canceled.u32(1)
+	clp, ccp := canceled.arrayStart(8)
+	canceled.arrayEnd(clp, ccp)
+	if _, err := decodePortalPreparePrintResponse(canceled.data); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancel error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDecodePortalPrintResponse(t *testing.T) {
+	for _, code := range []uint32{0, 2} {
+		b := newMsgBuf(0)
+		b.u32(code)
+		err := decodePortalPrintResponse(b.data)
+		if code == 0 && err != nil {
+			t.Fatalf("success response error = %v", err)
+		}
+		if code == 2 && err == nil {
+			t.Fatal("error response unexpectedly succeeded")
+		}
+	}
+	b := newMsgBuf(0)
+	b.u32(1)
+	if err := decodePortalPrintResponse(b.data); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancel error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDBusEncodeMsgWithFDs(t *testing.T) {
+	raw := dbusEncodeMsgWithFDs(
+		dbusMsgCall, 7,
+		"org.freedesktop.portal.Desktop",
+		"/org/freedesktop/portal/desktop",
+		"org.freedesktop.portal.Print",
+		"Print",
+		"ssha{sv}",
+		[]byte{0x01, 0x02, 0x03, 0x04},
+		1,
+	)
+	if len(raw) < 16 {
+		t.Fatalf("message too short: %d", len(raw))
+	}
+	hdrLen := int(binaryLE32(raw[12:16]))
+	msg := &dbusMsg{}
+	dbusParseHdrFields(raw[16:16+hdrLen], msg)
+	if msg.Sig != "ssha{sv}" {
+		t.Fatalf("signature = %q, want ssha{sv}", msg.Sig)
+	}
+	if msg.UnixFDs != 1 {
+		t.Fatalf("UnixFDs = %d, want 1", msg.UnixFDs)
+	}
+}
+
+func TestDBusSendCallWithFDsPassesDescriptor(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "bus.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Net: "unix", Name: socketPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	client, err := net.DialUnix("unix", nil, &net.UnixAddr{Net: "unix", Name: socketPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	server, err := listener.AcceptUnix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	document, err := os.CreateTemp(t.TempDir(), "document.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer document.Close()
+	defer os.Remove(document.Name())
+
+	conn := &dbusConn{rw: client}
+	_, err = conn.sendCallWithFDs("dest", "/path", "iface", "Print", "h", []byte{0, 0, 0, 0}, []int{int(document.Fd())})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 4096)
+	oob := make([]byte, 256)
+	n, oobn, _, _, err := server.ReadMsgUnix(buf, oob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n < 16 || oobn == 0 {
+		t.Fatalf("ReadMsgUnix() = data %d, oob %d; want payload and descriptor", n, oobn)
+	}
+	msg := &dbusMsg{}
+	hdrLen := int(binaryLE32(buf[12:16]))
+	if 16+hdrLen > n {
+		t.Fatalf("message header length %d exceeds payload %d", hdrLen, n)
+	}
+	dbusParseHdrFields(buf[16:16+hdrLen], msg)
+	if msg.UnixFDs != 1 || msg.Sig != "h" {
+		t.Fatalf("message metadata = UnixFDs:%d Sig:%q, want 1/h", msg.UnixFDs, msg.Sig)
+	}
+	control, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(control) != 1 {
+		t.Fatalf("control messages = %d, want 1", len(control))
+	}
+	passed, err := unix.ParseUnixRights(&control[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(passed) != 1 {
+		t.Fatalf("passed descriptors = %d, want 1", len(passed))
+	}
+	defer unix.Close(passed[0])
+}
+
+func TestCreateLinuxPrintDocumentOwnsAndCleansFile(t *testing.T) {
+	f, err := createLinuxPrintDocument([]byte("%PDF-test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := f.Name()
+	defer closeLinuxPrintDocument(f)
+	if filepath.Ext(name) != ".pdf" {
+		t.Fatalf("temporary document name = %q, want .pdf extension", name)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Fatalf("temporary document mode = %#o, want 0600", mode)
+	}
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "%PDF-test" {
+		t.Fatalf("temporary document = %q, want original bytes", data)
+	}
+	closeLinuxPrintDocument(f)
+	if _, err := os.Stat(name); !os.IsNotExist(err) {
+		t.Fatalf("temporary document still exists after cleanup: %v", err)
+	}
+}
+
+func TestLinuxPrintJobCancelClosesConnectionAndDocument(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+	document, err := createLinuxPrintDocument([]byte("pdf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := document.Name()
+	ctx, cancel := context.WithCancel(context.Background())
+	job := &linuxPrintJob{
+		done:          make(chan error, 1),
+		ctx:           ctx,
+		cancel:        cancel,
+		conn:          &dbusConn{rw: client},
+		document:      document,
+		prepareSerial: 1,
+		preparePath:   "/org/freedesktop/portal/desktop/request/1_1/gogpu_1",
+		watchDone:     make(chan struct{}),
+	}
+	go job.watchCancellation()
+	go job.run()
+	job.Cancel()
+
+	select {
+	case got := <-job.Done():
+		if !errors.Is(got, context.Canceled) {
+			t.Fatalf("Done() = %v, want context.Canceled", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for canceled print job")
+	}
+	if _, err := os.Stat(name); !os.IsNotExist(err) {
+		t.Fatalf("temporary document still exists after canceled job: %v", err)
+	}
+}
+
+// readPortalDict decodes the string-valued subset used by PreparePrint
+// settings/options.  It intentionally rejects a non-string value so tests do
+// not accidentally accept a malformed variant.
+func readPortalDict(d *msgDecoder) (map[string]string, error) {
+	result := make(map[string]string)
+	n, err := d.readU32()
+	if err != nil {
+		return nil, err
+	}
+	if err := d.alignTo(8); err != nil {
+		return nil, err
+	}
+	end := d.pos + int(n)
+	for d.pos < end {
+		if err := d.alignTo(8); err != nil {
+			return nil, err
+		}
+		key, err := d.readStr()
+		if err != nil {
+			return nil, err
+		}
+		sig, err := d.readSig()
+		if err != nil {
+			return nil, err
+		}
+		if sig != "s" {
+			return nil, errors.New("portal test: expected string variant")
+		}
+		value, err := d.readStr()
+		if err != nil {
+			return nil, err
+		}
+		result[key] = value
+	}
+	return result, nil
+}
+
+func readPortalDictTyped(d *msgDecoder) (map[string]string, error) {
+	result := make(map[string]string)
+	n, err := d.readU32()
+	if err != nil {
+		return nil, err
+	}
+	if err := d.alignTo(8); err != nil {
+		return nil, err
+	}
+	end := d.pos + int(n)
+	for d.pos < end {
+		if err := d.alignTo(8); err != nil {
+			return nil, err
+		}
+		key, err := d.readStr()
+		if err != nil {
+			return nil, err
+		}
+		sig, err := d.readSig()
+		if err != nil {
+			return nil, err
+		}
+		switch sig {
+		case "s":
+			value, err := d.readStr()
+			if err != nil {
+				return nil, err
+			}
+			result[key] = value
+		case "u":
+			value, err := d.readU32()
+			if err != nil {
+				return nil, err
+			}
+			result[key] = strconv.FormatUint(uint64(value), 10)
+		default:
+			if err := d.skipValue(sig); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return result, nil
+}
+
+func binaryLE32(b []byte) uint32 {
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}

--- a/internal/platform/print_linux_test.go
+++ b/internal/platform/print_linux_test.go
@@ -5,6 +5,7 @@ package platform
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -261,6 +262,64 @@ func TestDBusSendCallWithFDsPassesDescriptor(t *testing.T) {
 		t.Fatalf("passed descriptors = %d, want 1", len(passed))
 	}
 	defer unix.Close(passed[0])
+}
+
+func TestDBusSendCallContextClosesBlockedSetupWrite(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+	conn := &dbusConn{rw: client}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := conn.sendCallContext(ctx, "dest", "/path", "iface", "PreparePrint", "s", make([]byte, 1<<20))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("sendCallContext() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDBusCloseRequestWritesPortalCloseMethod(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	conn := &dbusConn{rw: client}
+	handlePath := "/org/freedesktop/portal/desktop/request/1_2/gogpu_close"
+	done := make(chan struct{})
+	go func() {
+		conn.closeRequest(handlePath)
+		close(done)
+	}()
+	var fixed [16]byte
+	if _, err := io.ReadFull(server, fixed[:]); err != nil {
+		t.Fatal(err)
+	}
+	if fixed[1] != dbusMsgCall {
+		t.Fatalf("message type = %d, want method call", fixed[1])
+	}
+	hdrLen := int(binaryLE32(fixed[12:16]))
+	hdr := make([]byte, hdrLen)
+	if _, err := io.ReadFull(server, hdr); err != nil {
+		t.Fatal(err)
+	}
+	if pad := (8 - (16+hdrLen)%8) % 8; pad > 0 {
+		padding := make([]byte, pad)
+		if _, err := io.ReadFull(server, padding); err != nil {
+			t.Fatal(err)
+		}
+	}
+	msg := &dbusMsg{}
+	dbusParseHdrFields(hdr, msg)
+	if msg.Path != handlePath || msg.Interface != "org.freedesktop.portal.Request" || msg.Member != "Close" {
+		t.Fatalf("close request headers = path:%q iface:%q member:%q", msg.Path, msg.Interface, msg.Member)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("closeRequest did not return")
+	}
 }
 
 func TestCreateLinuxPrintDocumentOwnsAndCleansFile(t *testing.T) {

--- a/internal/platform/print_linux_test.go
+++ b/internal/platform/print_linux_test.go
@@ -303,16 +303,18 @@ func TestLinuxPrintJobCancelClosesConnectionAndDocument(t *testing.T) {
 	name := document.Name()
 	ctx, cancel := context.WithCancel(context.Background())
 	job := &linuxPrintJob{
-		done:          make(chan error, 1),
+		printJob:      newPrintJob(),
 		ctx:           ctx,
 		cancel:        cancel,
 		conn:          &dbusConn{rw: client},
 		document:      document,
 		prepareSerial: 1,
 		preparePath:   "/org/freedesktop/portal/desktop/request/1_1/gogpu_1",
-		watchDone:     make(chan struct{}),
 	}
-	go job.watchCancellation()
+	job.setCancel(func() {
+		cancel()
+		job.closeConn()
+	})
 	go job.run()
 	job.Cancel()
 

--- a/internal/platform/print_windows.go
+++ b/internal/platform/print_windows.go
@@ -31,6 +31,11 @@ const (
 	pdResultPrint  = 1
 	pdResultCancel = 2
 
+	// START_PAGE_GENERAL selects the General tab in the PRINTDLGEXW property
+	// sheet. Zero means the first driver-defined page and is not deterministic
+	// across printer drivers.
+	startPageGeneral uint32 = 0xFFFFFFFF
+
 	// The PASSTHROUGH escape sends caller-owned bytes directly to the printer
 	// driver's spool stream.  It is supported by the Win32 GDI print contract.
 	passthroughEscape = 19
@@ -348,6 +353,7 @@ func showWindowsPrintDialog(parent uintptr, request PrintRequest, calls windowsP
 		nMinPage:       1,
 		nMaxPage:       printDialogMaxPage,
 		nCopies:        1,
+		nStartPage:     startPageGeneral,
 	}
 	if len(request.Options.PageRanges) > 0 {
 		dlg.flags |= pdPageNums

--- a/internal/platform/print_windows.go
+++ b/internal/platform/print_windows.go
@@ -1,0 +1,527 @@
+//go:build windows
+
+package platform
+
+// The Windows backend deliberately uses the Win32 print dialog and GDI
+// passthrough path instead of adding a PDF renderer to gogpu.  The caller
+// owns the complete document bytes; the selected printer driver is
+// responsible for consuming the declared document format.  Drivers that
+// advertise raw PDF/document support can thus receive the same bytes that the
+// caller supplied without a second in-process renderer.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// PRINTDLGEX flags.
+	pdPageNums                   = 0x00000002
+	pdReturnDC                   = 0x00000100
+	pdUseDevModeCopiesAndCollate = 0x00040000
+	// PRINTDLGEX result actions.
+	pdResultPrint  = 1
+	pdResultCancel = 2
+
+	// The PASSTHROUGH escape sends caller-owned bytes directly to the printer
+	// driver's spool stream.  It is supported by the Win32 GDI print contract.
+	passthroughEscape = 19
+
+	// PrintDlgEx uses a DWORD page number.  A PDF's page count is intentionally
+	// not parsed by this package, so expose the full practical dialog range.
+	printDialogMaxPage = math.MaxUint32
+
+	// Keep individual Escape calls below the size accepted by older printer
+	// drivers.  The document itself may be arbitrarily larger.
+	printEscapeChunkSize = 64 * 1024
+)
+
+// printDlgEx mirrors PRINTDLGEXW.  Pointer-sized fields are represented as
+// uintptr so the struct has the same layout on 32- and 64-bit Windows.
+type printDlgEx struct {
+	lStructSize         uint32
+	hwndOwner           uintptr
+	hDevMode            uintptr
+	hDevNames           uintptr
+	hDC                 uintptr
+	flags               uint32
+	flags2              uint32
+	exclusionFlags      uint32
+	nPageRanges         uint32
+	nMaxPageRanges      uint32
+	lpPageRanges        uintptr
+	nMinPage            uint32
+	nMaxPage            uint32
+	nCopies             uint16
+	_                   uint16 // alignment before hInstance on 32/64-bit
+	hInstance           uintptr
+	lpPrintTemplateName *uint16
+	lpCallback          uintptr
+	nPropertyPages      uint32
+	lphPropertyPages    uintptr
+	nStartPage          uint32
+	dwResultAction      uint32
+}
+
+// printPageRange mirrors PRINTPAGERANGE.
+type printPageRange struct {
+	nFromPage uint32
+	nToPage   uint32
+}
+
+// printDocInfo mirrors DOCINFOW, used by StartDocW.
+type printDocInfo struct {
+	cbSize       int32
+	lpszDocName  *uint16
+	lpszOutput   *uint16
+	lpszDatatype *uint16
+	fwType       uint32
+}
+
+// windowsPrintSyscalls is the narrow syscall seam for deterministic tests.
+// All methods are called from the worker's locked OS thread except AbortDoc,
+// which may also be called by Cancel while a blocking print operation runs.
+type windowsPrintSyscalls struct {
+	printDlgEx   func(*printDlgEx) uint32
+	globalFree   func(uintptr)
+	deleteDC     func(uintptr) int32
+	startDoc     func(uintptr, *printDocInfo) int32
+	startPage    func(uintptr) int32
+	endPage      func(uintptr) int32
+	endDoc       func(uintptr) int32
+	escape       func(uintptr, int32, uint32, uintptr, uintptr) int32
+	abortDoc     func(uintptr) int32
+	cancelDialog func(uintptr)
+}
+
+var (
+	comdlg32Print               = windows.NewLazyDLL("comdlg32.dll")
+	gdi32Print                  = windows.NewLazyDLL("gdi32.dll")
+	procPrintDlgExW             = comdlg32Print.NewProc("PrintDlgExW")
+	procGlobalFreePrint         = kernel32.NewProc("GlobalFree")
+	procDeleteDCPrint           = gdi32Print.NewProc("DeleteDC")
+	procStartDocWPrint          = gdi32Print.NewProc("StartDocW")
+	procStartPagePrint          = gdi32Print.NewProc("StartPage")
+	procEndPagePrint            = gdi32Print.NewProc("EndPage")
+	procEndDocPrint             = gdi32Print.NewProc("EndDoc")
+	procEscapePrint             = gdi32Print.NewProc("Escape")
+	procAbortDocPrint           = gdi32Print.NewProc("AbortDoc")
+	procGetLastActivePopupPrint = user32.NewProc("GetLastActivePopup")
+)
+
+var windowsPrintCalls = windowsPrintSyscalls{
+	printDlgEx: func(dlg *printDlgEx) uint32 {
+		r, _, _ := procPrintDlgExW.Call(uintptr(unsafe.Pointer(dlg)))
+		return uint32(r)
+	},
+	globalFree: func(handle uintptr) {
+		procGlobalFreePrint.Call(handle)
+	},
+	deleteDC: func(hdc uintptr) int32 {
+		r, _, _ := procDeleteDCPrint.Call(hdc)
+		return int32(r)
+	},
+	startDoc: func(hdc uintptr, info *printDocInfo) int32 {
+		r, _, _ := procStartDocWPrint.Call(hdc, uintptr(unsafe.Pointer(info)))
+		return int32(r)
+	},
+	startPage: func(hdc uintptr) int32 {
+		r, _, _ := procStartPagePrint.Call(hdc)
+		return int32(r)
+	},
+	endPage: func(hdc uintptr) int32 {
+		r, _, _ := procEndPagePrint.Call(hdc)
+		return int32(r)
+	},
+	endDoc: func(hdc uintptr) int32 {
+		r, _, _ := procEndDocPrint.Call(hdc)
+		return int32(r)
+	},
+	escape: func(hdc uintptr, escape int32, inputCount uint32, input, output uintptr) int32 {
+		r, _, _ := procEscapePrint.Call(hdc, uintptr(escape), uintptr(inputCount), input, output)
+		return int32(r)
+	},
+	abortDoc: func(hdc uintptr) int32 {
+		r, _, _ := procAbortDocPrint.Call(hdc)
+		return int32(r)
+	},
+	cancelDialog: func(parent uintptr) {
+		if parent == 0 {
+			return
+		}
+		popup, _, _ := procGetLastActivePopupPrint.Call(parent)
+		if popup != 0 && popup != parent {
+			procPostMessageW.Call(popup, uintptr(wmClose), 0, 0)
+		}
+	},
+}
+
+// windowsPrintJob owns the asynchronous operation and its terminal signal.
+// abort is installed only while a native GDI job is active; this keeps Cancel
+// idempotent and prevents an after-Done cancellation from touching a recycled
+// HDC.
+type windowsPrintJob struct {
+	done     chan error
+	finished chan struct{}
+
+	cancelOnce sync.Once
+	finishOnce sync.Once
+	mu         sync.Mutex
+	canceled   bool
+	abort      func()
+}
+
+func newWindowsPrintJob() *windowsPrintJob {
+	return &windowsPrintJob{
+		done:     make(chan error, 1),
+		finished: make(chan struct{}),
+	}
+}
+
+func (j *windowsPrintJob) Done() <-chan error { return j.done }
+
+func (j *windowsPrintJob) Cancel() {
+	j.cancelOnce.Do(func() {
+		j.mu.Lock()
+		j.canceled = true
+		abort := j.abort
+		j.mu.Unlock()
+		if abort != nil {
+			abort()
+		}
+	})
+}
+
+func (j *windowsPrintJob) setAbort(abort func()) {
+	j.mu.Lock()
+	if j.canceled {
+		j.mu.Unlock()
+		if abort != nil {
+			abort()
+		}
+		return
+	}
+	j.abort = abort
+	j.mu.Unlock()
+}
+
+func (j *windowsPrintJob) clearAbort() {
+	j.mu.Lock()
+	j.abort = nil
+	j.mu.Unlock()
+}
+
+func (j *windowsPrintJob) isCanceled() bool {
+	j.mu.Lock()
+	canceled := j.canceled
+	j.mu.Unlock()
+	return canceled
+}
+
+func (j *windowsPrintJob) finish(err error) {
+	j.finishOnce.Do(func() {
+		if j.isCanceled() || errors.Is(err, context.Canceled) {
+			err = context.Canceled
+		}
+		j.clearAbort()
+		j.done <- err
+		close(j.done)
+		close(j.finished)
+	})
+}
+
+// StartPrint implements PrintManager for the Win32 platform.  The request is
+// accepted after synchronous validation/parent lookup; dialog and spooling
+// run asynchronously on a locked OS thread so App.Print never blocks on UI.
+func (p *windowsPlatform) StartPrint(ctx context.Context, request PrintRequest) (PrintJob, error) {
+	if ctx == nil {
+		return nil, errors.New("windows print: nil context")
+	}
+	if request.Document.MIMEType == "" || len(request.Document.Data) == 0 {
+		return nil, errors.New("windows print: empty document")
+	}
+	if request.Options.Copies < 0 {
+		return nil, errors.New("windows print: copies must not be negative")
+	}
+	if request.Options.Copies > math.MaxUint16 {
+		return nil, fmt.Errorf("windows print: copies %d exceeds Windows limit %d", request.Options.Copies, math.MaxUint16)
+	}
+	for _, r := range request.Options.PageRanges {
+		if r.From <= 0 || r.To < r.From {
+			return nil, fmt.Errorf("windows print: invalid page range %d-%d", r.From, r.To)
+		}
+	}
+
+	parent, err := p.printParent(request.Options.Parent)
+	if err != nil {
+		return nil, err
+	}
+
+	// App.Print already copies the request, but keep this boundary explicit for
+	// direct internal callers and for the worker's asynchronous lifetime.
+	request.Document.Data = append([]byte(nil), request.Document.Data...)
+	request.Options.PageRanges = append([]PrintPageRange(nil), request.Options.PageRanges...)
+
+	job := newWindowsPrintJob()
+	go p.runPrint(ctx, parent, request, job)
+	go func() {
+		select {
+		case <-ctx.Done():
+			job.Cancel()
+		case <-job.finished:
+		}
+	}()
+	return job, nil
+}
+
+// printParent resolves the backend-neutral WindowID to its owning HWND while
+// retaining the parent relationship for the complete native operation.
+func (p *windowsPlatform) printParent(id WindowID) (uintptr, error) {
+	p.windowMu.RLock()
+	defer p.windowMu.RUnlock()
+	if id == 0 {
+		if p.primary == nil || p.primary.hwnd == 0 {
+			return 0, nil
+		}
+		return uintptr(p.primary.hwnd), nil
+	}
+	if p.primary != nil && p.primary.id == id && p.primary.hwnd != 0 {
+		return uintptr(p.primary.hwnd), nil
+	}
+	for _, window := range p.windows {
+		if window != nil && window.id == id && window.hwnd != 0 {
+			return uintptr(window.hwnd), nil
+		}
+	}
+	return 0, fmt.Errorf("windows print: parent window %d is unavailable", id)
+}
+
+func (p *windowsPlatform) runPrint(ctx context.Context, parent uintptr, request PrintRequest, job *windowsPrintJob) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if ctx.Err() != nil || job.isCanceled() {
+		job.finish(context.Canceled)
+		return
+	}
+
+	// A native print dialog is modal and Windows requires a message-aware OS
+	// thread.  Serialize dialogs/spool setup so concurrent calls cannot compete
+	// for the process's default printer UI.
+	windowsPrintMu.Lock()
+	defer windowsPrintMu.Unlock()
+
+	// PrintDlgEx owns its modal loop.  GetLastActivePopup + WM_CLOSE is the
+	// documented Win32 escape hatch for a caller that must cancel a common
+	// dialog from another goroutine; the result is still checked against the
+	// job/context after the dialog returns.
+	if windowsPrintCalls.cancelDialog != nil {
+		job.setAbort(func() { windowsPrintCalls.cancelDialog(parent) })
+	}
+	if ctx.Err() != nil || job.isCanceled() {
+		job.finish(context.Canceled)
+		return
+	}
+	result, err := showWindowsPrintDialog(parent, request, windowsPrintCalls)
+	if err != nil {
+		job.finish(err)
+		return
+	}
+	if result.canceled || ctx.Err() != nil || job.isCanceled() {
+		if result.hdc != 0 {
+			windowsPrintCalls.deleteDC(result.hdc)
+		}
+		job.finish(context.Canceled)
+		return
+	}
+
+	// AbortDoc is safe from the cancellation watcher while Escape/EndDoc is
+	// blocked in a printer driver.  It is cleared before Done is signaled.
+	job.setAbort(func() { windowsPrintCalls.abortDoc(result.hdc) })
+	err = spoolWindowsDocument(ctx, request, result.hdc, job, windowsPrintCalls)
+	job.finish(err)
+}
+
+type windowsPrintDialogResult struct {
+	hdc      uintptr
+	canceled bool
+}
+
+func showWindowsPrintDialog(parent uintptr, request PrintRequest, calls windowsPrintSyscalls) (result windowsPrintDialogResult, err error) {
+	pageRanges := make([]printPageRange, maxPrintPageRanges(len(request.Options.PageRanges)))
+	for i, r := range request.Options.PageRanges {
+		if uint64(r.From) > math.MaxUint32 || uint64(r.To) > math.MaxUint32 {
+			return result, fmt.Errorf("windows print: page range %d-%d exceeds Windows limit", r.From, r.To)
+		}
+		pageRanges[i] = printPageRange{nFromPage: uint32(r.From), nToPage: uint32(r.To)}
+	}
+
+	dlg := printDlgEx{
+		lStructSize:    uint32(unsafe.Sizeof(printDlgEx{})),
+		hwndOwner:      parent,
+		flags:          pdReturnDC | pdUseDevModeCopiesAndCollate,
+		nMaxPageRanges: uint32(len(pageRanges)),
+		nMinPage:       1,
+		nMaxPage:       printDialogMaxPage,
+		nCopies:        1,
+	}
+	if len(request.Options.PageRanges) > 0 {
+		dlg.flags |= pdPageNums
+		dlg.nPageRanges = uint32(len(request.Options.PageRanges))
+	}
+	if request.Options.Copies > 0 {
+		dlg.nCopies = uint16(request.Options.Copies)
+	}
+	if len(pageRanges) > 0 {
+		dlg.lpPageRanges = uintptr(unsafe.Pointer(&pageRanges[0]))
+	}
+
+	hresult := calls.printDlgEx(&dlg)
+	runtime.KeepAlive(pageRanges)
+	if hresult != 0 {
+		freePrintDialogResources(dlg, calls)
+		return result, fmt.Errorf("windows print: PrintDlgExW failed (HRESULT 0x%08X)", hresult)
+	}
+	if dlg.dwResultAction == pdResultCancel {
+		freePrintDialogResources(dlg, calls)
+		return windowsPrintDialogResult{canceled: true}, nil
+	}
+	if dlg.dwResultAction != pdResultPrint {
+		freePrintDialogResources(dlg, calls)
+		return result, fmt.Errorf("windows print: PrintDlgExW returned unexpected action %d", dlg.dwResultAction)
+	}
+	if dlg.hDC == 0 {
+		freePrintDialogResources(dlg, calls)
+		return result, errors.New("windows print: PrintDlgExW returned no printer DC")
+	}
+
+	// The HDC owns the selected printer and DEVMODE.  Release the dialog's
+	// memory blocks now; the HDC remains valid until spoolWindowsDocument ends.
+	if dlg.hDevMode != 0 {
+		calls.globalFree(dlg.hDevMode)
+	}
+	if dlg.hDevNames != 0 {
+		calls.globalFree(dlg.hDevNames)
+	}
+	return windowsPrintDialogResult{hdc: dlg.hDC}, nil
+}
+
+func maxPrintPageRanges(requested int) int {
+	if requested < 1 {
+		// Keep the page-range controls available when the caller did not provide
+		// a preselected range.  PRINTDLGEX writes the user's selection back into
+		// this buffer before returning.
+		return 16
+	}
+	return requested
+}
+
+func freePrintDialogResources(dlg printDlgEx, calls windowsPrintSyscalls) {
+	if dlg.hDC != 0 {
+		calls.deleteDC(dlg.hDC)
+	}
+	if dlg.hDevMode != 0 {
+		calls.globalFree(dlg.hDevMode)
+	}
+	if dlg.hDevNames != 0 {
+		calls.globalFree(dlg.hDevNames)
+	}
+}
+
+func spoolWindowsDocument(ctx context.Context, request PrintRequest, hdc uintptr, job *windowsPrintJob, calls windowsPrintSyscalls) error {
+	if hdc == 0 {
+		return errors.New("windows print: nil printer DC")
+	}
+	defer calls.deleteDC(hdc)
+	if ctx.Err() != nil || job.isCanceled() {
+		calls.abortDoc(hdc)
+		return context.Canceled
+	}
+
+	docName := request.Document.Name
+	if docName == "" {
+		docName = request.Options.Title
+	}
+	if docName == "" {
+		docName = "GoGPU document"
+	}
+	docNameW, err := windows.UTF16PtrFromString(docName)
+	if err != nil {
+		return fmt.Errorf("windows print: document name: %w", err)
+	}
+	datatypeW, _ := windows.UTF16PtrFromString("RAW")
+	info := printDocInfo{
+		cbSize:       int32(unsafe.Sizeof(printDocInfo{})),
+		lpszDocName:  docNameW,
+		lpszDatatype: datatypeW,
+	}
+	if calls.startDoc(hdc, &info) <= 0 {
+		return fmt.Errorf("windows print: StartDocW failed: %w", printLastError())
+	}
+
+	if ctx.Err() != nil || job.isCanceled() {
+		calls.abortDoc(hdc)
+		return context.Canceled
+	}
+	if calls.startPage(hdc) <= 0 {
+		calls.abortDoc(hdc)
+		return fmt.Errorf("windows print: StartPage failed: %w", printLastError())
+	}
+
+	data := request.Document.Data
+	for offset := 0; offset < len(data); {
+		if ctx.Err() != nil || job.isCanceled() {
+			calls.abortDoc(hdc)
+			return context.Canceled
+		}
+		end := offset + printEscapeChunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[offset:end]
+		if len(chunk) == 0 {
+			break
+		}
+		if calls.escape(hdc, passthroughEscape, uint32(len(chunk)), uintptr(unsafe.Pointer(&chunk[0])), 0) <= 0 {
+			calls.abortDoc(hdc)
+			return fmt.Errorf("windows print: PASSTHROUGH failed at byte %d: %w", offset, printLastError())
+		}
+		offset = end
+	}
+	runtime.KeepAlive(data)
+
+	if calls.endPage(hdc) <= 0 {
+		calls.abortDoc(hdc)
+		return fmt.Errorf("windows print: EndPage failed: %w", printLastError())
+	}
+	if calls.endDoc(hdc) <= 0 {
+		calls.abortDoc(hdc)
+		return fmt.Errorf("windows print: EndDoc failed: %w", printLastError())
+	}
+	return nil
+}
+
+func printLastError() error {
+	err := windows.GetLastError()
+	if err == nil || err == syscall.Errno(0) {
+		return syscall.EIO
+	}
+	return err
+}
+
+// Compile-time capability assertion.  The backend is additive: other
+// platforms simply omit a PrintManager implementation and remain unsupported.
+var _ PrintManager = (*windowsPlatform)(nil)
+
+// windowsPrintMu serializes native print-dialog entry.  Win32 common dialogs
+// and printer drivers are process-global; overlapping modal dialogs otherwise
+// race the default printer selection and make cancellation nondeterministic.
+var windowsPrintMu sync.Mutex

--- a/internal/platform/print_windows.go
+++ b/internal/platform/print_windows.go
@@ -164,78 +164,38 @@ var windowsPrintCalls = windowsPrintSyscalls{
 	},
 }
 
-// windowsPrintJob owns the asynchronous operation and its terminal signal.
-// abort is installed only while a native GDI job is active; this keeps Cancel
-// idempotent and prevents an after-Done cancellation from touching a recycled
-// HDC.
+// windowsPrintJob adds the native abort hook to the shared print lifecycle.
+// The shared state machine makes cancellation and terminal publication match
+// the macOS/Linux backends; abort is installed only while a native GDI job is
+// active so a later Cancel cannot touch a recycled HDC.
 type windowsPrintJob struct {
-	done     chan error
-	finished chan struct{}
-
-	cancelOnce sync.Once
-	finishOnce sync.Once
-	mu         sync.Mutex
-	canceled   bool
-	abort      func()
+	*printJob
 }
 
 func newWindowsPrintJob() *windowsPrintJob {
 	return &windowsPrintJob{
-		done:     make(chan error, 1),
-		finished: make(chan struct{}),
+		printJob: newPrintJob(),
 	}
-}
-
-func (j *windowsPrintJob) Done() <-chan error { return j.done }
-
-func (j *windowsPrintJob) Cancel() {
-	j.cancelOnce.Do(func() {
-		j.mu.Lock()
-		j.canceled = true
-		abort := j.abort
-		j.mu.Unlock()
-		if abort != nil {
-			abort()
-		}
-	})
 }
 
 func (j *windowsPrintJob) setAbort(abort func()) {
-	j.mu.Lock()
-	if j.canceled {
-		j.mu.Unlock()
-		if abort != nil {
-			abort()
-		}
-		return
-	}
-	j.abort = abort
-	j.mu.Unlock()
+	j.setCancel(abort)
 }
 
 func (j *windowsPrintJob) clearAbort() {
-	j.mu.Lock()
-	j.abort = nil
-	j.mu.Unlock()
+	j.clearCancel()
 }
 
 func (j *windowsPrintJob) isCanceled() bool {
-	j.mu.Lock()
-	canceled := j.canceled
-	j.mu.Unlock()
-	return canceled
+	return j.canceled()
 }
 
 func (j *windowsPrintJob) finish(err error) {
-	j.finishOnce.Do(func() {
-		if j.isCanceled() || errors.Is(err, context.Canceled) {
-			err = context.Canceled
-		}
-		j.clearAbort()
-		j.done <- err
-		close(j.done)
-		close(j.finished)
-	})
+	if errors.Is(err, context.Canceled) {
+		err = context.Canceled
+	}
+	j.clearAbort()
+	j.complete(err)
 }
 
 // StartPrint implements PrintManager for the Win32 platform.  The request is
@@ -272,13 +232,7 @@ func (p *windowsPlatform) StartPrint(ctx context.Context, request PrintRequest) 
 
 	job := newWindowsPrintJob()
 	go p.runPrint(ctx, parent, request, job)
-	go func() {
-		select {
-		case <-ctx.Done():
-			job.Cancel()
-		case <-job.finished:
-		}
-	}()
+	watchPrintContext(ctx, job.printJob)
 	return job, nil
 }
 

--- a/internal/platform/print_windows.go
+++ b/internal/platform/print_windows.go
@@ -205,6 +205,12 @@ func (p *windowsPlatform) StartPrint(ctx context.Context, request PrintRequest) 
 	if ctx == nil {
 		return nil, errors.New("windows print: nil context")
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, ErrPrintUnavailable
+	}
 	if request.Document.MIMEType == "" || len(request.Document.Data) == 0 {
 		return nil, errors.New("windows print: empty document")
 	}
@@ -224,6 +230,13 @@ func (p *windowsPlatform) StartPrint(ctx context.Context, request PrintRequest) 
 	if err != nil {
 		return nil, err
 	}
+	if parent == 0 {
+		// PrintDlgExW requires a valid owner HWND (NULL is not accepted).  A
+		// caller may submit a document before Run creates the primary window;
+		// reject that request synchronously rather than launching an orphaned
+		// dialog whose native setup error would arrive on PrintJob.Done.
+		return nil, errors.New("windows print: parent window is unavailable")
+	}
 
 	// App.Print already copies the request, but keep this boundary explicit for
 	// direct internal callers and for the worker's asynchronous lifetime.
@@ -239,6 +252,9 @@ func (p *windowsPlatform) StartPrint(ctx context.Context, request PrintRequest) 
 // printParent resolves the backend-neutral WindowID to its owning HWND while
 // retaining the parent relationship for the complete native operation.
 func (p *windowsPlatform) printParent(id WindowID) (uintptr, error) {
+	if p == nil {
+		return 0, ErrPrintUnavailable
+	}
 	p.windowMu.RLock()
 	defer p.windowMu.RUnlock()
 	if id == 0 {
@@ -261,6 +277,12 @@ func (p *windowsPlatform) printParent(id WindowID) (uintptr, error) {
 func (p *windowsPlatform) runPrint(ctx context.Context, parent uintptr, request PrintRequest, job *windowsPrintJob) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
+	// PrintDlgExW may create COM-backed property sheets.  This goroutine is
+	// deliberately pinned to one OS thread, so initialize an STA on that same
+	// thread and balance it before the thread is released.
+	if hr, _, _ := procCoInitializeEx.Call(0, coinitApartmentThreaded); hr == comSOK || hr == comSFalse {
+		defer procCoUninitialize.Call()
+	}
 
 	if ctx.Err() != nil || job.isCanceled() {
 		job.finish(context.Canceled)
@@ -394,7 +416,13 @@ func spoolWindowsDocument(ctx context.Context, request PrintRequest, hdc uintptr
 	if hdc == 0 {
 		return errors.New("windows print: nil printer DC")
 	}
-	defer calls.deleteDC(hdc)
+	// The cancellation hook may call AbortDoc on this HDC from another
+	// goroutine.  Clear it before DeleteDC so a cancellation racing cleanup
+	// cannot touch a released (and potentially recycled) handle.
+	defer func() {
+		job.clearAbort()
+		calls.deleteDC(hdc)
+	}()
 	if ctx.Err() != nil || job.isCanceled() {
 		calls.abortDoc(hdc)
 		return context.Canceled

--- a/internal/platform/print_windows_test.go
+++ b/internal/platform/print_windows_test.go
@@ -48,6 +48,9 @@ func TestShowWindowsPrintDialogCopiesRangesAndReleasesDialogMemory(t *testing.T)
 	if got.nCopies != 3 {
 		t.Fatalf("nCopies = %d, want 3", got.nCopies)
 	}
+	if got.nStartPage != startPageGeneral {
+		t.Fatalf("nStartPage = %#x, want START_PAGE_GENERAL %#x", got.nStartPage, startPageGeneral)
+	}
 	if !reflect.DeepEqual(freed, []uintptr{42, 43}) {
 		t.Fatalf("freed handles = %v, want [42 43]", freed)
 	}

--- a/internal/platform/print_windows_test.go
+++ b/internal/platform/print_windows_test.go
@@ -1,0 +1,151 @@
+//go:build windows
+
+package platform
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestShowWindowsPrintDialogCopiesRangesAndReleasesDialogMemory(t *testing.T) {
+	var got printDlgEx
+	var freed []uintptr
+	calls := windowsPrintSyscalls{
+		printDlgEx: func(dlg *printDlgEx) uint32 {
+			got = *dlg
+			if dlg.nPageRanges != 2 {
+				t.Fatalf("nPageRanges = %d, want 2", dlg.nPageRanges)
+			}
+			if dlg.lpPageRanges == 0 {
+				t.Fatal("lpPageRanges is nil")
+			}
+			dlg.hDC = 41
+			dlg.hDevMode = 42
+			dlg.hDevNames = 43
+			dlg.dwResultAction = pdResultPrint
+			return 0
+		},
+		globalFree: func(handle uintptr) { freed = append(freed, handle) },
+	}
+	result, err := showWindowsPrintDialog(99, PrintRequest{
+		Document: PrintDocument{MIMEType: "application/pdf", Data: []byte("pdf")},
+		Options: PrintOptions{
+			PageRanges: []PrintPageRange{{From: 2, To: 4}, {From: 8, To: 9}},
+			Copies:     3,
+		},
+	}, calls)
+	if err != nil {
+		t.Fatalf("showWindowsPrintDialog() error = %v", err)
+	}
+	if result.hdc != 41 || result.canceled {
+		t.Fatalf("result = %+v, want hdc 41 and not canceled", result)
+	}
+	if got.hwndOwner != 99 || got.flags&(pdReturnDC|pdUseDevModeCopiesAndCollate|pdPageNums) != (pdReturnDC|pdUseDevModeCopiesAndCollate|pdPageNums) {
+		t.Fatalf("dialog owner/flags = hwnd %d flags %#x", got.hwndOwner, got.flags)
+	}
+	if got.nCopies != 3 {
+		t.Fatalf("nCopies = %d, want 3", got.nCopies)
+	}
+	if !reflect.DeepEqual(freed, []uintptr{42, 43}) {
+		t.Fatalf("freed handles = %v, want [42 43]", freed)
+	}
+}
+
+func TestShowWindowsPrintDialogCancelReleasesHDCAndMemory(t *testing.T) {
+	var freed []uintptr
+	var deleted []uintptr
+	calls := windowsPrintSyscalls{
+		printDlgEx: func(dlg *printDlgEx) uint32 {
+			dlg.hDC = 7
+			dlg.hDevMode = 8
+			dlg.hDevNames = 9
+			dlg.dwResultAction = pdResultCancel
+			return 0
+		},
+		deleteDC:   func(hdc uintptr) int32 { deleted = append(deleted, hdc); return 1 },
+		globalFree: func(handle uintptr) { freed = append(freed, handle) },
+	}
+	result, err := showWindowsPrintDialog(0, PrintRequest{Document: PrintDocument{MIMEType: "application/pdf", Data: []byte("pdf")}}, calls)
+	if err != nil {
+		t.Fatalf("showWindowsPrintDialog() error = %v", err)
+	}
+	if !result.canceled || result.hdc != 0 {
+		t.Fatalf("result = %+v, want canceled result without HDC", result)
+	}
+	if !reflect.DeepEqual(deleted, []uintptr{7}) || !reflect.DeepEqual(freed, []uintptr{8, 9}) {
+		t.Fatalf("cleanup = delete %v/free %v, want delete [7], free [8 9]", deleted, freed)
+	}
+}
+
+func TestSpoolWindowsDocumentUsesGDIPassthroughAndCleansUp(t *testing.T) {
+	var callsSeen []string
+	var chunkSizes []int
+	calls := windowsPrintSyscalls{
+		startDoc: func(_ uintptr, info *printDocInfo) int32 {
+			callsSeen = append(callsSeen, "start-doc")
+			if info.lpszDatatype == nil || info.cbSize <= 0 {
+				t.Fatal("StartDocW received incomplete DOCINFO")
+			}
+			return 1
+		},
+		startPage: func(uintptr) int32 { callsSeen = append(callsSeen, "start-page"); return 1 },
+		escape: func(_ uintptr, escape int32, count uint32, input, _ uintptr) int32 {
+			if escape != passthroughEscape {
+				t.Fatalf("escape code = %d, want %d", escape, passthroughEscape)
+			}
+			callsSeen = append(callsSeen, "escape")
+			if input == 0 {
+				t.Fatal("PASSTHROUGH input pointer is nil")
+			}
+			chunkSizes = append(chunkSizes, int(count))
+			return int32(count)
+		},
+		endPage:  func(uintptr) int32 { callsSeen = append(callsSeen, "end-page"); return 1 },
+		endDoc:   func(uintptr) int32 { callsSeen = append(callsSeen, "end-doc"); return 1 },
+		deleteDC: func(uintptr) int32 { callsSeen = append(callsSeen, "delete-dc"); return 1 },
+		abortDoc: func(uintptr) int32 { callsSeen = append(callsSeen, "abort-doc"); return 1 },
+	}
+	job := newWindowsPrintJob()
+	want := bytesForPrintTest(3*printEscapeChunkSize + 17)
+	err := spoolWindowsDocument(context.Background(), PrintRequest{
+		Document: PrintDocument{Name: "report.pdf", MIMEType: "application/pdf", Data: want},
+	}, 55, job, calls)
+	if err != nil {
+		t.Fatalf("spoolWindowsDocument() error = %v", err)
+	}
+	if !reflect.DeepEqual(callsSeen, []string{"start-doc", "start-page", "escape", "escape", "escape", "escape", "end-page", "end-doc", "delete-dc"}) {
+		t.Fatalf("call order = %v", callsSeen)
+	}
+	var got int
+	for _, size := range chunkSizes {
+		got += size
+	}
+	if got != len(want) {
+		t.Fatalf("spooled byte count = %d, want %d", got, len(want))
+	}
+}
+
+func TestSpoolWindowsDocumentCancellationAbortsBeforeStart(t *testing.T) {
+	var aborted, deleted bool
+	calls := windowsPrintSyscalls{
+		startDoc: func(uintptr, *printDocInfo) int32 { t.Fatal("StartDocW called after cancellation"); return 0 },
+		abortDoc: func(uintptr) int32 { aborted = true; return 1 },
+		deleteDC: func(uintptr) int32 { deleted = true; return 1 },
+	}
+	job := newWindowsPrintJob()
+	job.Cancel()
+	err := spoolWindowsDocument(context.Background(), PrintRequest{Document: PrintDocument{Data: []byte("pdf"), MIMEType: "application/pdf"}}, 12, job, calls)
+	if !errors.Is(err, context.Canceled) || !aborted || !deleted {
+		t.Fatalf("error=%v aborted=%v deleted=%v, want canceled/abort/delete", err, aborted, deleted)
+	}
+}
+
+func bytesForPrintTest(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i)
+	}
+	return b
+}

--- a/internal/platform/print_windows_test.go
+++ b/internal/platform/print_windows_test.go
@@ -142,6 +142,34 @@ func TestSpoolWindowsDocumentCancellationAbortsBeforeStart(t *testing.T) {
 	}
 }
 
+func TestSpoolWindowsDocumentClearsAbortBeforeDeletingHDC(t *testing.T) {
+	job := newWindowsPrintJob()
+	var abortCalls, deleteCalls int
+	job.setAbort(func() { abortCalls++ })
+	calls := windowsPrintSyscalls{
+		startDoc:  func(uintptr, *printDocInfo) int32 { return 1 },
+		startPage: func(uintptr) int32 { return 1 },
+		escape:    func(uintptr, int32, uint32, uintptr, uintptr) int32 { return 1 },
+		endPage:   func(uintptr) int32 { return 1 },
+		endDoc:    func(uintptr) int32 { return 1 },
+		deleteDC: func(uintptr) int32 {
+			deleteCalls++
+			// If clearAbort ran after DeleteDC, this cancellation would invoke the
+			// hook against the released HDC.
+			job.Cancel()
+			return 1
+		},
+	}
+	if err := spoolWindowsDocument(context.Background(), PrintRequest{
+		Document: PrintDocument{MIMEType: "application/pdf", Data: []byte("pdf")},
+	}, 12, job, calls); err != nil {
+		t.Fatalf("spoolWindowsDocument() error = %v", err)
+	}
+	if abortCalls != 0 || deleteCalls != 1 {
+		t.Fatalf("abort calls=%d delete calls=%d, want 0/1", abortCalls, deleteCalls)
+	}
+}
+
 func bytesForPrintTest(n int) []byte {
 	b := make([]byte, n)
 	for i := range b {

--- a/print.go
+++ b/print.go
@@ -1,0 +1,159 @@
+package gogpu
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gogpu/gogpu/internal/platform"
+)
+
+const (
+	// PrintMIMETypePDF identifies a PDF print document.
+	PrintMIMETypePDF = "application/pdf"
+)
+
+// PrintDocument is the complete document submitted to a native print
+// operation. Data is copied when Print is called, so the caller may reuse its
+// source buffer after Print returns. A document is not rendered by gogpu;
+// callers (for example, gg or ui) provide the final bytes and media type.
+type PrintDocument struct {
+	// Name is the user-facing document name. It may be empty when the native
+	// backend supplies a default.
+	Name string
+	// MIMEType identifies the document bytes. PrintMIMETypePDF is the portable
+	// format currently expected by native backends; other document types may be
+	// added without changing the contract.
+	MIMEType string
+	// Data contains the complete document bytes. The bytes must remain a valid
+	// document for the declared MIMEType.
+	Data []byte
+}
+
+// NewPDFDocument creates a print document backed by PDF bytes. It copies pdf
+// so the returned document owns its input data.
+func NewPDFDocument(name string, pdf []byte) PrintDocument {
+	return PrintDocument{
+		Name:     name,
+		MIMEType: PrintMIMETypePDF,
+		Data:     append([]byte(nil), pdf...),
+	}
+}
+
+// PrintPageRange is an inclusive, one-based page range. An empty range slice
+// means that no explicit range was supplied; native backends print all pages.
+type PrintPageRange struct {
+	From int
+	To   int
+}
+
+// PrintOptions controls the native print operation.
+type PrintOptions struct {
+	// Parent identifies the window that owns the native print UI. Zero uses the
+	// app's primary window when one exists, or the application parent otherwise.
+	Parent WindowID
+	// Title is an optional native dialog title.
+	Title string
+	// PageRanges limits printing to these inclusive, one-based ranges. An empty
+	// slice means all pages.
+	PageRanges []PrintPageRange
+	// Copies requests the number of copies. Zero uses the platform default (one).
+	Copies int
+}
+
+// PrintJob represents an accepted native print operation.
+//
+// StartPrint returns after the platform has accepted the request; the native
+// dialog/spool operation may still be running. Done returns a channel that
+// receives exactly one value and is then closed: nil means the operation
+// completed, context.Canceled means it was canceled, and any other error is a
+// platform or spool failure. Cancel is idempotent and has no effect after Done
+// has completed.
+type PrintJob interface {
+	Done() <-chan error
+	Cancel()
+}
+
+var (
+	// ErrPrintUnsupported means the selected platform has no native print
+	// implementation yet. It is returned synchronously and no job is created.
+	ErrPrintUnsupported = errors.New("gogpu: native printing unsupported")
+	// ErrInvalidPrintDocument means the document has no media type or bytes.
+	ErrInvalidPrintDocument = errors.New("gogpu: invalid print document")
+	// ErrInvalidPrintOptions means a print option is outside the contract.
+	ErrInvalidPrintOptions = errors.New("gogpu: invalid print options")
+	// ErrNilPrintContext means a nil context was passed to Print. Callers must
+	// pass context.Background() when they do not need cancellation.
+	ErrNilPrintContext = errors.New("gogpu: nil print context")
+)
+
+func (d PrintDocument) validate() error {
+	if d.MIMEType == "" || len(d.Data) == 0 {
+		return fmt.Errorf("%w: MIMEType and Data are required", ErrInvalidPrintDocument)
+	}
+	return nil
+}
+
+func (o PrintOptions) validate() error {
+	if o.Copies < 0 {
+		return fmt.Errorf("%w: Copies must not be negative", ErrInvalidPrintOptions)
+	}
+	for _, r := range o.PageRanges {
+		if r.From <= 0 || r.To < r.From {
+			return fmt.Errorf("%w: page range %d-%d is not positive and inclusive", ErrInvalidPrintOptions, r.From, r.To)
+		}
+	}
+	return nil
+}
+
+// Print submits a complete document to the platform's native print contract.
+// The call is asynchronous after request acceptance: wait on PrintJob.Done or
+// cancel it through the returned job/context. Before Run, the primary parent
+// is unavailable and a backend may reject a request that requires a window.
+// gogpu does not generate or paginate documents.
+func (a *App) Print(ctx context.Context, document PrintDocument, opts PrintOptions) (PrintJob, error) {
+	if ctx == nil {
+		return nil, ErrNilPrintContext
+	}
+	if err := document.validate(); err != nil {
+		return nil, err
+	}
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	if a.manager == nil {
+		return nil, ErrPrintUnsupported
+	}
+	manager, ok := a.manager.(platform.PrintManager)
+	if !ok {
+		return nil, ErrPrintUnsupported
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if opts.Parent == 0 && a.platWindow != nil {
+		opts.Parent = WindowID(a.platWindow.ID())
+	}
+
+	// Copy all caller-owned slices/bytes before an asynchronous backend can
+	// retain the request. This makes the lifetime boundary explicit.
+	request := platform.PrintRequest{
+		Document: platform.PrintDocument{
+			Name:     document.Name,
+			MIMEType: document.MIMEType,
+			Data:     append([]byte(nil), document.Data...),
+		},
+		Options: platform.PrintOptions{
+			Parent: platform.WindowID(opts.Parent),
+			Title:  opts.Title,
+			Copies: opts.Copies,
+		},
+	}
+	if len(opts.PageRanges) != 0 {
+		request.Options.PageRanges = make([]platform.PrintPageRange, len(opts.PageRanges))
+		for i, r := range opts.PageRanges {
+			request.Options.PageRanges[i] = platform.PrintPageRange{From: r.From, To: r.To}
+		}
+	}
+	return manager.StartPrint(ctx, request)
+}

--- a/print.go
+++ b/print.go
@@ -75,8 +75,9 @@ type PrintJob interface {
 }
 
 var (
-	// ErrPrintUnsupported means the selected platform has no native print
-	// implementation yet. It is returned synchronously and no job is created.
+	// ErrPrintUnsupported means the selected platform has no usable native print
+	// implementation or service. It is returned synchronously and no job is
+	// created.
 	ErrPrintUnsupported = errors.New("gogpu: native printing unsupported")
 	// ErrInvalidPrintDocument means the document has no media type or bytes.
 	ErrInvalidPrintDocument = errors.New("gogpu: invalid print document")
@@ -155,5 +156,19 @@ func (a *App) Print(ctx context.Context, document PrintDocument, opts PrintOptio
 			request.Options.PageRanges[i] = platform.PrintPageRange{From: r.From, To: r.To}
 		}
 	}
-	return manager.StartPrint(ctx, request)
+	job, err := manager.StartPrint(ctx, request)
+	if err != nil {
+		// A backend may discover cancellation while its synchronous acceptance
+		// work is in flight. Keep the public boundary deterministic: once the
+		// caller's context is canceled, Print reports context.Canceled rather
+		// than leaking a platform setup error from that race.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if errors.Is(err, platform.ErrPrintUnavailable) {
+			return nil, ErrPrintUnsupported
+		}
+		return nil, err
+	}
+	return job, nil
 }

--- a/print_test.go
+++ b/print_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gogpu/gogpu/internal/platform"
 )
 
+type printRequestContextKey struct{}
+
 type printTestJob struct {
 	done     chan error
 	canceled bool
@@ -32,6 +34,16 @@ type printTestManager struct {
 	ctx     context.Context
 	job     *printTestJob
 	err     error
+}
+
+type printCancelDuringStartManager struct {
+	mockManager
+	cancel context.CancelFunc
+}
+
+func (m *printCancelDuringStartManager) StartPrint(_ context.Context, _ platform.PrintRequest) (platform.PrintJob, error) {
+	m.cancel()
+	return nil, errors.New("backend setup raced cancellation")
 }
 
 func (m *printTestManager) StartPrint(ctx context.Context, request platform.PrintRequest) (platform.PrintJob, error) {
@@ -61,7 +73,8 @@ func TestPrintRejectsInvalidRequests(t *testing.T) {
 	if _, err := app.Print(context.Background(), PrintDocument{}, PrintOptions{}); !errors.Is(err, ErrInvalidPrintDocument) {
 		t.Fatalf("invalid document error = %v, want ErrInvalidPrintDocument", err)
 	}
-	if _, err := app.Print(nil, NewPDFDocument("x.pdf", []byte("pdf")), PrintOptions{}); !errors.Is(err, ErrNilPrintContext) {
+	var nilContext context.Context
+	if _, err := app.Print(nilContext, NewPDFDocument("x.pdf", []byte("pdf")), PrintOptions{}); !errors.Is(err, ErrNilPrintContext) {
 		t.Fatalf("nil context error = %v, want ErrNilPrintContext", err)
 	}
 	if _, err := app.Print(context.Background(), NewPDFDocument("x.pdf", []byte("pdf")), PrintOptions{Copies: -1}); !errors.Is(err, ErrInvalidPrintOptions) {
@@ -80,6 +93,10 @@ func TestPrintUnsupportedWithoutPlatformCapability(t *testing.T) {
 	if _, err := (&App{manager: &mockManager{}}).Print(context.Background(), doc, PrintOptions{}); !errors.Is(err, ErrPrintUnsupported) {
 		t.Fatalf("manager without PrintManager error = %v, want ErrPrintUnsupported", err)
 	}
+	managerUnavailable := &printTestManager{err: platform.ErrPrintUnavailable}
+	if _, err := (&App{manager: managerUnavailable}).Print(context.Background(), doc, PrintOptions{}); !errors.Is(err, ErrPrintUnsupported) {
+		t.Fatalf("unavailable native service error = %v, want ErrPrintUnsupported", err)
+	}
 }
 
 func TestPrintDelegatesCopiedRequestAndPrimaryParent(t *testing.T) {
@@ -90,7 +107,7 @@ func TestPrintDelegatesCopiedRequestAndPrimaryParent(t *testing.T) {
 	}
 	pdf := []byte("pdf bytes")
 	ranges := []PrintPageRange{{From: 1, To: 2}}
-	ctx := context.WithValue(context.Background(), struct{}{}, "request")
+	ctx := context.WithValue(context.Background(), printRequestContextKey{}, "request")
 	job, err := app.Print(ctx, PrintDocument{Name: "x.pdf", MIMEType: PrintMIMETypePDF, Data: pdf}, PrintOptions{
 		Title:      "Print x",
 		PageRanges: ranges,
@@ -138,6 +155,16 @@ func TestPrintCanceledContextDoesNotStartJob(t *testing.T) {
 	}
 	if mgr.job != nil {
 		t.Fatal("pre-canceled request should not start a print job")
+	}
+}
+
+func TestPrintNormalizesCancellationDuringBackendAcceptance(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mgr := &printCancelDuringStartManager{cancel: cancel}
+	app := &App{manager: mgr}
+	_, err := app.Print(ctx, NewPDFDocument("x.pdf", []byte("pdf")), PrintOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Print() error = %v, want context.Canceled", err)
 	}
 }
 

--- a/print_test.go
+++ b/print_test.go
@@ -99,6 +99,15 @@ func TestPrintUnsupportedWithoutPlatformCapability(t *testing.T) {
 	}
 }
 
+func TestPrintReturnsBackendError(t *testing.T) {
+	backendErr := errors.New("printer setup failed")
+	app := &App{manager: &printTestManager{err: backendErr}}
+
+	if _, err := app.Print(context.Background(), NewPDFDocument("x.pdf", []byte("pdf")), PrintOptions{}); !errors.Is(err, backendErr) {
+		t.Fatalf("backend error = %v, want %v", err, backendErr)
+	}
+}
+
 func TestPrintDelegatesCopiedRequestAndPrimaryParent(t *testing.T) {
 	mgr := &printTestManager{}
 	app := &App{

--- a/print_test.go
+++ b/print_test.go
@@ -1,0 +1,157 @@
+package gogpu
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gogpu/gogpu/internal/platform"
+)
+
+type printTestJob struct {
+	done     chan error
+	canceled bool
+}
+
+func newPrintTestJob() *printTestJob {
+	return &printTestJob{done: make(chan error, 1)}
+}
+
+func (j *printTestJob) Done() <-chan error { return j.done }
+func (j *printTestJob) Cancel() {
+	if !j.canceled {
+		j.canceled = true
+		j.done <- context.Canceled
+		close(j.done)
+	}
+}
+
+type printTestManager struct {
+	mockManager
+	request platform.PrintRequest
+	ctx     context.Context
+	job     *printTestJob
+	err     error
+}
+
+func (m *printTestManager) StartPrint(ctx context.Context, request platform.PrintRequest) (platform.PrintJob, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	m.ctx = ctx
+	m.request = request
+	m.job = newPrintTestJob()
+	return m.job, nil
+}
+
+func TestNewPDFDocumentOwnsInput(t *testing.T) {
+	pdf := []byte("%PDF-test")
+	doc := NewPDFDocument("report.pdf", pdf)
+	pdf[0] = 'x'
+	if doc.MIMEType != PrintMIMETypePDF {
+		t.Fatalf("MIMEType = %q, want %q", doc.MIMEType, PrintMIMETypePDF)
+	}
+	if string(doc.Data) != "%PDF-test" {
+		t.Fatalf("Data = %q, want original PDF bytes", doc.Data)
+	}
+}
+
+func TestPrintRejectsInvalidRequests(t *testing.T) {
+	app := NewApp(DefaultConfig())
+	if _, err := app.Print(context.Background(), PrintDocument{}, PrintOptions{}); !errors.Is(err, ErrInvalidPrintDocument) {
+		t.Fatalf("invalid document error = %v, want ErrInvalidPrintDocument", err)
+	}
+	if _, err := app.Print(nil, NewPDFDocument("x.pdf", []byte("pdf")), PrintOptions{}); !errors.Is(err, ErrNilPrintContext) {
+		t.Fatalf("nil context error = %v, want ErrNilPrintContext", err)
+	}
+	if _, err := app.Print(context.Background(), NewPDFDocument("x.pdf", []byte("pdf")), PrintOptions{Copies: -1}); !errors.Is(err, ErrInvalidPrintOptions) {
+		t.Fatalf("invalid options error = %v, want ErrInvalidPrintOptions", err)
+	}
+	if _, err := app.Print(context.Background(), NewPDFDocument("x.pdf", []byte("pdf")), PrintOptions{PageRanges: []PrintPageRange{{From: 0, To: 1}}}); !errors.Is(err, ErrInvalidPrintOptions) {
+		t.Fatalf("invalid page range error = %v, want ErrInvalidPrintOptions", err)
+	}
+}
+
+func TestPrintUnsupportedWithoutPlatformCapability(t *testing.T) {
+	doc := NewPDFDocument("x.pdf", []byte("pdf"))
+	if _, err := NewApp(DefaultConfig()).Print(context.Background(), doc, PrintOptions{}); !errors.Is(err, ErrPrintUnsupported) {
+		t.Fatalf("nil manager error = %v, want ErrPrintUnsupported", err)
+	}
+	if _, err := (&App{manager: &mockManager{}}).Print(context.Background(), doc, PrintOptions{}); !errors.Is(err, ErrPrintUnsupported) {
+		t.Fatalf("manager without PrintManager error = %v, want ErrPrintUnsupported", err)
+	}
+}
+
+func TestPrintDelegatesCopiedRequestAndPrimaryParent(t *testing.T) {
+	mgr := &printTestManager{}
+	app := &App{
+		manager:    mgr,
+		platWindow: &mockWindow{windowID: 42},
+	}
+	pdf := []byte("pdf bytes")
+	ranges := []PrintPageRange{{From: 1, To: 2}}
+	ctx := context.WithValue(context.Background(), struct{}{}, "request")
+	job, err := app.Print(ctx, PrintDocument{Name: "x.pdf", MIMEType: PrintMIMETypePDF, Data: pdf}, PrintOptions{
+		Title:      "Print x",
+		PageRanges: ranges,
+		Copies:     2,
+	})
+	if err != nil {
+		t.Fatalf("Print() error = %v", err)
+	}
+	pdf[0] = 'X'
+	ranges[0].From = 99
+	if mgr.ctx != ctx {
+		t.Fatal("Print() did not forward context")
+	}
+	if mgr.request.Options.Parent != platform.WindowID(42) {
+		t.Fatalf("Parent = %d, want 42", mgr.request.Options.Parent)
+	}
+	if string(mgr.request.Document.Data) != "pdf bytes" {
+		t.Fatalf("request Data = %q, want copied bytes", mgr.request.Document.Data)
+	}
+	if mgr.request.Options.PageRanges[0].From != 1 {
+		t.Fatalf("request PageRanges was not copied: %+v", mgr.request.Options.PageRanges)
+	}
+	if mgr.request.Options.Title != "Print x" || mgr.request.Options.Copies != 2 {
+		t.Fatalf("request options = %+v, want title/copies preserved", mgr.request.Options)
+	}
+
+	select {
+	case got := <-job.Done():
+		t.Fatalf("initial Done value = %v, want no value until backend completes", got)
+	default:
+	}
+	job.Cancel()
+	if got := <-job.Done(); !errors.Is(got, context.Canceled) {
+		t.Fatalf("canceled Done value = %v, want context.Canceled", got)
+	}
+}
+
+func TestPrintCanceledContextDoesNotStartJob(t *testing.T) {
+	mgr := &printTestManager{}
+	app := &App{manager: mgr}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := app.Print(ctx, NewPDFDocument("x.pdf", []byte("pdf")), PrintOptions{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-canceled Print() error = %v, want context.Canceled", err)
+	}
+	if mgr.job != nil {
+		t.Fatal("pre-canceled request should not start a print job")
+	}
+}
+
+func TestPrintJobCancellationIsTerminalAndIdempotent(t *testing.T) {
+	job := newPrintTestJob()
+	job.Cancel()
+	job.Cancel()
+	if !job.canceled {
+		t.Fatal("Cancel did not mark job canceled")
+	}
+	if got := <-job.Done(); !errors.Is(got, context.Canceled) {
+		t.Fatalf("Done() = %v, want context.Canceled", got)
+	}
+	if _, open := <-job.Done(); open {
+		t.Fatal("Done channel should close after terminal cancellation")
+	}
+}


### PR DESCRIPTION
## Summary
- keep the backend-neutral `App.Print` contract for caller-supplied complete documents
- add Windows `PrintDlgExW`/GDI spooling with parent HWND, ranges, copies, and cancellation
- add macOS PDFKit/AppKit printing with main-thread panel dispatch, parent window ownership, ranges, copies, and cancellation
- add Linux X11/Wayland xdg-desktop-portal PreparePrint/Print flow with parent tokens, temporary document FD lifetime, ranges, copies, and cancellation
- unify native job lifecycle/cancellation semantics and map unavailable native services to `ErrPrintUnsupported`

## Verification
- `gofmt -l .`, `git diff --check`
- `go test -count=1 ./...`, `go test -race -count=1 ./...`, `go build ./...`
- Windows amd64/arm64 builds and platform test compilation
- macOS amd64/arm64 builds and platform test compilation
- Linux amd64/arm64 builds and platform test compilation
- Linux platform vet passes
- `golangci-lint` runs with only two pre-existing `goconst` findings (`internal/platform/darwin/menu.go`, `sound/sound_darwin.go`)

## Validation limits
- interactive Windows printer/dialog, macOS AppKit panel, and Linux portal/spool runs require their native hosts and were not available here
- Windows forwards the caller's complete document through GDI `RAW`; printer-driver support for PDF/document input remains a native-environment concern
- browser/WASM printing remains unsupported

Refs #243
