### PR TITLE
fix(macOS): preserve Window menu across SetMenu (#463, #464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **macOS: Window menu lost after `SetMenu`** (#463, #464) — `applyMenu` preserved only the App Menu item, so Minimize/Zoom/Close (Cmd+W)/Full Screen disappeared from the menu bar. The system Window menu is now detached, retained, and re-inserted after user items (GLFW/Qt6/Electron pattern).
 - **macOS: `SetMenu` separators lost between Role items** (#456) — top-level separators were routed to the menu bar (invisible). They now go to the App Menu submenu, matching GLFW `cocoa_init.m`.
 - **macOS: About ⓘ icon missing on Role+Action** (#456) — custom `Action` no longer swaps the item to `handleMenuItem:`. Role+Action keeps the system selector (`orderFrontStandardAboutPanel:` etc.) and overrides via `setTarget:` on the app delegate (Electron/Qt pattern), so AppKit still draws role chrome.
 - **macOS: `SetMenu` appended to App Menu instead of replacing** (#456) — `applyMenu` now clears the App Menu submenu before applying caller items (`Menu.setApplicationMenu()` replace semantics).

--- a/internal/platform/darwin/menu.go
+++ b/internal/platform/darwin/menu.go
@@ -685,6 +685,10 @@ func addServicesMenuItem(menu ID, title string) ID {
 		return 0
 	}
 	menu.SendPtr(menuSels.addItem, item.Ptr())
+	// Balance alloc from NewMenuItemWithSubmenu; menu retain owns the item.
+	item.Send(Selectors().Release())
+	// Balance alloc of servicesMenu; setServicesMenu: + setSubmenu: retain it.
+	servicesMenu.Send(Selectors().Release())
 	return item
 }
 
@@ -745,6 +749,11 @@ func NewMenuWithTitle(title string) ID {
 }
 
 // NewMenuItemWithSubmenu creates an NSMenuItem with a title and an attached submenu.
+//
+// Ownership follows Cocoa alloc/init (+1). Callers that transfer the item into
+// an NSMenu via addItem: must Send(Selectors().Release()) once after addItem:
+// so the menu's retain is the sole owner (avoids retain=alloc+addItem leak).
+// setSubmenu: retains submenu; the caller still owns any +1 they held on submenu.
 func NewMenuItemWithSubmenu(title string, submenu ID) ID {
 	if err := initRuntime(); err != nil {
 		return 0

--- a/internal/platform/darwin/menu_test.go
+++ b/internal/platform/darwin/menu_test.go
@@ -340,6 +340,8 @@ func TestClearMenuActions_RemovesCallbacks(t *testing.T) {
 			subItem := platformdarwin.NewMenuItemWithSubmenu("Sub", submenu)
 			if !subItem.IsNil() {
 				menu.SendPtr(platformdarwin.RegisterSelector("addItem:"), subItem.Ptr())
+				subItem.Send(platformdarwin.Selectors().Release())
+				submenu.Send(platformdarwin.Selectors().Release())
 			}
 		}
 

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -1636,6 +1636,10 @@ func (p *darwinPlatform) SetApplicationMenu(items []MenuItem) {
 // cleared before applying caller items, so Role items are not appended after
 // the default About/Hide/Quit entries.
 //
+// The system Window menu (Minimize, Zoom, Close/Cmd+W, Full Screen, Bring All
+// to Front) is preserved across replace — same as GLFW, Qt6, Flutter, and
+// Electron. Without it, Cmd+W and the Window menu bar entry disappear (#463, #464).
+//
 // Must only be called after NSApplication has been initialized.
 func (p *darwinPlatform) applyMenu(items []MenuItem) {
 	nsApp := p.app.NSApp()
@@ -1648,10 +1652,19 @@ func (p *darwinPlatform) applyMenu(items []MenuItem) {
 	}
 
 	appMenuItem := mainMenu.SendInt(darwin.RegisterSelector("itemAtIndex:"), 0)
+	windowMenuItem := p.findWindowsMenuItem(mainMenu)
+
+	// Detach + retain Window menu before ClearMenuActions/removeAllItems so
+	// system items (Close/Cmd+W) and AddToSystemMenu(Window) Go callbacks
+	// survive SetMenu replace (#463, #464).
+	if !windowMenuItem.IsNil() {
+		windowMenuItem.Send(darwin.Selectors().Retain())
+		mainMenu.SendPtr(darwin.RegisterSelector("removeItem:"), windowMenuItem.Ptr())
+	}
 
 	// Drop Go callbacks before AppKit deallocates the items. Recurses into
-	// App Menu / Window / custom submenus so replace SetMenu cannot leave
-	// stale menuActionMap entries keyed by reused pointers.
+	// App Menu / custom submenus so replace SetMenu cannot leave stale
+	// menuActionMap entries keyed by reused pointers.
 	darwin.ClearMenuActions(mainMenu)
 
 	mainMenu.Send(darwin.RegisterSelector("removeAllItems"))
@@ -1679,6 +1692,65 @@ func (p *darwinPlatform) applyMenu(items []MenuItem) {
 			slog.Warn("gogpu: macOS menu bar requires submenus — leaf item skipped",
 				"title", item.Title)
 		}
+	}
+
+	// Re-insert Window menu after user items (GLFW/Qt/Electron pattern).
+	p.restoreWindowsMenu(mainMenu, windowMenuItem)
+	if !windowMenuItem.IsNil() {
+		windowMenuItem.Send(darwin.Selectors().Release())
+	}
+}
+
+// findWindowsMenuItem returns the main-menu NSMenuItem whose submenu is
+// NSApp.windowsMenu, or 0 if the Window menu is not currently in the bar.
+func (p *darwinPlatform) findWindowsMenuItem(mainMenu darwin.ID) darwin.ID {
+	windowMenu := p.getWindowMenu()
+	if windowMenu.IsNil() || mainMenu.IsNil() {
+		return 0
+	}
+
+	count := mainMenu.GetInt64(darwin.RegisterSelector("numberOfItems"))
+	for i := int64(0); i < count; i++ {
+		item := mainMenu.SendInt(darwin.RegisterSelector("itemAtIndex:"), i)
+		if item.IsNil() {
+			continue
+		}
+		submenu := item.Send(darwin.RegisterSelector("submenu"))
+		if !submenu.IsNil() && submenu.Ptr() == windowMenu.Ptr() {
+			return item
+		}
+	}
+	return 0
+}
+
+// restoreWindowsMenu puts the system Window menu back on the menu bar after
+// SetMenu replace. If the previous NSMenuItem was captured, it is re-added;
+// otherwise a new item is wrapped around NSApp.windowsMenu (still retained by
+// the application after a prior strip).
+func (p *darwinPlatform) restoreWindowsMenu(mainMenu, windowMenuItem darwin.ID) {
+	if mainMenu.IsNil() || p.app == nil {
+		return
+	}
+
+	nsApp := p.app.NSApp()
+	if nsApp.IsNil() {
+		return
+	}
+
+	if windowMenuItem.IsNil() {
+		windowMenu := p.getWindowMenu()
+		if windowMenu.IsNil() {
+			return
+		}
+		windowMenuItem = darwin.NewMenuItemWithSubmenu("Window", windowMenu)
+		if windowMenuItem.IsNil() {
+			return
+		}
+	}
+
+	mainMenu.SendPtr(darwin.RegisterSelector("addItem:"), windowMenuItem.Ptr())
+	if submenu := windowMenuItem.Send(darwin.RegisterSelector("submenu")); !submenu.IsNil() {
+		nsApp.SendPtr(darwin.RegisterSelector("setWindowsMenu:"), submenu.Ptr())
 	}
 }
 
@@ -1843,6 +1915,9 @@ func (p *darwinPlatform) getSystemMenu(menu SystemMenu) darwin.ID {
 // getAppMenu returns the NSMenu of the Apple menu (the first submenu of the main menu).
 // This is the menu that contains About, Preferences, Services, Quit, etc.
 func (p *darwinPlatform) getAppMenu() darwin.ID {
+	if p.app == nil {
+		return 0
+	}
 	nsApp := p.app.NSApp()
 	if nsApp.IsNil() {
 		return 0
@@ -1863,6 +1938,9 @@ func (p *darwinPlatform) getAppMenu() darwin.ID {
 // NSApplication automatically manages the Window menu when setWindowsMenu: is called,
 // which createMenuBar already does during Init().
 func (p *darwinPlatform) getWindowMenu() darwin.ID {
+	if p.app == nil {
+		return 0
+	}
 	nsApp := p.app.NSApp()
 	if nsApp.IsNil() {
 		return 0

--- a/internal/platform/platform_darwin.go
+++ b/internal/platform/platform_darwin.go
@@ -1737,6 +1737,7 @@ func (p *darwinPlatform) restoreWindowsMenu(mainMenu, windowMenuItem darwin.ID) 
 		return
 	}
 
+	created := false
 	if windowMenuItem.IsNil() {
 		windowMenu := p.getWindowMenu()
 		if windowMenu.IsNil() {
@@ -1746,9 +1747,14 @@ func (p *darwinPlatform) restoreWindowsMenu(mainMenu, windowMenuItem darwin.ID) 
 		if windowMenuItem.IsNil() {
 			return
 		}
+		created = true
 	}
 
 	mainMenu.SendPtr(darwin.RegisterSelector("addItem:"), windowMenuItem.Ptr())
+	if created {
+		// Balance alloc from NewMenuItemWithSubmenu; addItem: retains the item.
+		windowMenuItem.Send(darwin.Selectors().Release())
+	}
 	if submenu := windowMenuItem.Send(darwin.RegisterSelector("submenu")); !submenu.IsNil() {
 		nsApp.SendPtr(darwin.RegisterSelector("setWindowsMenu:"), submenu.Ptr())
 	}
@@ -1812,9 +1818,14 @@ func (p *darwinPlatform) addPlatformItem(parentMenu darwin.ID, item MenuItem) {
 		}
 
 		menuItem := darwin.NewMenuItemWithSubmenu(item.Title, submenu)
-		if !menuItem.IsNil() {
-			parentMenu.SendPtr(darwin.RegisterSelector("addItem:"), menuItem.Ptr())
+		if menuItem.IsNil() {
+			submenu.Send(darwin.Selectors().Release())
+			return
 		}
+		parentMenu.SendPtr(darwin.RegisterSelector("addItem:"), menuItem.Ptr())
+		// Balance allocs: addItem:/setSubmenu: retain item and submenu.
+		menuItem.Send(darwin.Selectors().Release())
+		submenu.Send(darwin.Selectors().Release())
 		return
 	}
 

--- a/internal/platform/platform_darwin_menu_test.go
+++ b/internal/platform/platform_darwin_menu_test.go
@@ -70,3 +70,11 @@ func TestMacOSMenuDestination_Issue456Reproduction(t *testing.T) {
 		}
 	}
 }
+
+func TestFindWindowsMenuItem_NilSafe(t *testing.T) {
+	p := &darwinPlatform{}
+	if got := p.findWindowsMenuItem(0); !got.IsNil() {
+		t.Fatalf("findWindowsMenuItem(uninit) = %v, want nil", got)
+	}
+	p.restoreWindowsMenu(0, 0) // must not panic
+}


### PR DESCRIPTION
## Summary
- `applyMenu` no longer drops the system Window menu (Minimize, Zoom, Close/Cmd+W, Full Screen, Bring All to Front) when replacing the menu bar via `SetMenu`
- Window menu item is detached + retained before `removeAllItems`, then re-inserted after user items (GLFW / Qt6 / Electron pattern)
- If the bar was already stripped, wraps `NSApp.windowsMenu` in a new item so recovery still works
- Fixes missing Window menu in `examples/menu` (#464) and dead Cmd+W on About panel after custom `SetMenu` (#463)

## Test plan
- [x] `go test ./internal/platform/ -run 'MacOSMenu|FindWindows'`
- [x] Run `examples/menu` on macOS: Window menu visible in menu bar
- [x] About panel → ⌘W closes the panel
- [x] `examples/window_header` still has working ⌘W (default menu path)
- [x] Call `SetMenu` twice in a row — Window menu remains, no duplicate crash