### PR TITLE
fix: replace broken star-history.com embed with starhistory.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,11 +802,11 @@ MIT License — see [LICENSE](LICENSE) for details.
 
 ## Star History
 
-<a href="https://star-history.com/#gogpu/gogpu&Date">
+<a href="https://starhistory.io">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=gogpu/gogpu&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=gogpu/gogpu&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=gogpu/gogpu&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.starhistory.io/png?repos=gogpu/gogpu&style=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.starhistory.io/png?repos=gogpu/gogpu&style=professional" />
+   <img alt="Star History Chart" src="https://api.starhistory.io/png?repos=gogpu/gogpu" width="800" />
  </picture>
 </a>
 


### PR DESCRIPTION
## Summary

- Replace broken star-history.com embed (503 since June 30, 2026 GitHub API restriction)
- Use our own starhistory.io service at `api.starhistory.io`
- Dark/light mode via `<picture>` element
- 2x Retina PNG, powered by gogpu/gg

## Before
star-history.com → 503 (broken permanently)

## After
api.starhistory.io → working chart with professional rendering