### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,11 +802,11 @@ MIT License — see [LICENSE](LICENSE) for details.
 
 ## Star History
 
-<a href="https://star-history.com/#gogpu/gogpu&Date">
+<a href="https://star-history.dera.page/#gogpu/gogpu&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=gogpu/gogpu&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=gogpu/gogpu&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=gogpu/gogpu&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=gogpu/gogpu&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=gogpu/gogpu&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=gogpu/gogpu&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart in the README is currently broken and no longer renders for visitors, which makes the repository look less established than it is. This change points the chart and its wrapping link to a working endpoint so the chart displays correctly again.

No behavior beyond the chart link is affected.