### PR TITLE
perf: reuse frame encoder and batch textured quads

### DIFF
--- a/context.go
+++ b/context.go
@@ -297,6 +297,13 @@ func (c *Context) CommandEncoder() *wgpu.CommandEncoder {
 		slog.Error("gogpu: shared frame encoder unavailable", "err", err)
 		return nil
 	}
+	// A textured-quad run may keep its render pass open for batching. Close it
+	// before lending the encoder to an external renderer so its pass can be
+	// recorded in the exact call-order position requested by the caller.
+	if err := ws.endTexturedQuadPass(); err != nil {
+		slog.Error("gogpu: shared frame encoder unavailable after textured quad pass", "err", err)
+		return nil
+	}
 	// Deferred clears must precede every externally recorded pass. Flushing
 	// here preserves call order; waiting until EndFrame would clear overlays.
 	if !ws.flushClear(ws.renderer.device, ws.renderer) {

--- a/context_command_encoder_test.go
+++ b/context_command_encoder_test.go
@@ -157,6 +157,20 @@ func TestContextCommandEncoderReusesAndSubmitsFrameEncoderOnce(t *testing.T) {
 	}
 }
 
+func TestBeginFrameReleasesPreviousTexturedQuadUniformArena(t *testing.T) {
+	ws := &RenderTarget{
+		texQuadUniformChunks: []texQuadUniformChunk{{nextSlot: 7}},
+	}
+	r := &Renderer{primary: ws}
+
+	if r.BeginFrame() {
+		t.Fatal("BeginFrame succeeded for an unconfigured surface")
+	}
+	if got := len(ws.texQuadUniformChunks); got != 0 {
+		t.Fatalf("textured-quad uniform chunks after new frame = %d, want 0", got)
+	}
+}
+
 func TestDrawTexturedQuadsReuseFrameEncoderAndPreserveLoadOrder(t *testing.T) {
 	halDevice := &recordingCommandEncoderDevice{}
 	ctx, target, queue := newSharedEncoderTestContextWithDevice(t, halDevice)

--- a/context_command_encoder_test.go
+++ b/context_command_encoder_test.go
@@ -13,7 +13,8 @@ import (
 
 type countingSubmitQueue struct {
 	noop.Queue
-	submits int
+	submits        int
+	writeBufferErr error
 }
 
 type commandEncoderFailDevice struct{ noop.Device }
@@ -27,6 +28,13 @@ func (d *commandEncoderFailDevice) CreateCommandEncoder(
 func (q *countingSubmitQueue) Submit(_ []hal.CommandBuffer) (uint64, error) {
 	q.submits++
 	return uint64(q.submits), nil
+}
+
+func (q *countingSubmitQueue) WriteBuffer(buffer hal.Buffer, offset uint64, data []byte) error {
+	if q.writeBufferErr != nil {
+		return q.writeBufferErr
+	}
+	return q.Queue.WriteBuffer(buffer, offset, data)
 }
 
 // recordingCommandEncoderDevice counts frame encoder creation and records the
@@ -429,6 +437,41 @@ func TestContextCommandEncoderReturnsNilWhenCreationFails(t *testing.T) {
 	ctx, _, _ := newSharedEncoderTestContextWithDevice(t, &commandEncoderFailDevice{})
 	if got := ctx.CommandEncoder(); got != nil {
 		t.Fatalf("CommandEncoder() = %v after creation failure, want nil", got)
+	}
+}
+
+func TestContextCommandEncoderReturnsNilWhenTexturedQuadPassEndFails(t *testing.T) {
+	ctx, target, queue := newSharedEncoderTestContext(t)
+	target.renderer.surfaceFormat = gputypes.TextureFormatBGRA8Unorm
+	target.format = gputypes.TextureFormatBGRA8Unorm
+	target.width = 1
+	target.height = 1
+
+	tex, err := target.renderer.NewTextureFromRGBA(1, 1, []byte{255, 0, 0, 255})
+	if err != nil {
+		t.Fatalf("NewTextureFromRGBA: %v", err)
+	}
+	t.Cleanup(tex.Destroy)
+
+	queue.writeBufferErr = errors.New("injected uniform write failure")
+	if err := ctx.DrawTextureEx(tex, DrawTextureOptions{Width: 1, Height: 1, Alpha: 1}); err != nil {
+		t.Fatalf("DrawTextureEx: %v", err)
+	}
+	if target.texturedQuadPass == nil {
+		t.Fatal("DrawTextureEx did not leave an active textured-quad pass")
+	}
+
+	if got := ctx.CommandEncoder(); got != nil {
+		t.Fatal("CommandEncoder returned an encoder after textured-quad pass failure")
+	}
+	if target.texturedQuadPass != nil {
+		t.Fatal("failed textured-quad pass was retained")
+	}
+	if target.frameEncoder != nil {
+		t.Fatal("failed shared encoder was retained")
+	}
+	if queue.submits != 0 {
+		t.Fatalf("failed shared encoder submissions = %d, want 0", queue.submits)
 	}
 }
 

--- a/context_command_encoder_test.go
+++ b/context_command_encoder_test.go
@@ -2,6 +2,7 @@ package gogpu
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/gogpu/gputypes"
@@ -28,13 +29,64 @@ func (q *countingSubmitQueue) Submit(_ []hal.CommandBuffer) (uint64, error) {
 	return uint64(q.submits), nil
 }
 
-func newSharedEncoderTestContext(t *testing.T) (*Context, *RenderTarget, *countingSubmitQueue) {
+// recordingCommandEncoderDevice counts frame encoder creation and records the
+// load operation for each render pass. It wraps the noop backend so the test
+// can prove both the submission boundary and clear/load ordering without a
+// real display or GPU.
+type recordingCommandEncoderDevice struct {
+	noop.Device
+	encoders []*recordingCommandEncoder
+}
+
+type recordingCommandEncoder struct {
+	*noop.CommandEncoder
+	loadOps        []gputypes.LoadOp
+	uniformOffsets [][]uint32
+}
+
+type recordingRenderPassEncoder struct {
+	hal.RenderPassEncoder
+	owner *recordingCommandEncoder
+}
+
+func (d *recordingCommandEncoderDevice) CreateCommandEncoder(
+	_ *hal.CommandEncoderDescriptor,
+) (hal.CommandEncoder, error) {
+	encoder := &recordingCommandEncoder{CommandEncoder: &noop.CommandEncoder{}}
+	d.encoders = append(d.encoders, encoder)
+	return encoder, nil
+}
+
+func (e *recordingCommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.RenderPassEncoder {
+	if len(desc.ColorAttachments) > 0 {
+		e.loadOps = append(e.loadOps, desc.ColorAttachments[0].LoadOp)
+	}
+	return &recordingRenderPassEncoder{
+		RenderPassEncoder: e.CommandEncoder.BeginRenderPass(desc),
+		owner:             e,
+	}
+}
+
+func (p *recordingRenderPassEncoder) SetBindGroup(index uint32, group hal.BindGroup, offsets []uint32) {
+	if index == 0 {
+		p.owner.uniformOffsets = append(p.owner.uniformOffsets, append([]uint32(nil), offsets...))
+	}
+	p.RenderPassEncoder.SetBindGroup(index, group, offsets)
+}
+
+type testContextHelper interface {
+	Helper()
+	Cleanup(func())
+	Fatalf(string, ...any)
+}
+
+func newSharedEncoderTestContext(t testContextHelper) (*Context, *RenderTarget, *countingSubmitQueue) {
 	t.Helper()
 	return newSharedEncoderTestContextWithDevice(t, &noop.Device{})
 }
 
 func newSharedEncoderTestContextWithDevice(
-	t *testing.T,
+	t testContextHelper,
 	halDevice hal.Device,
 ) (*Context, *RenderTarget, *countingSubmitQueue) {
 	t.Helper()
@@ -77,7 +129,7 @@ func newSharedEncoderTestContextWithDevice(
 			target.currentView.Release()
 		}
 		texture.Release()
-		device.Release()
+		renderer.Destroy()
 	})
 	return newContext(renderer, 1), target, queue
 }
@@ -102,6 +154,133 @@ func TestContextCommandEncoderReusesAndSubmitsFrameEncoderOnce(t *testing.T) {
 	}
 	if target.frameEncoder != nil {
 		t.Fatal("frame encoder retained after submission")
+	}
+}
+
+func TestDrawTexturedQuadsReuseFrameEncoderAndPreserveLoadOrder(t *testing.T) {
+	halDevice := &recordingCommandEncoderDevice{}
+	ctx, target, queue := newSharedEncoderTestContextWithDevice(t, halDevice)
+	target.renderer.surfaceFormat = gputypes.TextureFormatBGRA8Unorm
+	target.format = gputypes.TextureFormatBGRA8Unorm
+	target.width = 1
+	target.height = 1
+
+	tex, err := target.renderer.NewTextureFromRGBA(1, 1, []byte{255, 0, 0, 255})
+	if err != nil {
+		t.Fatalf("NewTextureFromRGBA: %v", err)
+	}
+	t.Cleanup(tex.Destroy)
+
+	// The first quad consumes the pending clear. Every subsequent quad must
+	// load the prior result while remaining in the same frame submission.
+	target.clear(0.1, 0.2, 0.3, 1)
+	for i := 0; i < 3; i++ {
+		if err := ctx.DrawTextureEx(tex, DrawTextureOptions{
+			X:      float32(i),
+			Y:      0,
+			Width:  1,
+			Height: 1,
+			Alpha:  1,
+		}); err != nil {
+			t.Fatalf("DrawTextureEx(%d): %v", i, err)
+		}
+	}
+
+	if got := len(halDevice.encoders); got != 1 {
+		t.Fatalf("frame command encoders created = %d, want 1", got)
+	}
+	if queue.submits != 0 {
+		t.Fatalf("submissions before EndFrame = %d, want 0", queue.submits)
+	}
+
+	if got, want := halDevice.encoders[0].loadOps, []gputypes.LoadOp{
+		gputypes.LoadOpClear,
+		gputypes.LoadOpLoad,
+		gputypes.LoadOpLoad,
+	}; !equalLoadOps(got, want) {
+		t.Fatalf("render-pass load ops = %v, want %v", got, want)
+	}
+	if got, want := halDevice.encoders[0].uniformOffsets, [][]uint32{{0}, {256}, {512}}; !equalOffsets(got, want) {
+		t.Fatalf("uniform dynamic offsets = %v, want %v", got, want)
+	}
+
+	target.submitFrameEncoder(target.renderer)
+	if queue.submits != 1 {
+		t.Fatalf("submissions after EndFrame = %d, want 1", queue.submits)
+	}
+}
+
+func equalLoadOps(got, want []gputypes.LoadOp) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalOffsets(got, want [][]uint32) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if len(got[i]) != len(want[i]) {
+			return false
+		}
+		for j := range got[i] {
+			if got[i][j] != want[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func BenchmarkDrawTexturedQuadsSharedFrameEncoder(b *testing.B) {
+	for _, draws := range []int{1, 20, 100} {
+		b.Run(fmt.Sprintf("draws=%d", draws), func(b *testing.B) {
+			halDevice := &recordingCommandEncoderDevice{}
+			ctx, target, queue := newSharedEncoderTestContextWithDevice(b, halDevice)
+			target.renderer.surfaceFormat = gputypes.TextureFormatBGRA8Unorm
+			target.format = gputypes.TextureFormatBGRA8Unorm
+			target.width = 1
+			target.height = 1
+
+			tex, err := target.renderer.NewTextureFromRGBA(1, 1, []byte{255, 0, 0, 255})
+			if err != nil {
+				b.Fatalf("NewTextureFromRGBA: %v", err)
+			}
+			b.Cleanup(tex.Destroy)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				target.frameCleared = false
+				for j := 0; j < draws; j++ {
+					if err := ctx.DrawTextureEx(tex, DrawTextureOptions{
+						X:      float32(j),
+						Width:  1,
+						Height: 1,
+						Alpha:  1,
+					}); err != nil {
+						b.Fatalf("DrawTextureEx(%d): %v", j, err)
+					}
+				}
+				target.submitFrameEncoder(target.renderer)
+				target.renderer.pollSubmissions()
+				target.releaseTexQuadUniformChunks()
+			}
+			b.StopTimer()
+
+			if got := len(halDevice.encoders); got != b.N {
+				b.Fatalf("frame command encoders created = %d, want %d", got, b.N)
+			}
+			if got := queue.submits; got != b.N {
+				b.Fatalf("frame submissions = %d, want %d", got, b.N)
+			}
+		})
 	}
 }
 

--- a/context_command_encoder_test.go
+++ b/context_command_encoder_test.go
@@ -207,17 +207,85 @@ func TestDrawTexturedQuadsReuseFrameEncoderAndPreserveLoadOrder(t *testing.T) {
 		t.Fatalf("submissions before EndFrame = %d, want 0", queue.submits)
 	}
 
-	if got, want := halDevice.encoders[0].loadOps, []gputypes.LoadOp{
-		gputypes.LoadOpClear,
-		gputypes.LoadOpLoad,
-		gputypes.LoadOpLoad,
-	}; !equalLoadOps(got, want) {
+	if got, want := halDevice.encoders[0].loadOps, []gputypes.LoadOp{gputypes.LoadOpClear}; !equalLoadOps(got, want) {
 		t.Fatalf("render-pass load ops = %v, want %v", got, want)
 	}
 	if got, want := halDevice.encoders[0].uniformOffsets, [][]uint32{{0}, {256}, {512}}; !equalOffsets(got, want) {
 		t.Fatalf("uniform dynamic offsets = %v, want %v", got, want)
 	}
 
+	target.submitFrameEncoder(target.renderer)
+	if queue.submits != 1 {
+		t.Fatalf("submissions after EndFrame = %d, want 1", queue.submits)
+	}
+}
+
+func TestTexturedQuadPassPreservesExternalAndClearBoundaries(t *testing.T) {
+	halDevice := &recordingCommandEncoderDevice{}
+	ctx, target, queue := newSharedEncoderTestContextWithDevice(t, halDevice)
+	target.renderer.surfaceFormat = gputypes.TextureFormatBGRA8Unorm
+	target.format = gputypes.TextureFormatBGRA8Unorm
+	target.width = 1
+	target.height = 1
+
+	tex, err := target.renderer.NewTextureFromRGBA(1, 1, []byte{255, 0, 0, 255})
+	if err != nil {
+		t.Fatalf("NewTextureFromRGBA: %v", err)
+	}
+	t.Cleanup(tex.Destroy)
+
+	target.clear(0.1, 0.2, 0.3, 1)
+	if err := ctx.DrawTextureEx(tex, DrawTextureOptions{Width: 1, Height: 1, Alpha: 1}); err != nil {
+		t.Fatalf("first DrawTextureEx: %v", err)
+	}
+
+	// Lending the frame encoder to an external renderer must close the current
+	// quad pass, then the next quad resumes with LoadOpLoad in call order.
+	encoder := ctx.CommandEncoder()
+	if encoder == nil {
+		t.Fatal("CommandEncoder returned nil")
+	}
+	externalPass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		ColorAttachments: []wgpu.RenderPassColorAttachment{{
+			View:    target.renderView(),
+			LoadOp:  gputypes.LoadOpLoad,
+			StoreOp: gputypes.StoreOpStore,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("external BeginRenderPass: %v", err)
+	}
+	if err := externalPass.End(); err != nil {
+		t.Fatalf("external End: %v", err)
+	}
+	if err := ctx.DrawTextureEx(tex, DrawTextureOptions{X: 1, Width: 1, Height: 1, Alpha: 1}); err != nil {
+		t.Fatalf("second DrawTextureEx: %v", err)
+	}
+
+	// An explicit clear is another pass boundary. It must not be folded into
+	// the already-open pass or reorder the clear relative to the next draw.
+	target.clear(0.4, 0.5, 0.6, 1)
+	if err := ctx.DrawTextureEx(tex, DrawTextureOptions{X: 2, Width: 1, Height: 1, Alpha: 1}); err != nil {
+		t.Fatalf("third DrawTextureEx: %v", err)
+	}
+
+	if got := len(halDevice.encoders); got != 1 {
+		t.Fatalf("frame command encoders created = %d, want 1", got)
+	}
+	if got, want := halDevice.encoders[0].loadOps, []gputypes.LoadOp{
+		gputypes.LoadOpClear,
+		gputypes.LoadOpLoad,
+		gputypes.LoadOpLoad,
+		gputypes.LoadOpClear,
+	}; !equalLoadOps(got, want) {
+		t.Fatalf("render-pass load ops = %v, want %v", got, want)
+	}
+	if got, want := halDevice.encoders[0].uniformOffsets, [][]uint32{{0}, {256}, {512}}; !equalOffsets(got, want) {
+		t.Fatalf("uniform dynamic offsets = %v, want %v", got, want)
+	}
+	if queue.submits != 0 {
+		t.Fatalf("submissions before EndFrame = %d, want 0", queue.submits)
+	}
 	target.submitFrameEncoder(target.renderer)
 	if queue.submits != 1 {
 		t.Fatalf("submissions after EndFrame = %d, want 1", queue.submits)
@@ -282,6 +350,9 @@ func BenchmarkDrawTexturedQuadsSharedFrameEncoder(b *testing.B) {
 						b.Fatalf("DrawTextureEx(%d): %v", j, err)
 					}
 				}
+				if got := len(halDevice.encoders[i].loadOps); got != 1 {
+					b.Fatalf("render passes for %d draws = %d, want 1", draws, got)
+				}
 				target.submitFrameEncoder(target.renderer)
 				target.renderer.pollSubmissions()
 				target.releaseTexQuadUniformChunks()
@@ -294,6 +365,10 @@ func BenchmarkDrawTexturedQuadsSharedFrameEncoder(b *testing.B) {
 			if got := queue.submits; got != b.N {
 				b.Fatalf("frame submissions = %d, want %d", got, b.N)
 			}
+			b.ReportMetric(float64(draws), "draws/frame")
+			b.ReportMetric(1, "passes/frame")
+			b.ReportMetric(1, "encoders/frame")
+			b.ReportMetric(1, "submits/frame")
 		})
 	}
 }

--- a/renderer.go
+++ b/renderer.go
@@ -1703,30 +1703,6 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 		ws.hasPendingClear = false
 	}
 
-	// Upload uniform data only after the render pass has been accepted. Queue
-	// writes may be deferred in a staging encoder; keeping them after the begin
-	// check avoids leaving a write targeting an unreferenced frame buffer when a
-	// released attachment rejects the pass.
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[0:4], math.Float32bits(opts.X))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[4:8], math.Float32bits(opts.Y))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[8:12], math.Float32bits(opts.Width))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[12:16], math.Float32bits(opts.Height))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[16:20], math.Float32bits(float32(ws.width)))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[20:24], math.Float32bits(float32(ws.height)))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[24:28], math.Float32bits(opts.Alpha))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[28:32], math.Float32bits(premulFlag))
-	if err := r.device.Queue().WriteBuffer(uniform.buffer, uint64(uniform.offset), r.texQuadUniformData); err != nil {
-		// The pass has no useful draw without its parameters. Close and discard
-		// the shared encoder so the clear/pass cannot reach the surface, while
-		// preserving the frame's previous resources for the next frame boundary.
-		_ = renderPass.End()
-		if consumePendingClear {
-			ws.hasPendingClear = true
-		}
-		ws.discardFrameEncoder()
-		return fmt.Errorf("gogpu: WriteBuffer uniform failed: %w", err)
-	}
-
 	// Set pipeline and bind groups
 	renderPass.SetPipeline(r.texQuadPipeline)
 	renderPass.SetBindGroup(0, uniform.bindGrp, []uint32{uniform.offset})
@@ -1737,8 +1713,34 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 
 	// End render pass
 	if err := renderPass.End(); err != nil {
+		if consumePendingClear {
+			ws.hasPendingClear = true
+		}
 		ws.discardFrameEncoder()
 		return fmt.Errorf("gogpu: failed to end render pass: %w", err)
+	}
+
+	// Upload uniform data only after the render pass has fully recorded. Queue
+	// writes may be deferred in a staging encoder and are prepended before user
+	// command buffers at Submit, so this ordering avoids leaving a write
+	// targeting an unreferenced frame buffer when pass validation fails.
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[0:4], math.Float32bits(opts.X))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[4:8], math.Float32bits(opts.Y))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[8:12], math.Float32bits(opts.Width))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[12:16], math.Float32bits(opts.Height))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[16:20], math.Float32bits(float32(ws.width)))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[20:24], math.Float32bits(float32(ws.height)))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[24:28], math.Float32bits(opts.Alpha))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[28:32], math.Float32bits(premulFlag))
+	if err := r.device.Queue().WriteBuffer(uniform.buffer, uint64(uniform.offset), r.texQuadUniformData); err != nil {
+		// The pass has no useful draw without its parameters. Discard the shared
+		// encoder so the clear/pass cannot reach the surface, while preserving the
+		// frame's previous resources for the next frame boundary.
+		if consumePendingClear {
+			ws.hasPendingClear = true
+		}
+		ws.discardFrameEncoder()
+		return fmt.Errorf("gogpu: WriteBuffer uniform failed: %w", err)
 	}
 
 	// Mark frame as having content (for subsequent LoadOp)

--- a/renderer.go
+++ b/renderer.go
@@ -30,6 +30,30 @@ const (
 	texQuadUniformSize = 32
 )
 
+// texQuadUniformStride is the dynamic-uniform alignment required by WebGPU's
+// minimum uniform-buffer offset limit. Keeping each draw in its own aligned
+// slot is required once textured quads share a command encoder: a queue write
+// must not overwrite the parameters recorded for an earlier pass.
+const texQuadUniformStride = 256
+
+// texQuadUniformChunkSlots bounds the initial per-frame allocation. A new
+// chunk is added only for unusually large frames; older chunks stay alive until
+// the frame boundary because already-recorded passes may still reference them.
+const texQuadUniformChunkSlots = 64
+
+type texQuadUniformChunk struct {
+	buffer   *wgpu.Buffer
+	bindGrp  *wgpu.BindGroup
+	stride   uint32
+	nextSlot uint32
+}
+
+type texQuadUniformAllocation struct {
+	buffer  *wgpu.Buffer
+	bindGrp *wgpu.BindGroup
+	offset  uint32
+}
+
 // SurfaceState tracks the lifecycle state of a GPU surface.
 // Transitions follow the WebGPU spec + wgpu framework.rs recovery pattern:
 //
@@ -68,6 +92,11 @@ type RenderTarget struct {
 	// frameEncoder is borrowed by external renderers and owned by this surface.
 	// It is finished and submitted exactly once at frame end.
 	frameEncoder *wgpu.CommandEncoder
+
+	// Textured-quad uniform chunks are owned by this surface frame. Each draw
+	// gets a distinct dynamic-uniform slot so recording N passes into the shared
+	// encoder preserves every quad's parameters on direct-write backends too.
+	texQuadUniformChunks []texQuadUniformChunk
 
 	// Deferred clear -- eliminates separate Clear render pass.
 	// ClearColor stores the color and sets hasPendingClear=true.
@@ -215,9 +244,6 @@ type Renderer struct {
 	texQuadUniformLayout  *wgpu.BindGroupLayout
 	texQuadTextureLayout  *wgpu.BindGroupLayout
 	texQuadPipelineLayout *wgpu.PipelineLayout
-	texQuadUniformBuffer  *wgpu.Buffer
-	texQuadUniformBindGrp *wgpu.BindGroup
-	texQuadUniformData    []byte
 	texQuadPipelineInited bool
 
 	// Dedicated composition blit pipeline (ADR-067).
@@ -839,6 +865,7 @@ func (ws *RenderTarget) setTransactionPresent(enabled bool) {
 // Uses ws.platWindow and ws.renderer.{device,adapter} — no parameters needed.
 func (ws *RenderTarget) prepareLazyAcquire() {
 	ws.discardFrameEncoder()
+	ws.releaseTexQuadUniformChunks()
 	ws.frameStarted = false
 	ws.hasGPUWork = false
 	ws.pixelPresented = false
@@ -917,6 +944,72 @@ func (ws *RenderTarget) ensureFrameEncoder() (*wgpu.CommandEncoder, error) {
 	}
 	ws.frameEncoder = encoder
 	return encoder, nil
+}
+
+// allocateTexQuadUniform reserves one aligned uniform slot for a textured
+// quad recorded in the current frame. Chunks are frame-owned rather than
+// renderer-owned so their data cannot be overwritten while another window's
+// frame is still in flight.
+func (ws *RenderTarget) allocateTexQuadUniform(r *Renderer) (texQuadUniformAllocation, error) {
+	stride := uint32(texQuadUniformStride)
+	if limit := r.device.Limits().MinUniformBufferOffsetAlignment; limit > stride {
+		stride = limit
+	}
+	if len(ws.texQuadUniformChunks) == 0 ||
+		ws.texQuadUniformChunks[len(ws.texQuadUniformChunks)-1].nextSlot >= texQuadUniformChunkSlots {
+		buffer, err := r.device.CreateBuffer(&wgpu.BufferDescriptor{
+			Label: "Textured Quad Frame Uniforms",
+			Size:  uint64(stride) * uint64(texQuadUniformChunkSlots),
+			Usage: gputypes.BufferUsageUniform | gputypes.BufferUsageCopyDst,
+		})
+		if err != nil {
+			return texQuadUniformAllocation{}, fmt.Errorf("gogpu: create textured quad frame uniforms: %w", err)
+		}
+		bindGrp, err := r.device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+			Label:  "Textured Quad Frame Uniform Bind Group",
+			Layout: r.texQuadUniformLayout,
+			Entries: []wgpu.BindGroupEntry{
+				{
+					Binding: 0,
+					Buffer:  buffer,
+					Size:    texQuadUniformSize,
+				},
+			},
+		})
+		if err != nil {
+			buffer.Release()
+			return texQuadUniformAllocation{}, fmt.Errorf("gogpu: create textured quad frame uniform bind group: %w", err)
+		}
+		ws.texQuadUniformChunks = append(ws.texQuadUniformChunks, texQuadUniformChunk{
+			buffer:  buffer,
+			bindGrp: bindGrp,
+			stride:  stride,
+		})
+	}
+
+	chunk := &ws.texQuadUniformChunks[len(ws.texQuadUniformChunks)-1]
+	offset := chunk.nextSlot * chunk.stride
+	chunk.nextSlot++
+	return texQuadUniformAllocation{
+		buffer:  chunk.buffer,
+		bindGrp: chunk.bindGrp,
+		offset:  offset,
+	}, nil
+}
+
+// releaseTexQuadUniformChunks releases frame uniform resources after the
+// previous frame's submission has completed (the same boundary used for
+// composition bind groups). It is also called by RenderTarget.destroy.
+func (ws *RenderTarget) releaseTexQuadUniformChunks() {
+	for _, chunk := range ws.texQuadUniformChunks {
+		if chunk.bindGrp != nil {
+			chunk.bindGrp.Release()
+		}
+		if chunk.buffer != nil {
+			chunk.buffer.Release()
+		}
+	}
+	ws.texQuadUniformChunks = nil
 }
 
 // submitFrameEncoder finishes and submits the framework-owned shared encoder.
@@ -1389,8 +1482,9 @@ func (r *Renderer) initTexturedQuadPipeline() error {
 				Binding:    0,
 				Visibility: gputypes.ShaderStageVertex | gputypes.ShaderStageFragment,
 				Buffer: &gputypes.BufferBindingLayout{
-					Type:           gputypes.BufferBindingTypeUniform,
-					MinBindingSize: texQuadUniformSize,
+					Type:             gputypes.BufferBindingTypeUniform,
+					HasDynamicOffset: true,
+					MinBindingSize:   texQuadUniformSize,
 				},
 			},
 		},
@@ -1473,38 +1567,6 @@ func (r *Renderer) initTexturedQuadPipeline() error {
 		return fmt.Errorf("gogpu: failed to create render pipeline: %w", err)
 	}
 
-	// Create uniform buffer. CopyDst required because Queue.WriteBuffer uses
-	// PendingWrites staging → CopyBufferRegion internally.
-	// MapWrite + MappedAtCreation removed: buffer is never re-mapped after
-	// creation, and initial data is written via WriteBuffer each frame.
-	r.texQuadUniformBuffer, err = r.device.CreateBuffer(&wgpu.BufferDescriptor{
-		Label: "Textured Quad Uniforms",
-		Size:  texQuadUniformSize,
-		Usage: gputypes.BufferUsageUniform | gputypes.BufferUsageCopyDst,
-	})
-	if err != nil {
-		return fmt.Errorf("gogpu: failed to create uniform buffer: %w", err)
-	}
-
-	// Create bind group for uniforms (group 0)
-	r.texQuadUniformBindGrp, err = r.device.CreateBindGroup(&wgpu.BindGroupDescriptor{
-		Label:  "Textured Quad Uniform Bind Group",
-		Layout: r.texQuadUniformLayout,
-		Entries: []wgpu.BindGroupEntry{
-			{
-				Binding: 0,
-				Buffer:  r.texQuadUniformBuffer,
-				Size:    texQuadUniformSize,
-			},
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("gogpu: failed to create uniform bind group: %w", err)
-	}
-
-	// Pre-allocate uniform data buffer to avoid per-frame allocations
-	r.texQuadUniformData = make([]byte, texQuadUniformSize)
-
 	r.texQuadPipelineInited = true
 	return nil
 }
@@ -1585,24 +1647,30 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 		return fmt.Errorf("gogpu: failed to get texture bind group: %w", err)
 	}
 
-	// Create command encoder
-	encoder, err := r.device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{
-		Label: "DrawTexturedQuad",
-	})
+	// Record into the frame-owned encoder. The frame finishes and submits this
+	// encoder once at EndFrame, so multiple textured quads avoid one encoder
+	// creation, finish, and queue submission per draw while retaining their
+	// render-pass order.
+	encoder, err := ws.ensureFrameEncoder()
 	if err != nil {
-		return fmt.Errorf("gogpu: failed to create command encoder: %w", err)
+		return fmt.Errorf("gogpu: shared frame encoder unavailable: %w", err)
+	}
+	uniform, err := ws.allocateTexQuadUniform(r)
+	if err != nil {
+		return err
 	}
 
 	// Upload uniform data — screen dimensions come from per-window state
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[0:4], math.Float32bits(opts.X))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[4:8], math.Float32bits(opts.Y))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[8:12], math.Float32bits(opts.Width))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[12:16], math.Float32bits(opts.Height))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[16:20], math.Float32bits(float32(ws.width)))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[20:24], math.Float32bits(float32(ws.height)))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[24:28], math.Float32bits(opts.Alpha))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[28:32], math.Float32bits(premulFlag))
-	if err := r.device.Queue().WriteBuffer(r.texQuadUniformBuffer, 0, r.texQuadUniformData); err != nil {
+	var uniformData [texQuadUniformSize]byte
+	binary.LittleEndian.PutUint32(uniformData[0:4], math.Float32bits(opts.X))
+	binary.LittleEndian.PutUint32(uniformData[4:8], math.Float32bits(opts.Y))
+	binary.LittleEndian.PutUint32(uniformData[8:12], math.Float32bits(opts.Width))
+	binary.LittleEndian.PutUint32(uniformData[12:16], math.Float32bits(opts.Height))
+	binary.LittleEndian.PutUint32(uniformData[16:20], math.Float32bits(float32(ws.width)))
+	binary.LittleEndian.PutUint32(uniformData[20:24], math.Float32bits(float32(ws.height)))
+	binary.LittleEndian.PutUint32(uniformData[24:28], math.Float32bits(opts.Alpha))
+	binary.LittleEndian.PutUint32(uniformData[28:32], math.Float32bits(premulFlag))
+	if err := r.device.Queue().WriteBuffer(uniform.buffer, uint64(uniform.offset), uniformData[:]); err != nil {
 		return fmt.Errorf("gogpu: WriteBuffer uniform failed: %w", err)
 	}
 
@@ -1635,7 +1703,7 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 
 	// Set pipeline and bind groups
 	renderPass.SetPipeline(r.texQuadPipeline)
-	renderPass.SetBindGroup(0, r.texQuadUniformBindGrp, nil)
+	renderPass.SetBindGroup(0, uniform.bindGrp, []uint32{uniform.offset})
 	renderPass.SetBindGroup(1, texBindGroup, nil)
 
 	// Draw 6 vertices (2 triangles for quad)
@@ -1645,15 +1713,6 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 	if err := renderPass.End(); err != nil {
 		return fmt.Errorf("gogpu: failed to end render pass: %w", err)
 	}
-
-	// Finish and submit
-	commands, err := encoder.Finish()
-	if err != nil {
-		return fmt.Errorf("gogpu: failed to finish encoding: %w", err)
-	}
-
-	// Submit with fence tracking (command buffer released when GPU done)
-	r.submitTracked(commands)
 
 	// Mark frame as having content (for subsequent LoadOp)
 	ws.frameCleared = true
@@ -1720,12 +1779,17 @@ func (r *Renderer) RenderToImage(width, height int, draw func(*Context)) (*image
 		currentView:  view,
 		frameStarted: true,
 	}
+	defer synthetic.releaseTexQuadUniformChunks()
 	r.primary = synthetic
 
 	ctx := newContext(r, 1.0)
 	draw(ctx)
 	// Flush Context.Clear() calls that were deferred as a pending clear.
 	synthetic.flushClear(r.device, r)
+	// Window frames submit their shared encoder in EndFrame. RenderToImage has
+	// no window lifecycle, so finish the synthetic frame before issuing the
+	// readback command buffer below.
+	synthetic.submitFrameEncoder(r)
 
 	r.primary = prevPrimary
 
@@ -1887,14 +1951,6 @@ func (r *Renderer) Destroy() {
 	r.destroyBlitPipeline()
 
 	// Release textured quad pipeline resources (reverse order)
-	if r.texQuadUniformBindGrp != nil {
-		r.texQuadUniformBindGrp.Release()
-		r.texQuadUniformBindGrp = nil
-	}
-	if r.texQuadUniformBuffer != nil {
-		r.texQuadUniformBuffer.Release()
-		r.texQuadUniformBuffer = nil
-	}
 	if r.texQuadPipelineLayout != nil {
 		r.texQuadPipelineLayout.Release()
 		r.texQuadPipelineLayout = nil
@@ -1962,6 +2018,7 @@ func (r *Renderer) destroyBlitPipeline() {
 // destroy releases all resources owned by this window surface.
 func (ws *RenderTarget) destroy() {
 	ws.discardFrameEncoder()
+	ws.releaseTexQuadUniformChunks()
 	ws.releaseCompositionTexture()
 	if ws.currentView != nil {
 		ws.currentView.Release()

--- a/renderer.go
+++ b/renderer.go
@@ -54,6 +54,12 @@ type texQuadUniformAllocation struct {
 	offset  uint32
 }
 
+type texQuadUniformWrite struct {
+	buffer *wgpu.Buffer
+	offset uint32
+	data   [texQuadUniformSize]byte
+}
+
 // SurfaceState tracks the lifecycle state of a GPU surface.
 // Transitions follow the WebGPU spec + wgpu framework.rs recovery pattern:
 //
@@ -90,8 +96,20 @@ type RenderTarget struct {
 	frameCleared          bool // Whether the frame has been cleared (for LoadOp selection)
 	externalContent       bool // External renderer (g3d) has content on surface (MarkPreserveContent)
 	// frameEncoder is borrowed by external renderers and owned by this surface.
-	// It is finished and submitted exactly once at frame end.
+	// It is normally finished and submitted at frame end; standalone rendering
+	// paths may flush it earlier to preserve call order.
 	frameEncoder *wgpu.CommandEncoder
+	// texturedQuadPass stays open while consecutive textured quads target the
+	// same frame. Boundary operations (external passes, clears, blits, and frame
+	// submission) close it before recording their own pass so call order remains
+	// observable and arbitrary external interleaving remains valid.
+	texturedQuadPass *wgpu.RenderPassEncoder
+	// Uniform writes are deferred until texturedQuadPass closes. Queue writes
+	// recorded while a pass is still open could survive a failed pass and target
+	// an unsubmitted frame buffer; retaining one immutable payload per draw keeps
+	// the A3 failure/lifetime guarantee while allowing one pass per contiguous run.
+	pendingTexQuadUniformWrites   []texQuadUniformWrite
+	texturedQuadPassConsumedClear bool
 
 	// Textured-quad uniform chunks are owned by this surface frame. Each draw
 	// gets a distinct dynamic-uniform slot so recording N passes into the shared
@@ -1017,10 +1035,16 @@ func (ws *RenderTarget) releaseTexQuadUniformChunks() {
 		}
 	}
 	ws.texQuadUniformChunks = nil
+	ws.pendingTexQuadUniformWrites = ws.pendingTexQuadUniformWrites[:0]
+	ws.texturedQuadPassConsumedClear = false
 }
 
 // submitFrameEncoder finishes and submits the framework-owned shared encoder.
 func (ws *RenderTarget) submitFrameEncoder(r *Renderer) {
+	if err := ws.endTexturedQuadPass(); err != nil {
+		slog.Error("finish textured quad render pass failed", "err", err)
+		return
+	}
 	encoder := ws.frameEncoder
 	ws.frameEncoder = nil
 	if encoder == nil {
@@ -1032,6 +1056,84 @@ func (ws *RenderTarget) submitFrameEncoder(r *Renderer) {
 		return
 	}
 	r.submitTracked(commands)
+}
+
+// endTexturedQuadPass closes the pass used by the current contiguous textured
+// quad run and publishes its deferred uniform writes. It is the only normal
+// path that ends this pass; callers use it before recording any external or
+// framework-owned pass so pass order remains explicit.
+func (ws *RenderTarget) endTexturedQuadPass() error {
+	pass := ws.texturedQuadPass
+	if pass == nil {
+		return nil
+	}
+	ws.texturedQuadPass = nil
+	if err := pass.End(); err != nil {
+		ws.abortTexturedQuadPassState()
+		ws.discardFrameEncoder()
+		return fmt.Errorf("gogpu: end textured quad render pass: %w", err)
+	}
+
+	writes := ws.pendingTexQuadUniformWrites
+	for _, write := range writes {
+		if err := ws.renderer.device.Queue().WriteBuffer(write.buffer, uint64(write.offset), write.data[:]); err != nil {
+			ws.pendingTexQuadUniformWrites = ws.pendingTexQuadUniformWrites[:0]
+			ws.abortTexturedQuadPassState()
+			ws.discardFrameEncoder()
+			return fmt.Errorf("gogpu: WriteBuffer uniform failed: %w", err)
+		}
+	}
+	ws.pendingTexQuadUniformWrites = ws.pendingTexQuadUniformWrites[:0]
+	ws.texturedQuadPassConsumedClear = false
+	return nil
+}
+
+// beginTexturedQuadPass starts a pass for a contiguous textured-quad run.
+// The caller has already closed any prior run when an explicit clear is
+// pending, so this helper only handles the first pass state for the run.
+func (ws *RenderTarget) beginTexturedQuadPass(encoder *wgpu.CommandEncoder) error {
+	loadOp := gputypes.LoadOpClear
+	clearValue := gputypes.Color{R: 0, G: 0, B: 0, A: 0}
+	consumePendingClear := false
+	switch {
+	case ws.hasPendingClear:
+		clearValue = ws.pendingClearColor
+		consumePendingClear = true
+	case ws.frameCleared:
+		loadOp = gputypes.LoadOpLoad
+	}
+
+	pass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		ColorAttachments: []wgpu.RenderPassColorAttachment{{
+			View:       ws.renderView(),
+			LoadOp:     loadOp,
+			StoreOp:    gputypes.StoreOpStore,
+			ClearValue: clearValue,
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("gogpu: failed to begin render pass: %w", err)
+	}
+	ws.texturedQuadPass = pass
+	ws.texturedQuadPassConsumedClear = consumePendingClear
+	if consumePendingClear {
+		ws.hasPendingClear = false
+	}
+	return nil
+}
+
+// abortTexturedQuadPassState drops the pass-local state after a failed pass or
+// an abandoned frame. The shared encoder itself is discarded by the caller.
+func (ws *RenderTarget) abortTexturedQuadPassState() {
+	if ws.texturedQuadPass != nil {
+		_ = ws.texturedQuadPass.End()
+		ws.texturedQuadPass = nil
+	}
+	if ws.texturedQuadPassConsumedClear {
+		ws.hasPendingClear = true
+	}
+	ws.texturedQuadPassConsumedClear = false
+	ws.pendingTexQuadUniformWrites = ws.pendingTexQuadUniformWrites[:0]
 }
 
 // drawDebugOverlays iterates registered debug overlays and calls their Draw
@@ -1064,6 +1166,10 @@ func (ws *RenderTarget) drawDebugOverlays() {
 	if ws.currentView == nil {
 		return
 	}
+	if err := ws.endTexturedQuadPass(); err != nil {
+		slog.Error("gogpu: end textured quad pass before debug overlays failed", "err", err)
+		return
+	}
 
 	encoder, err := ws.ensureFrameEncoder()
 	if err != nil {
@@ -1093,6 +1199,7 @@ func (ws *RenderTarget) drawDebugOverlays() {
 
 // discardFrameEncoder abandons an unsubmitted shared encoder on cancellation.
 func (ws *RenderTarget) discardFrameEncoder() {
+	ws.abortTexturedQuadPassState()
 	if ws.frameEncoder == nil {
 		return
 	}
@@ -1220,6 +1327,10 @@ func (r *Renderer) blitComposToSwapchain(ws *RenderTarget) {
 	if ws.composView == nil || ws.currentView == nil {
 		return
 	}
+	if err := ws.endTexturedQuadPass(); err != nil {
+		slog.Error("gogpu: end textured quad pass before composition blit failed", "err", err)
+		return
+	}
 	if !r.blitPipeline.Inited {
 		if err := r.initBlitPipeline(); err != nil {
 			slog.Error("gogpu: blit pipeline init failed", "err", err)
@@ -1266,6 +1377,10 @@ func (ws *RenderTarget) clear(red, green, blue, alpha float64) {
 // flushClear applies any pending clear immediately as a standalone render pass.
 // Called by EndFrame if no draw calls consumed the pending clear.
 func (ws *RenderTarget) flushClear(device *wgpu.Device, r *Renderer) bool {
+	if err := ws.endTexturedQuadPass(); err != nil {
+		slog.Error("end textured quad pass before clear failed", "err", err)
+		return false
+	}
 	if !ws.hasPendingClear || ws.currentView == nil {
 		return true
 	}
@@ -1414,6 +1529,12 @@ func (r *Renderer) DrawTriangle(clearR, clearG, clearB, clearA float64) error {
 		return nil
 	}
 	ws.hasGPUWork = true
+	// DrawTriangle retains its standalone submission contract. Flush any
+	// shared textured-quad encoder first so a triangle interleaved with quads
+	// cannot overtake the earlier draws while the quad pass is still open.
+	if ws.frameEncoder != nil {
+		ws.submitFrameEncoder(r)
+	}
 
 	// Initialize pipeline on first use
 	if r.trianglePipeline == nil {
@@ -1657,71 +1778,41 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 		return fmt.Errorf("gogpu: failed to get texture bind group: %w", err)
 	}
 
-	// Record into the frame-owned encoder. The frame finishes and submits this
-	// encoder once at EndFrame, so multiple textured quads avoid one encoder
-	// creation, finish, and queue submission per draw while retaining their
-	// render-pass order.
+	// Record into the frame-owned encoder. Consecutive textured quads share one
+	// render pass; boundary operations close it before recording their own pass,
+	// preserving arbitrary texture ordering and external interleaving.
 	encoder, err := ws.ensureFrameEncoder()
 	if err != nil {
 		return fmt.Errorf("gogpu: shared frame encoder unavailable: %w", err)
+	}
+	if ws.texturedQuadPass != nil && ws.hasPendingClear {
+		if err := ws.endTexturedQuadPass(); err != nil {
+			return err
+		}
 	}
 	uniform, err := ws.allocateTexQuadUniform(r)
 	if err != nil {
 		return err
 	}
 
-	// Determine LoadOp: consume pending clear if available, otherwise preserve content.
-	// Default clear = transparent black (WebGPU spec, Rust wgpu Color::default).
-	// Opaque black (A:1) would destroy alpha for compositing (ggcanvas, DrawTexture).
-	loadOp := gputypes.LoadOpClear
-	clearValue := gputypes.Color{R: 0, G: 0, B: 0, A: 0}
-	consumePendingClear := false
-	if ws.hasPendingClear {
-		clearValue = ws.pendingClearColor
-		consumePendingClear = true
-	} else if ws.frameCleared {
-		loadOp = gputypes.LoadOpLoad
-	}
-
-	// Begin render pass
-	renderPass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
-		ColorAttachments: []wgpu.RenderPassColorAttachment{
-			{
-				View:       ws.renderView(),
-				LoadOp:     loadOp,
-				StoreOp:    gputypes.StoreOpStore,
-				ClearValue: clearValue,
-			},
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("gogpu: failed to begin render pass: %w", err)
-	}
-	if consumePendingClear {
-		ws.hasPendingClear = false
+	if ws.texturedQuadPass == nil {
+		if err := ws.beginTexturedQuadPass(encoder); err != nil {
+			return err
+		}
 	}
 
 	// Set pipeline and bind groups
-	renderPass.SetPipeline(r.texQuadPipeline)
-	renderPass.SetBindGroup(0, uniform.bindGrp, []uint32{uniform.offset})
-	renderPass.SetBindGroup(1, texBindGroup, nil)
+	ws.texturedQuadPass.SetPipeline(r.texQuadPipeline)
+	ws.texturedQuadPass.SetBindGroup(0, uniform.bindGrp, []uint32{uniform.offset})
+	ws.texturedQuadPass.SetBindGroup(1, texBindGroup, nil)
 
 	// Draw 6 vertices (2 triangles for quad)
-	renderPass.Draw(6, 1, 0, 0)
+	ws.texturedQuadPass.Draw(6, 1, 0, 0)
 
-	// End render pass
-	if err := renderPass.End(); err != nil {
-		if consumePendingClear {
-			ws.hasPendingClear = true
-		}
-		ws.discardFrameEncoder()
-		return fmt.Errorf("gogpu: failed to end render pass: %w", err)
-	}
-
-	// Upload uniform data only after the render pass has fully recorded. Queue
-	// writes may be deferred in a staging encoder and are prepended before user
-	// command buffers at Submit, so this ordering avoids leaving a write
-	// targeting an unreferenced frame buffer when pass validation fails.
+	// Retain an immutable payload until the pass closes. Queue writes may be
+	// deferred in a staging encoder and are prepended before user command buffers
+	// at Submit, so publishing only after End avoids targeting an unreferenced
+	// frame buffer when pass validation fails.
 	binary.LittleEndian.PutUint32(r.texQuadUniformData[0:4], math.Float32bits(opts.X))
 	binary.LittleEndian.PutUint32(r.texQuadUniformData[4:8], math.Float32bits(opts.Y))
 	binary.LittleEndian.PutUint32(r.texQuadUniformData[8:12], math.Float32bits(opts.Width))
@@ -1730,16 +1821,11 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 	binary.LittleEndian.PutUint32(r.texQuadUniformData[20:24], math.Float32bits(float32(ws.height)))
 	binary.LittleEndian.PutUint32(r.texQuadUniformData[24:28], math.Float32bits(opts.Alpha))
 	binary.LittleEndian.PutUint32(r.texQuadUniformData[28:32], math.Float32bits(premulFlag))
-	if err := r.device.Queue().WriteBuffer(uniform.buffer, uint64(uniform.offset), r.texQuadUniformData); err != nil {
-		// The pass has no useful draw without its parameters. Discard the shared
-		// encoder so the clear/pass cannot reach the surface, while preserving the
-		// frame's previous resources for the next frame boundary.
-		if consumePendingClear {
-			ws.hasPendingClear = true
-		}
-		ws.discardFrameEncoder()
-		return fmt.Errorf("gogpu: WriteBuffer uniform failed: %w", err)
-	}
+	ws.pendingTexQuadUniformWrites = append(ws.pendingTexQuadUniformWrites, texQuadUniformWrite{
+		buffer: uniform.buffer,
+		offset: uniform.offset,
+	})
+	copy(ws.pendingTexQuadUniformWrites[len(ws.pendingTexQuadUniformWrites)-1].data[:], r.texQuadUniformData)
 
 	// Mark frame as having content (for subsequent LoadOp)
 	ws.frameCleared = true

--- a/renderer.go
+++ b/renderer.go
@@ -1463,8 +1463,6 @@ func (r *Renderer) DrawTriangle(clearR, clearG, clearB, clearA float64) error {
 
 // initTexturedQuadPipeline creates the GPU resources for textured quad rendering.
 // This is called lazily on the first DrawTexture call.
-//
-//nolint:funlen // pipeline init is inherently sequential setup code
 func (r *Renderer) initTexturedQuadPipeline() error {
 	if r.texQuadPipelineInited {
 		return nil

--- a/renderer.go
+++ b/renderer.go
@@ -244,6 +244,7 @@ type Renderer struct {
 	texQuadUniformLayout  *wgpu.BindGroupLayout
 	texQuadTextureLayout  *wgpu.BindGroupLayout
 	texQuadPipelineLayout *wgpu.PipelineLayout
+	texQuadUniformData    []byte
 	texQuadPipelineInited bool
 
 	// Dedicated composition blit pipeline (ADR-067).
@@ -1567,6 +1568,11 @@ func (r *Renderer) initTexturedQuadPipeline() error {
 		return fmt.Errorf("gogpu: failed to create render pipeline: %w", err)
 	}
 
+	// Reuse the CPU-side payload while Queue.WriteBuffer copies it into the
+	// backend's staging/direct-write path. The GPU-visible data is still kept
+	// in per-draw dynamic slots above, so this scratch buffer is safe to reuse
+	// between calls on the render thread.
+	r.texQuadUniformData = make([]byte, texQuadUniformSize)
 	r.texQuadPipelineInited = true
 	return nil
 }
@@ -1661,16 +1667,15 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 	}
 
 	// Upload uniform data — screen dimensions come from per-window state
-	var uniformData [texQuadUniformSize]byte
-	binary.LittleEndian.PutUint32(uniformData[0:4], math.Float32bits(opts.X))
-	binary.LittleEndian.PutUint32(uniformData[4:8], math.Float32bits(opts.Y))
-	binary.LittleEndian.PutUint32(uniformData[8:12], math.Float32bits(opts.Width))
-	binary.LittleEndian.PutUint32(uniformData[12:16], math.Float32bits(opts.Height))
-	binary.LittleEndian.PutUint32(uniformData[16:20], math.Float32bits(float32(ws.width)))
-	binary.LittleEndian.PutUint32(uniformData[20:24], math.Float32bits(float32(ws.height)))
-	binary.LittleEndian.PutUint32(uniformData[24:28], math.Float32bits(opts.Alpha))
-	binary.LittleEndian.PutUint32(uniformData[28:32], math.Float32bits(premulFlag))
-	if err := r.device.Queue().WriteBuffer(uniform.buffer, uint64(uniform.offset), uniformData[:]); err != nil {
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[0:4], math.Float32bits(opts.X))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[4:8], math.Float32bits(opts.Y))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[8:12], math.Float32bits(opts.Width))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[12:16], math.Float32bits(opts.Height))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[16:20], math.Float32bits(float32(ws.width)))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[20:24], math.Float32bits(float32(ws.height)))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[24:28], math.Float32bits(opts.Alpha))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[28:32], math.Float32bits(premulFlag))
+	if err := r.device.Queue().WriteBuffer(uniform.buffer, uint64(uniform.offset), r.texQuadUniformData); err != nil {
 		return fmt.Errorf("gogpu: WriteBuffer uniform failed: %w", err)
 	}
 
@@ -1963,6 +1968,7 @@ func (r *Renderer) Destroy() {
 		r.texQuadUniformLayout.Release()
 		r.texQuadUniformLayout = nil
 	}
+	r.texQuadUniformData = nil
 	if r.texQuadShader != nil {
 		r.texQuadShader.Release()
 		r.texQuadShader = nil

--- a/renderer.go
+++ b/renderer.go
@@ -579,6 +579,12 @@ func (ws *RenderTarget) CanRender() bool {
 //   - ErrSurfaceOutdated → reconfigure (swapchain stale after resize/DPI change)
 //   - ErrSurfaceLost → mark SurfaceLost (caller must recreate)
 func (ws *RenderTarget) beginFrame(platWin platform.PlatformWindow, device *wgpu.Device, adapter *wgpu.Adapter) bool {
+	// The app frame loop normally releases these in prepareLazyAcquire, but the
+	// exported Renderer.BeginFrame/EndFrame pair reaches beginFrame directly.
+	// Start every acquired frame with a fresh uniform arena so manual callers do
+	// not retain one chunk per frame indefinitely.
+	ws.releaseTexQuadUniformChunks()
+
 	if !ws.CanRender() {
 		return false
 	}
@@ -1666,27 +1672,15 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 		return err
 	}
 
-	// Upload uniform data — screen dimensions come from per-window state
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[0:4], math.Float32bits(opts.X))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[4:8], math.Float32bits(opts.Y))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[8:12], math.Float32bits(opts.Width))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[12:16], math.Float32bits(opts.Height))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[16:20], math.Float32bits(float32(ws.width)))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[20:24], math.Float32bits(float32(ws.height)))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[24:28], math.Float32bits(opts.Alpha))
-	binary.LittleEndian.PutUint32(r.texQuadUniformData[28:32], math.Float32bits(premulFlag))
-	if err := r.device.Queue().WriteBuffer(uniform.buffer, uint64(uniform.offset), r.texQuadUniformData); err != nil {
-		return fmt.Errorf("gogpu: WriteBuffer uniform failed: %w", err)
-	}
-
 	// Determine LoadOp: consume pending clear if available, otherwise preserve content.
 	// Default clear = transparent black (WebGPU spec, Rust wgpu Color::default).
 	// Opaque black (A:1) would destroy alpha for compositing (ggcanvas, DrawTexture).
 	loadOp := gputypes.LoadOpClear
 	clearValue := gputypes.Color{R: 0, G: 0, B: 0, A: 0}
+	consumePendingClear := false
 	if ws.hasPendingClear {
 		clearValue = ws.pendingClearColor
-		ws.hasPendingClear = false
+		consumePendingClear = true
 	} else if ws.frameCleared {
 		loadOp = gputypes.LoadOpLoad
 	}
@@ -1705,6 +1699,33 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 	if err != nil {
 		return fmt.Errorf("gogpu: failed to begin render pass: %w", err)
 	}
+	if consumePendingClear {
+		ws.hasPendingClear = false
+	}
+
+	// Upload uniform data only after the render pass has been accepted. Queue
+	// writes may be deferred in a staging encoder; keeping them after the begin
+	// check avoids leaving a write targeting an unreferenced frame buffer when a
+	// released attachment rejects the pass.
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[0:4], math.Float32bits(opts.X))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[4:8], math.Float32bits(opts.Y))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[8:12], math.Float32bits(opts.Width))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[12:16], math.Float32bits(opts.Height))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[16:20], math.Float32bits(float32(ws.width)))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[20:24], math.Float32bits(float32(ws.height)))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[24:28], math.Float32bits(opts.Alpha))
+	binary.LittleEndian.PutUint32(r.texQuadUniformData[28:32], math.Float32bits(premulFlag))
+	if err := r.device.Queue().WriteBuffer(uniform.buffer, uint64(uniform.offset), r.texQuadUniformData); err != nil {
+		// The pass has no useful draw without its parameters. Close and discard
+		// the shared encoder so the clear/pass cannot reach the surface, while
+		// preserving the frame's previous resources for the next frame boundary.
+		_ = renderPass.End()
+		if consumePendingClear {
+			ws.hasPendingClear = true
+		}
+		ws.discardFrameEncoder()
+		return fmt.Errorf("gogpu: WriteBuffer uniform failed: %w", err)
+	}
 
 	// Set pipeline and bind groups
 	renderPass.SetPipeline(r.texQuadPipeline)
@@ -1716,6 +1737,7 @@ func (r *Renderer) drawTexturedQuad(tex *Texture, opts DrawTextureOptions) error
 
 	// End render pass
 	if err := renderPass.End(); err != nil {
+		ws.discardFrameEncoder()
 		return fmt.Errorf("gogpu: failed to end render pass: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Reuse the frame-owned command encoder for textured-quad draws and submit it once at frame end.
- Keep one render pass open for each contiguous run of textured quads, while retaining per-draw dynamic uniform payloads.
- Preserve ordering and load semantics across external `Context.CommandEncoder` use, explicit clears, composition blits, debug overlays, standalone triangle draws, `RenderToImage`, and frame submission.
- Keep uniform writes deferred until the pass closes so failed-pass and frame-lifetime guarantees remain intact.

## Scope

This is the evidence-backed P1/P2 performance fix for #329. It changes private encoder/pass lifetime and batching only; there are no public API, storage-buffer, texture-atlas, or same-texture instancing changes. A broader instancing design remains deferred until a concrete workload and maintainer-approved contract justify it.

## Verification

- Focused textured-quad, encoder-boundary, clear-boundary, and lifetime tests
- `go test . -count=1`
- `go test ./... -count=1`
- `go test . -race -count=1`
- `go test -tags nogpu ./... -count=1`
- Host/Linux/Windows/JS-WASM builds
- `golangci-lint` v2.12.2 (`config verify`, `run --timeout=5m`)
- Benchmark confirms one encoder, one pass, and one submit for 1/20/100 contiguous draws

Closes #329.
