### PR TITLE
release: v0.54.0 — strided UpdateRegion + GPUStats (#484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Strided `Texture.UpdateRegion`** (#484) — `bytesPerRow` parameter (pre-v1.0 signature change). `0` = tightly packed rows (`w * bytesPerPixel`), matching WebGPU `ImageDataLayout.bytesPerRow`. Enables zero-copy dirty-band uploads from a full-frame RGBA buffer (geckty/ggcanvas) without `extractRegion` memcpy. wgpu already handles 256-byte row-pitch alignment via `alignTextureDataInto`.
+- **Strided `Texture.UpdateRegion`** (#484) — `bytesPerRow` parameter (pre-v1.0 signature change). `0` = tightly packed rows (`w * bytesPerPixel`), matching WebGPU `ImageDataLayout.bytesPerRow`. Enables zero-copy dirty-band uploads from a full-frame RGBA buffer (ggcanvas and similar) without `extractRegion` memcpy. wgpu already handles 256-byte row-pitch alignment via `alignTextureDataInto`.
 - **GPUStats — two-level observability** (#484) — Rust wgpu + Flutter pattern:
   - `Renderer.GetCounters()` — cumulative texture count, allocated bytes, upload totals (device owner)
   - `Context.FrameStats()` — per-frame `UploadBytes`, `UploadRegions`, `PresentSkipped`, `FrameDuration` (frame owner)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Strided `Texture.UpdateRegion`** (#484) — `bytesPerRow` parameter (pre-v1.0 signature change). `0` = tightly packed rows (`w * bytesPerPixel`), matching WebGPU `ImageDataLayout.bytesPerRow`. Enables zero-copy dirty-band uploads from a full-frame RGBA buffer (ggcanvas and similar) without `extractRegion` memcpy. wgpu already handles 256-byte row-pitch alignment via `alignTextureDataInto`.
+- **Strided `Texture.UpdateRegion`** (#484) — `image.Rectangle` + `gpucontext.ImageDataLayout` (WebGPU / Go stdlib idiom). Zero-value layout = offset 0, tightly packed rows, region height. Enables zero-copy dirty-band uploads from a full-frame RGBA buffer without `extractRegion` memcpy. wgpu handles 256-byte row-pitch alignment via `alignTextureDataInto`.
 - **GPUStats — two-level observability** (#484) — Rust wgpu + Flutter pattern:
   - `Renderer.GetCounters()` — cumulative texture count, allocated bytes, upload totals (device owner)
   - `Context.FrameStats()` — per-frame `UploadBytes`, `UploadRegions`, `PresentSkipped`, `FrameDuration` (frame owner)
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **deps:** gpucontext v0.30.0 → v0.31.0 (`TextureRegionUpdater.UpdateRegion` gains `bytesPerRow`)
+- **deps:** gpucontext v0.30.0 → v0.31.1 (`TextureRegionUpdater.UpdateRegion` struct API)
 
 ## [0.53.2] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **deps:** gpucontext v0.30.0 → v0.31.1 (`TextureRegionUpdater.UpdateRegion` struct API)
+- **deps:** gpucontext v0.30.0 → v0.31.2 (`TextureRegionUpdater.UpdateRegion` struct API)
 
 ## [0.53.2] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.54.0] - 2026-08-30
+
+### Added
+
+- **Strided `Texture.UpdateRegion`** (#484) — `bytesPerRow` parameter (pre-v1.0 signature change). `0` = tightly packed rows (`w * bytesPerPixel`), matching WebGPU `ImageDataLayout.bytesPerRow`. Enables zero-copy dirty-band uploads from a full-frame RGBA buffer (geckty/ggcanvas) without `extractRegion` memcpy. wgpu already handles 256-byte row-pitch alignment via `alignTextureDataInto`.
+- **GPUStats — two-level observability** (#484) — Rust wgpu + Flutter pattern:
+  - `Renderer.GetCounters()` — cumulative texture count, allocated bytes, upload totals (device owner)
+  - `Context.FrameStats()` — per-frame `UploadBytes`, `UploadRegions`, `PresentSkipped`, `FrameDuration` (frame owner)
+  - Feature-gated: `GOGPU_STATS=1` or `EnableStats()` / `DisableStats()`. Zero-cost when off (single atomic load).
+
+### Changed
+
+- **deps:** gpucontext v0.30.0 → v0.31.0 (`TextureRegionUpdater.UpdateRegion` gains `bytesPerRow`)
+
 ## [0.53.2] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ All settings can be overridden via environment variables (no code changes needed
 | `GOGPU_POWER_PREFERENCE` | `low`, `high` | none | GPU power/performance trade-off |
 | `GOGPU_RENDER_MODE` | `auto`, `cpu`, `gpu` | auto | 2D rendering path (ADR-020) |
 | `GOGPU_DEBUG_DAMAGE` | `1` | off | Show damage region overlay (ADR-021) |
+| `GOGPU_STATS` | `1` | off | Enable GPU upload/resource stats (#484) |
 
 ```bash
 # Examples:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,9 +25,10 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 ---
 
-## Current State: v0.50.0
+## Current State: v0.54.0
 
 ✅ **Production-ready** with full feature set:
+- **Strided texture uploads + GPUStats** (#484) — `Texture.UpdateRegion(..., bytesPerRow, data)` for zero-copy dirty bands; `Renderer.GetCounters()` + `Context.FrameStats()` behind `GOGPU_STATS=1`
 - **Outgoing drag source** (#427, ADR-061) — `Window.StartDrag(DragData, callback)` on all 5 platforms (Windows COM DoDragDrop, macOS NSDraggingSource, X11 XDND v5, Wayland wl_data_source, Browser stub). Enterprise references: Qt6, SDL3, winit
 - **Per-pixel alpha transparency** (#361, @shaolei) — `Config.WithTransparent(bool)` for overlay/tray popup windows. Windows DwmBlurBehind, macOS isOpaque+clearColor, X11 ARGB visual
 - **Window control API** (#361, @shaolei) — `Window.Show()`, `Hide()`, `SetPosition()`, `SetSize()` on all desktop platforms
@@ -93,6 +94,8 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.54.0** | 2026-08-30 | **Strided UpdateRegion + GPUStats** (#484). deps gpucontext v0.31.0. |
+| **v0.53.2** | 2026-08-30 | DownlevelCapabilities (ADR-071). deps wgpu v0.33.0, gpucontext v0.30.0. |
 | **v0.50.0** | 2026-08-06 | **Outgoing drag source** (#427, ADR-061) — `StartDrag` all 5 platforms. Per-pixel alpha (#361, @shaolei). Input ordering fix (#425, @FDUTCH). deps wgpu v0.30.36. |
 | **v0.49.2** | 2026-08-05 | Input JustPressed/Delta ordering fix (#425, @FDUTCH). 38 enterprise input tests. |
 | **v0.49.1** | 2026-08-04 | macOS menu Role+Action fix (#423, @jbunds). |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 ## Current State: v0.54.0
 
 ✅ **Production-ready** with full feature set:
-- **Strided texture uploads + GPUStats** (#484) — `Texture.UpdateRegion(..., bytesPerRow, data)` for zero-copy dirty bands; `Renderer.GetCounters()` + `Context.FrameStats()` behind `GOGPU_STATS=1`
+- **Strided texture uploads + GPUStats** (#484) — `Texture.UpdateRegion(region, data, layout)` for zero-copy dirty bands; `Renderer.GetCounters()` + `Context.FrameStats()` behind `GOGPU_STATS=1`
 - **Outgoing drag source** (#427, ADR-061) — `Window.StartDrag(DragData, callback)` on all 5 platforms (Windows COM DoDragDrop, macOS NSDraggingSource, X11 XDND v5, Wayland wl_data_source, Browser stub). Enterprise references: Qt6, SDL3, winit
 - **Per-pixel alpha transparency** (#361, @shaolei) — `Config.WithTransparent(bool)` for overlay/tray popup windows. Windows DwmBlurBehind, macOS isOpaque+clearColor, X11 ARGB visual
 - **Window control API** (#361, @shaolei) — `Window.Show()`, `Hide()`, `SetPosition()`, `SetSize()` on all desktop platforms
@@ -94,7 +94,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
-| **v0.54.0** | 2026-08-30 | **Strided UpdateRegion + GPUStats** (#484). deps gpucontext v0.31.0. |
+| **v0.54.0** | 2026-08-30 | **Strided UpdateRegion + GPUStats** (#484). deps gpucontext v0.31.1. |
 | **v0.53.2** | 2026-08-30 | DownlevelCapabilities (ADR-071). deps wgpu v0.33.0, gpucontext v0.30.0. |
 | **v0.50.0** | 2026-08-06 | **Outgoing drag source** (#427, ADR-061) — `StartDrag` all 5 platforms. Per-pixel alpha (#361, @shaolei). Input ordering fix (#425, @FDUTCH). deps wgpu v0.30.36. |
 | **v0.49.2** | 2026-08-05 | Input JustPressed/Delta ordering fix (#425, @FDUTCH). 38 enterprise input tests. |
@@ -286,7 +286,7 @@ Surface-based lifecycle for desktop + mobile + web + headless. Replaces "primary
 | **gogpu/naga** | v0.17.6 | Shader compiler (WGSL → SPIR-V/MSL/GLSL/HLSL/DXIL) |
 | **gogpu/gg** | v0.41.2 | 2D graphics with GPU acceleration, Vello compute, scene renderer |
 | **gogpu/ui** | v0.1.13 | GUI toolkit: 22+ widgets, 4 themes, offscreen renderer |
-| **gogpu/gpucontext** | v0.31.0 | Shared interfaces (DeviceProvider, TextureView, TextureRegionUpdater) |
+| **gogpu/gpucontext** | v0.31.1 | Shared interfaces (DeviceProvider, TextureView, TextureRegionUpdater) |
 | **gogpu/gputypes** | v0.7.0 | WebGPU type definitions (zero value = spec default) |
 | **gogpu/compose** | design | Multi-process composition library |
 | **gogpu/g3d** | v0.1.0 | 3D rendering (scene graph, PBR Blinn-Phong, forward renderer, 5 backends) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,7 +94,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
-| **v0.54.0** | 2026-08-30 | **Strided UpdateRegion + GPUStats** (#484). deps gpucontext v0.31.1. |
+| **v0.54.0** | 2026-08-30 | **Strided UpdateRegion + GPUStats** (#484). deps gpucontext v0.31.2. |
 | **v0.53.2** | 2026-08-30 | DownlevelCapabilities (ADR-071). deps wgpu v0.33.0, gpucontext v0.30.0. |
 | **v0.50.0** | 2026-08-06 | **Outgoing drag source** (#427, ADR-061) — `StartDrag` all 5 platforms. Per-pixel alpha (#361, @shaolei). Input ordering fix (#425, @FDUTCH). deps wgpu v0.30.36. |
 | **v0.49.2** | 2026-08-05 | Input JustPressed/Delta ordering fix (#425, @FDUTCH). 38 enterprise input tests. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -281,13 +281,13 @@ Surface-based lifecycle for desktop + mobile + web + headless. Replaces "primary
 
 | Component | Version | Description |
 |-----------|---------|-------------|
-| **gogpu/gogpu** | v0.29.2 | GPU application framework, windowing, multi-window, damage-aware present |
-| **gogpu/wgpu** | v0.26.4 | Pure Go WebGPU (Vulkan, Metal, DX12, GLES, Software) |
+| **gogpu/gogpu** | v0.54.0 | GPU application framework, windowing, multi-window, damage-aware present |
+| **gogpu/wgpu** | v0.33.0 | Pure Go WebGPU (Vulkan, Metal, DX12, GLES, Software) |
 | **gogpu/naga** | v0.17.6 | Shader compiler (WGSL → SPIR-V/MSL/GLSL/HLSL/DXIL) |
 | **gogpu/gg** | v0.41.2 | 2D graphics with GPU acceleration, Vello compute, scene renderer |
 | **gogpu/ui** | v0.1.13 | GUI toolkit: 22+ widgets, 4 themes, offscreen renderer |
-| **gogpu/gpucontext** | v0.14.0 | Shared interfaces (DeviceProvider, TextureView, TextureRegionUpdater) |
-| **gogpu/gputypes** | v0.5.0 | WebGPU type definitions (zero value = spec default) |
+| **gogpu/gpucontext** | v0.31.0 | Shared interfaces (DeviceProvider, TextureView, TextureRegionUpdater) |
+| **gogpu/gputypes** | v0.7.0 | WebGPU type definitions (zero value = spec default) |
 | **gogpu/compose** | design | Multi-process composition library |
 | **gogpu/g3d** | v0.1.0 | 3D rendering (scene graph, PBR Blinn-Phong, forward renderer, 5 backends) |
 | **gogpu/gg-pdf** | v0.1.0 | PDF export |

--- a/app.go
+++ b/app.go
@@ -1137,6 +1137,7 @@ func (a *App) renderFrameGPU(frames []windowFrame) {
 			if ws.acquireFailed {
 				a.RequestRedraw()
 			}
+			a.renderer.endFrameStats(true) // idle: no acquire → present skipped (#484 FrameStats)
 			ws.resetLazyState()
 			a.renderer.currentSurface = nil
 			continue

--- a/context_texture.go
+++ b/context_texture.go
@@ -168,10 +168,11 @@ var ErrInvalidTextureType = errors.New("gogpu: texture must be *Texture")
 
 // Compile-time interface compliance checks.
 var (
-	_ gpucontext.TextureDrawer  = (*contextTextureDrawer)(nil)
-	_ gpucontext.TextureCreator = (*rendererTextureCreator)(nil)
-	_ gpucontext.Texture        = (*Texture)(nil)
-	_ gpucontext.TextureUpdater = (*Texture)(nil)
+	_ gpucontext.TextureDrawer        = (*contextTextureDrawer)(nil)
+	_ gpucontext.TextureCreator       = (*rendererTextureCreator)(nil)
+	_ gpucontext.Texture              = (*Texture)(nil)
+	_ gpucontext.TextureUpdater       = (*Texture)(nil)
+	_ gpucontext.TextureRegionUpdater = (*Texture)(nil)
 )
 
 // contextTextureDrawer adapts Context to gpucontext.TextureDrawer interface.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,6 +190,7 @@ All Config options can be overridden via environment variables:
 | `GOGPU_POWER_PREFERENCE` | `low`, `high` | none | GPU selection |
 | `GOGPU_RENDER_MODE` | `auto`, `cpu`, `gpu` | auto | 2D render path (ADR-020) |
 | `GOGPU_DEBUG_DAMAGE` | `1` | off | Damage region overlay (ADR-021) |
+| `GOGPU_STATS` | `1` | off | GPU upload/resource counters (#484) |
 | `GOGPU_SUBPIXEL_LAYOUT` | `rgb`, `bgr`, `vrgb`, `vbgr`, `none` | auto-detect | LCD subpixel override (ADR-047) |
 | `GOGPU_WAYLAND_FRAME_CALLBACK` | `0` | enabled | Disable Wayland frame callback gating (ADR-049) |
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-webgpu/goffi v0.6.3
-	github.com/gogpu/gpucontext v0.31.1-0.20260830183443-01709c12389b
+	github.com/gogpu/gpucontext v0.31.2
 	github.com/gogpu/gputypes v0.7.0
 	github.com/gogpu/wgpu v0.33.0
 	golang.org/x/sys v0.47.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-webgpu/goffi v0.6.3
-	github.com/gogpu/gpucontext v0.30.0
+	github.com/gogpu/gpucontext v0.31.0
 	github.com/gogpu/gputypes v0.7.0
 	github.com/gogpu/wgpu v0.33.0
 	golang.org/x/sys v0.47.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-webgpu/goffi v0.6.3
-	github.com/gogpu/gpucontext v0.31.0
+	github.com/gogpu/gpucontext v0.31.1-0.20260830183443-01709c12389b
 	github.com/gogpu/gputypes v0.7.0
 	github.com/gogpu/wgpu v0.33.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gpucontext v0.30.0 h1:8O3ldG5d1oatYJ2IqMN6mlzxyJhGZqJfkeQehIg7TSU=
-github.com/gogpu/gpucontext v0.30.0/go.mod h1:uM3brJCMc71IN5xh9zhxBtEvKm1FKPhh3a2eYrejM8E=
+github.com/gogpu/gpucontext v0.31.0 h1:5kprSfDJ1b94K/cSanh3sFwA1Vx2u7sRsrb3GFmXNzU=
+github.com/gogpu/gpucontext v0.31.0/go.mod h1:uM3brJCMc71IN5xh9zhxBtEvKm1FKPhh3a2eYrejM8E=
 github.com/gogpu/gputypes v0.7.0 h1:1IcXGyPx8v6iAutpjwBYjcyYd3g6ep+FhThoZbhpVAg=
 github.com/gogpu/gputypes v0.7.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.19.0 h1:+Pu7kahdMhvRWtpEbTW5YFQZPoklccMO4vryEk6w9zU=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gpucontext v0.31.0 h1:5kprSfDJ1b94K/cSanh3sFwA1Vx2u7sRsrb3GFmXNzU=
-github.com/gogpu/gpucontext v0.31.0/go.mod h1:uM3brJCMc71IN5xh9zhxBtEvKm1FKPhh3a2eYrejM8E=
+github.com/gogpu/gpucontext v0.31.1-0.20260830183443-01709c12389b h1:alY6ny7x32MfkFXRnSPfYCLOchmbzpDs1MQfNnaBL3o=
+github.com/gogpu/gpucontext v0.31.1-0.20260830183443-01709c12389b/go.mod h1:uM3brJCMc71IN5xh9zhxBtEvKm1FKPhh3a2eYrejM8E=
 github.com/gogpu/gputypes v0.7.0 h1:1IcXGyPx8v6iAutpjwBYjcyYd3g6ep+FhThoZbhpVAg=
 github.com/gogpu/gputypes v0.7.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.19.0 h1:+Pu7kahdMhvRWtpEbTW5YFQZPoklccMO4vryEk6w9zU=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gpucontext v0.31.1-0.20260830183443-01709c12389b h1:alY6ny7x32MfkFXRnSPfYCLOchmbzpDs1MQfNnaBL3o=
-github.com/gogpu/gpucontext v0.31.1-0.20260830183443-01709c12389b/go.mod h1:uM3brJCMc71IN5xh9zhxBtEvKm1FKPhh3a2eYrejM8E=
+github.com/gogpu/gpucontext v0.31.2 h1:5K5jFKXHFimnXQdWasWPQn+dpX0GWxJ8wHNJki4gdes=
+github.com/gogpu/gpucontext v0.31.2/go.mod h1:uM3brJCMc71IN5xh9zhxBtEvKm1FKPhh3a2eYrejM8E=
 github.com/gogpu/gputypes v0.7.0 h1:1IcXGyPx8v6iAutpjwBYjcyYd3g6ep+FhThoZbhpVAg=
 github.com/gogpu/gputypes v0.7.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.19.0 h1:+Pu7kahdMhvRWtpEbTW5YFQZPoklccMO4vryEk6w9zU=

--- a/renderer.go
+++ b/renderer.go
@@ -247,6 +247,14 @@ type Renderer struct {
 	// single-window path. It is set only when a secondary platform window
 	// actually prepares compositor frame gating.
 	secondaryFrameGatePending atomic.Bool
+
+	// GPU stats (GOGPU_STATS=1 / EnableStats). Zero-cost when disabled —
+	// record paths return after a single atomic load (Rust wgpu counters pattern).
+	statsTextures      atomic.Int64
+	statsTextureBytes  atomic.Int64
+	statsUploadBytes   atomic.Int64
+	statsUploadRegions atomic.Int64
+	frameStats         frameStatsState
 }
 
 // newRenderer creates and initializes a new renderer.
@@ -586,6 +594,7 @@ func (ws *RenderTarget) resize(width, height int, device *wgpu.Device, adapter *
 // Backward compatibility wrapper — multi-window code uses beginFrameForSurface.
 func (r *Renderer) BeginFrame() bool {
 	r.DrainDeferredDestroys()
+	r.beginFrameStats()
 	return r.beginFrameForSurface(r.primary)
 }
 
@@ -685,6 +694,7 @@ func (ws *RenderTarget) recoverFromAcquireError(err error, device *wgpu.Device, 
 // Backward compatibility wrapper — multi-window code uses endFrameForSurface.
 func (r *Renderer) EndFrame() {
 	if !r.primary.frameStarted {
+		r.endFrameStats(true)
 		r.pollSubmissions()
 		return
 	}
@@ -705,6 +715,13 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 		ws.pixelPresented = false
 		ws.hasPendingClear = false
 		ws.releaseFrame()
+		r.endFrameStats(false)
+		return false
+	}
+
+	// No swapchain frame was started (idle / lazy acquire never triggered).
+	if !ws.frameStarted {
+		r.endFrameStats(true)
 		return false
 	}
 
@@ -736,6 +753,7 @@ func (r *Renderer) endFrameForSurface(ws *RenderTarget) bool {
 	reconfigured, presented := ws.present()
 	finishPresentationSync(ws, syncAttempt, presented)
 	ws.releaseFrame()
+	r.endFrameStats(!presented)
 	return reconfigured
 }
 
@@ -902,6 +920,9 @@ func (ws *RenderTarget) prepareLazyAcquire() {
 		ws.pendingBlitBindGroup = nil
 	}
 	ws.compositeState.Release()
+	if ws.renderer != nil {
+		ws.renderer.beginFrameStats()
+	}
 }
 
 // ensureFrameStarted calls beginFrame on first draw call (lazy acquire pattern).

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,205 @@
+package gogpu
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// GPU statistics follow a two-level design validated by Rust wgpu
+// (Device.get_internal_counters, feature-gated) and Flutter (FrameTiming):
+//
+//   - DeviceCounters — cumulative resource counts + bytes on the Renderer
+//     (device owner). Cheap atomics; zero-cost when stats are disabled.
+//   - FrameStats — per-frame upload/present metrics on the Context
+//     (frame owner). Reset at the start of each frame.
+//
+// Enable with GOGPU_STATS=1 or EnableStats(). When disabled, record paths
+// are a single atomic load and return immediately (Rust wgpu counters pattern).
+
+var statsEnabled atomic.Bool
+
+func init() {
+	if os.Getenv("GOGPU_STATS") == "1" {
+		statsEnabled.Store(true)
+	}
+}
+
+// EnableStats turns on GPU statistics collection.
+// Safe to call from any goroutine. Prefer GOGPU_STATS=1 for CI/prod toggles.
+func EnableStats() { statsEnabled.Store(true) }
+
+// DisableStats turns off GPU statistics collection.
+// In-flight counters are not cleared; call ResetCounters on Renderer if needed.
+func DisableStats() { statsEnabled.Store(false) }
+
+// StatsEnabled reports whether GPU statistics collection is active.
+func StatsEnabled() bool { return statsEnabled.Load() }
+
+// DeviceCounters holds cumulative GPU resource statistics owned by Renderer.
+// Matches Rust wgpu Device.get_internal_counters() shape at the app-framework
+// layer (buffers/textures/bytes), without importing wgpu internals.
+type DeviceCounters struct {
+	// Textures is the number of live gogpu.Texture objects tracked by this renderer.
+	Textures int64
+	// TextureBytesAllocated is the sum of width*height*bytesPerPixel for live textures.
+	TextureBytesAllocated int64
+	// UploadBytesTotal is the cumulative number of bytes uploaded via UpdateData/UpdateRegion.
+	UploadBytesTotal int64
+	// UploadRegionsTotal is the cumulative number of UpdateRegion calls (UpdateData counts as 1).
+	UploadRegionsTotal int64
+}
+
+// FrameStats holds per-frame upload and present metrics (Flutter FrameTiming pattern).
+// Values accumulate during OnDraw and are snapshotted for the completed frame.
+type FrameStats struct {
+	// UploadBytes is the total bytes uploaded this frame (UpdateData + UpdateRegion).
+	UploadBytes int64
+	// UploadRegions is the number of upload operations this frame.
+	UploadRegions int
+	// PresentSkipped is true when the frame did not present to the swapchain
+	// (no frame started, present failed, or idle path skipped the draw).
+	PresentSkipped bool
+	// FrameDuration is wall time from frame begin to EndFrame completion.
+	// Zero when stats were disabled for the frame or timing was unavailable.
+	FrameDuration time.Duration
+}
+
+// frameStatsState is the mutable per-renderer frame accumulator.
+// Accessed only on the render thread when stats are enabled, but protected
+// by a mutex so GetFrameStats / GetCounters remain safe for CI polling.
+type frameStatsState struct {
+	mu             sync.Mutex
+	uploadBytes    int64
+	uploadRegions  int
+	presentSkipped bool
+	frameStart     time.Time
+	last           FrameStats
+}
+
+// GetCounters returns a snapshot of cumulative device-level counters.
+// Returns a zero value when stats are disabled (callers should check StatsEnabled
+// or treat zeros as "not collected").
+func (r *Renderer) GetCounters() DeviceCounters {
+	if r == nil || !statsEnabled.Load() {
+		return DeviceCounters{}
+	}
+	return DeviceCounters{
+		Textures:              r.statsTextures.Load(),
+		TextureBytesAllocated: r.statsTextureBytes.Load(),
+		UploadBytesTotal:      r.statsUploadBytes.Load(),
+		UploadRegionsTotal:    r.statsUploadRegions.Load(),
+	}
+}
+
+// ResetCounters zeroes cumulative device counters. Frame stats are unaffected.
+// Intended for tests and long-running process observability windows.
+func (r *Renderer) ResetCounters() {
+	if r == nil {
+		return
+	}
+	r.statsTextures.Store(0)
+	r.statsTextureBytes.Store(0)
+	r.statsUploadBytes.Store(0)
+	r.statsUploadRegions.Store(0)
+}
+
+// GetFrameStats returns the last completed frame's FrameStats snapshot.
+// During OnDraw, prefer Context.FrameStats() for the in-progress frame.
+func (r *Renderer) GetFrameStats() FrameStats {
+	if r == nil || !statsEnabled.Load() {
+		return FrameStats{}
+	}
+	r.frameStats.mu.Lock()
+	defer r.frameStats.mu.Unlock()
+	return r.frameStats.last
+}
+
+// FrameStats returns the in-progress frame's upload/present metrics.
+// Safe to call during OnDraw after texture uploads to assert upload budgets
+// (e.g. geckty CI: dirty rows → UploadBytes < 10% of full frame).
+func (c *Context) FrameStats() FrameStats {
+	if c == nil || c.renderer == nil || !statsEnabled.Load() {
+		return FrameStats{}
+	}
+	fs := &c.renderer.frameStats
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	out := FrameStats{
+		UploadBytes:    fs.uploadBytes,
+		UploadRegions:  fs.uploadRegions,
+		PresentSkipped: fs.presentSkipped,
+	}
+	if !fs.frameStart.IsZero() {
+		out.FrameDuration = time.Since(fs.frameStart)
+	}
+	return out
+}
+
+func (r *Renderer) beginFrameStats() {
+	if r == nil || !statsEnabled.Load() {
+		return
+	}
+	fs := &r.frameStats
+	fs.mu.Lock()
+	fs.uploadBytes = 0
+	fs.uploadRegions = 0
+	fs.presentSkipped = false
+	fs.frameStart = time.Now()
+	fs.mu.Unlock()
+}
+
+func (r *Renderer) endFrameStats(presentSkipped bool) {
+	if r == nil || !statsEnabled.Load() {
+		return
+	}
+	fs := &r.frameStats
+	fs.mu.Lock()
+	if presentSkipped {
+		fs.presentSkipped = true
+	}
+	last := FrameStats{
+		UploadBytes:    fs.uploadBytes,
+		UploadRegions:  fs.uploadRegions,
+		PresentSkipped: fs.presentSkipped,
+	}
+	if !fs.frameStart.IsZero() {
+		last.FrameDuration = time.Since(fs.frameStart)
+	}
+	fs.last = last
+	fs.mu.Unlock()
+}
+
+func (r *Renderer) recordUpload(bytes int64, regions int) {
+	if r == nil || !statsEnabled.Load() || bytes < 0 {
+		return
+	}
+	if bytes > 0 {
+		r.statsUploadBytes.Add(bytes)
+	}
+	if regions > 0 {
+		r.statsUploadRegions.Add(int64(regions))
+	}
+	fs := &r.frameStats
+	fs.mu.Lock()
+	fs.uploadBytes += bytes
+	fs.uploadRegions += regions
+	fs.mu.Unlock()
+}
+
+func (r *Renderer) recordTextureAlloc(bytes int64) {
+	if r == nil || !statsEnabled.Load() || bytes <= 0 {
+		return
+	}
+	r.statsTextures.Add(1)
+	r.statsTextureBytes.Add(bytes)
+}
+
+func (r *Renderer) recordTextureFree(bytes int64) {
+	if r == nil || !statsEnabled.Load() || bytes <= 0 {
+		return
+	}
+	r.statsTextures.Add(-1)
+	r.statsTextureBytes.Add(-bytes)
+}

--- a/stats.go
+++ b/stats.go
@@ -118,7 +118,7 @@ func (r *Renderer) GetFrameStats() FrameStats {
 
 // FrameStats returns the in-progress frame's upload/present metrics.
 // Safe to call during OnDraw after texture uploads to assert upload budgets
-// (e.g. geckty CI: dirty rows → UploadBytes < 10% of full frame).
+// (e.g. CI: dirty rows → UploadBytes < 10% of full frame).
 func (c *Context) FrameStats() FrameStats {
 	if c == nil || c.renderer == nil || !statsEnabled.Load() {
 		return FrameStats{}

--- a/stats_test.go
+++ b/stats_test.go
@@ -2,6 +2,7 @@ package gogpu
 
 import (
 	"errors"
+	"image"
 	"testing"
 
 	"github.com/gogpu/gpucontext"
@@ -9,9 +10,11 @@ import (
 	_ "github.com/gogpu/wgpu/hal/software"
 )
 
-// TestUpdateRegionStrideValidation covers bytesPerRow validation without a live GPU
-// after the destroyed check is bypassed via a non-nil texture handle stub is not
-// available — these use a live headless renderer.
+func regionRect(x, w, h int) image.Rectangle {
+	return image.Rect(x, 0, x+w, h)
+}
+
+// TestUpdateRegionStrideValidation covers layout validation with a live headless renderer.
 func TestUpdateRegionStrideValidation(t *testing.T) {
 	EnableStats()
 	t.Cleanup(DisableStats)
@@ -34,48 +37,77 @@ func TestUpdateRegionStrideValidation(t *testing.T) {
 	t.Cleanup(tex.Destroy)
 
 	tests := []struct {
-		name        string
-		x, y, w, h  int
-		bytesPerRow int
-		dataLen     int
-		wantErr     error
+		name    string
+		region  image.Rectangle
+		layout  gpucontext.ImageDataLayout
+		dataLen int
+		wantErr error
 	}{
 		{
-			name: "tight packed zero stride",
-			w:    4, h: 2, bytesPerRow: 0, dataLen: 4 * 2 * 4,
+			name:    "tight packed zero layout",
+			region:  regionRect(0, 4, 2),
+			layout:  gpucontext.ImageDataLayout{},
+			dataLen: 4 * 2 * 4,
 		},
 		{
-			name: "explicit packed stride",
-			w:    4, h: 2, bytesPerRow: 16, dataLen: 4 * 2 * 4,
+			name:    "explicit packed stride",
+			region:  regionRect(0, 4, 2),
+			layout:  gpucontext.ImageDataLayout{BytesPerRow: 16},
+			dataLen: 4 * 2 * 4,
 		},
 		{
-			name: "strided full-frame buffer band",
-			// Region 4x2 from an 8-wide RGBA buffer: stride = 8*4 = 32.
-			// Need stride*(h-1)+packedRow = 32*1+16 = 48 bytes minimum.
-			w: 4, h: 2, bytesPerRow: 32, dataLen: 48,
+			name:    "strided full-frame buffer band",
+			region:  regionRect(0, 4, 2),
+			layout:  gpucontext.ImageDataLayout{BytesPerRow: 32},
+			dataLen: 48, // stride*(h-1)+packedRow = 32*1+16
 		},
 		{
-			name: "stride too small",
-			w:    4, h: 2, bytesPerRow: 8, dataLen: 100, wantErr: ErrInvalidStride,
+			name:    "stride too small",
+			region:  regionRect(0, 4, 2),
+			layout:  gpucontext.ImageDataLayout{BytesPerRow: 8},
+			dataLen: 100,
+			wantErr: ErrInvalidStride,
 		},
 		{
-			name: "data too short for stride",
-			w:    4, h: 2, bytesPerRow: 32, dataLen: 40, wantErr: ErrInvalidDataSize,
+			name:    "data too short for stride",
+			region:  regionRect(0, 4, 2),
+			layout:  gpucontext.ImageDataLayout{BytesPerRow: 32},
+			dataLen: 40,
+			wantErr: ErrInvalidDataSize,
 		},
 		{
-			name: "region out of bounds",
-			x:    6, w: 4, h: 1, bytesPerRow: 0, dataLen: 16, wantErr: ErrRegionOutOfBounds,
+			name:    "region out of bounds",
+			region:  regionRect(6, 4, 1),
+			layout:  gpucontext.ImageDataLayout{},
+			dataLen: 16,
+			wantErr: ErrRegionOutOfBounds,
 		},
 		{
-			name: "invalid region zero height",
-			w:    4, h: 0, bytesPerRow: 0, dataLen: 16, wantErr: ErrInvalidRegion,
+			name:    "invalid region zero height",
+			region:  regionRect(0, 4, 0),
+			layout:  gpucontext.ImageDataLayout{},
+			dataLen: 16,
+			wantErr: ErrInvalidRegion,
+		},
+		{
+			name:    "layout offset within buffer",
+			region:  regionRect(0, 4, 2),
+			layout:  gpucontext.ImageDataLayout{BytesPerRow: 16, Offset: 8},
+			dataLen: 8 + 4*2*4,
+		},
+		{
+			name:    "layout offset past buffer",
+			region:  regionRect(0, 4, 2),
+			layout:  gpucontext.ImageDataLayout{Offset: 100},
+			dataLen: 32,
+			wantErr: ErrInvalidDataSize,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			data := make([]byte, tt.dataLen)
-			err := tex.UpdateRegion(tt.x, tt.y, tt.w, tt.h, tt.bytesPerRow, data)
+			err := tex.UpdateRegion(tt.region, data, tt.layout)
 			if tt.wantErr == nil {
 				if err != nil {
 					t.Fatalf("UpdateRegion: %v", err)
@@ -109,7 +141,6 @@ func TestUpdateRegionStrideZeroCopyBand(t *testing.T) {
 		bpp    = 4
 	)
 	frame := make([]byte, fw*fh*bpp)
-	// Paint dirty rows 5..7 with a recognizable pattern.
 	for y := 5; y < 8; y++ {
 		for x := 0; x < fw; x++ {
 			i := (y*fw + x) * bpp
@@ -126,11 +157,13 @@ func TestUpdateRegionStrideZeroCopyBand(t *testing.T) {
 	}
 	defer tex.Destroy()
 
-	r.beginFrameStats() // isolate band upload from create upload
+	r.beginFrameStats()
 	dirtyY, dirtyH := 5, 3
-	bandOffset := dirtyY * fw * bpp
-	band := frame[bandOffset:] // zero-copy slice into full frame
-	if err := tex.UpdateRegion(0, dirtyY, fw, dirtyH, fw*bpp, band); err != nil {
+	stride := fw * bpp
+	band := frame[dirtyY*stride:] // zero-copy slice into full frame
+	region := image.Rect(0, dirtyY, fw, dirtyY+dirtyH)
+	layout := gpucontext.ImageDataLayout{BytesPerRow: stride}
+	if err := tex.UpdateRegion(region, band, layout); err != nil {
 		t.Fatalf("strided UpdateRegion: %v", err)
 	}
 
@@ -143,7 +176,6 @@ func TestUpdateRegionStrideZeroCopyBand(t *testing.T) {
 	if fs.UploadRegions != 1 {
 		t.Fatalf("FrameStats.UploadRegions = %d, want 1", fs.UploadRegions)
 	}
-	// Acceptance from #484: dirty rows ≪ full frame.
 	if fs.UploadBytes*10 >= fullBytes {
 		t.Fatalf("upload %d bytes is not < 10%% of full frame %d", fs.UploadBytes, fullBytes)
 	}
@@ -222,7 +254,7 @@ func TestFrameStatsPresentSkippedOnIdleEndFrame(t *testing.T) {
 	r := &Renderer{primary: &RenderTarget{}}
 	r.primary.renderer = r
 	r.beginFrameStats()
-	r.EndFrame() // frameStarted=false → present skipped
+	r.EndFrame()
 
 	last := r.GetFrameStats()
 	if !last.PresentSkipped {
@@ -231,13 +263,12 @@ func TestFrameStatsPresentSkippedOnIdleEndFrame(t *testing.T) {
 }
 
 func TestUpdateRegionValidationOrderDestroyedFirst(t *testing.T) {
-	// Destroyed check must precede region/stride validation (existing contract).
 	tex := &Texture{
 		width:  10,
 		height: 10,
 		format: gputypes.TextureFormatRGBA8Unorm,
 	}
-	err := tex.UpdateRegion(0, 0, 5, 5, 1, nil) // stride too small would be ErrInvalidStride if live
+	err := tex.UpdateRegion(image.Rect(0, 0, 5, 5), nil, gpucontext.ImageDataLayout{BytesPerRow: 1})
 	if !errors.Is(err, ErrTextureUpdateDestroyed) {
 		t.Fatalf("error = %v, want ErrTextureUpdateDestroyed", err)
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -89,7 +89,7 @@ func TestUpdateRegionStrideValidation(t *testing.T) {
 	}
 }
 
-// TestUpdateRegionStrideZeroCopyBand verifies the geckty/ggcanvas use case:
+// TestUpdateRegionStrideZeroCopyBand verifies the ggcanvas-style use case:
 // upload a dirty horizontal band from a full-frame RGBA buffer without extractRegion.
 func TestUpdateRegionStrideZeroCopyBand(t *testing.T) {
 	EnableStats()

--- a/stats_test.go
+++ b/stats_test.go
@@ -10,10 +10,6 @@ import (
 	_ "github.com/gogpu/wgpu/hal/software"
 )
 
-func regionRect(x, w, h int) image.Rectangle {
-	return image.Rect(x, 0, x+w, h)
-}
-
 // TestUpdateRegionStrideValidation covers layout validation with a live headless renderer.
 func TestUpdateRegionStrideValidation(t *testing.T) {
 	EnableStats()
@@ -45,59 +41,59 @@ func TestUpdateRegionStrideValidation(t *testing.T) {
 	}{
 		{
 			name:    "tight packed zero layout",
-			region:  regionRect(0, 4, 2),
+			region:  image.Rect(0, 0, 4, 2),
 			layout:  gpucontext.ImageDataLayout{},
 			dataLen: 4 * 2 * 4,
 		},
 		{
 			name:    "explicit packed stride",
-			region:  regionRect(0, 4, 2),
+			region:  image.Rect(0, 0, 4, 2),
 			layout:  gpucontext.ImageDataLayout{BytesPerRow: 16},
 			dataLen: 4 * 2 * 4,
 		},
 		{
 			name:    "strided full-frame buffer band",
-			region:  regionRect(0, 4, 2),
+			region:  image.Rect(0, 0, 4, 2),
 			layout:  gpucontext.ImageDataLayout{BytesPerRow: 32},
 			dataLen: 48, // stride*(h-1)+packedRow = 32*1+16
 		},
 		{
 			name:    "stride too small",
-			region:  regionRect(0, 4, 2),
+			region:  image.Rect(0, 0, 4, 2),
 			layout:  gpucontext.ImageDataLayout{BytesPerRow: 8},
 			dataLen: 100,
 			wantErr: ErrInvalidStride,
 		},
 		{
 			name:    "data too short for stride",
-			region:  regionRect(0, 4, 2),
+			region:  image.Rect(0, 0, 4, 2),
 			layout:  gpucontext.ImageDataLayout{BytesPerRow: 32},
 			dataLen: 40,
 			wantErr: ErrInvalidDataSize,
 		},
 		{
 			name:    "region out of bounds",
-			region:  regionRect(6, 4, 1),
+			region:  image.Rect(6, 0, 10, 1),
 			layout:  gpucontext.ImageDataLayout{},
 			dataLen: 16,
 			wantErr: ErrRegionOutOfBounds,
 		},
 		{
 			name:    "invalid region zero height",
-			region:  regionRect(0, 4, 0),
+			region:  image.Rect(0, 0, 4, 0),
 			layout:  gpucontext.ImageDataLayout{},
 			dataLen: 16,
 			wantErr: ErrInvalidRegion,
 		},
 		{
 			name:    "layout offset within buffer",
-			region:  regionRect(0, 4, 2),
+			region:  image.Rect(0, 0, 4, 2),
 			layout:  gpucontext.ImageDataLayout{BytesPerRow: 16, Offset: 8},
 			dataLen: 8 + 4*2*4,
 		},
 		{
 			name:    "layout offset past buffer",
-			region:  regionRect(0, 4, 2),
+			region:  image.Rect(0, 0, 4, 2),
 			layout:  gpucontext.ImageDataLayout{Offset: 100},
 			dataLen: 32,
 			wantErr: ErrInvalidDataSize,

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,244 @@
+package gogpu
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/gputypes"
+	_ "github.com/gogpu/wgpu/hal/software"
+)
+
+// TestUpdateRegionStrideValidation covers bytesPerRow validation without a live GPU
+// after the destroyed check is bypassed via a non-nil texture handle stub is not
+// available — these use a live headless renderer.
+func TestUpdateRegionStrideValidation(t *testing.T) {
+	EnableStats()
+	t.Cleanup(DisableStats)
+
+	r, err := NewHeadlessRenderer()
+	if err != nil {
+		t.Fatalf("NewHeadlessRenderer: %v", err)
+	}
+	t.Cleanup(func() {
+		r.Destroy()
+		r.ReleaseInstance()
+	})
+
+	const tw, th = 8, 8
+	full := make([]byte, tw*th*4)
+	tex, err := r.NewTextureFromRGBA(tw, th, full)
+	if err != nil {
+		t.Fatalf("NewTextureFromRGBA: %v", err)
+	}
+	t.Cleanup(tex.Destroy)
+
+	tests := []struct {
+		name        string
+		x, y, w, h  int
+		bytesPerRow int
+		dataLen     int
+		wantErr     error
+	}{
+		{
+			name: "tight packed zero stride",
+			w:    4, h: 2, bytesPerRow: 0, dataLen: 4 * 2 * 4,
+		},
+		{
+			name: "explicit packed stride",
+			w:    4, h: 2, bytesPerRow: 16, dataLen: 4 * 2 * 4,
+		},
+		{
+			name: "strided full-frame buffer band",
+			// Region 4x2 from an 8-wide RGBA buffer: stride = 8*4 = 32.
+			// Need stride*(h-1)+packedRow = 32*1+16 = 48 bytes minimum.
+			w: 4, h: 2, bytesPerRow: 32, dataLen: 48,
+		},
+		{
+			name: "stride too small",
+			w:    4, h: 2, bytesPerRow: 8, dataLen: 100, wantErr: ErrInvalidStride,
+		},
+		{
+			name: "data too short for stride",
+			w:    4, h: 2, bytesPerRow: 32, dataLen: 40, wantErr: ErrInvalidDataSize,
+		},
+		{
+			name: "region out of bounds",
+			x:    6, w: 4, h: 1, bytesPerRow: 0, dataLen: 16, wantErr: ErrRegionOutOfBounds,
+		},
+		{
+			name: "invalid region zero height",
+			w:    4, h: 0, bytesPerRow: 0, dataLen: 16, wantErr: ErrInvalidRegion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, tt.dataLen)
+			err := tex.UpdateRegion(tt.x, tt.y, tt.w, tt.h, tt.bytesPerRow, data)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("UpdateRegion: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("UpdateRegion error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestUpdateRegionStrideZeroCopyBand verifies the geckty/ggcanvas use case:
+// upload a dirty horizontal band from a full-frame RGBA buffer without extractRegion.
+func TestUpdateRegionStrideZeroCopyBand(t *testing.T) {
+	EnableStats()
+	defer DisableStats()
+
+	r, err := NewHeadlessRenderer()
+	if err != nil {
+		t.Fatalf("NewHeadlessRenderer: %v", err)
+	}
+	defer r.Destroy()
+	defer r.ReleaseInstance()
+	r.ResetCounters()
+	r.beginFrameStats()
+
+	const (
+		fw, fh = 80, 40 // grid where 3 dirty rows are < 10% of the frame (#484 acceptance)
+		bpp    = 4
+	)
+	frame := make([]byte, fw*fh*bpp)
+	// Paint dirty rows 5..7 with a recognizable pattern.
+	for y := 5; y < 8; y++ {
+		for x := 0; x < fw; x++ {
+			i := (y*fw + x) * bpp
+			frame[i] = 0x11
+			frame[i+1] = 0x22
+			frame[i+2] = 0x33
+			frame[i+3] = 0xFF
+		}
+	}
+
+	tex, err := r.NewTextureFromRGBA(fw, fh, frame)
+	if err != nil {
+		t.Fatalf("NewTextureFromRGBA: %v", err)
+	}
+	defer tex.Destroy()
+
+	r.beginFrameStats() // isolate band upload from create upload
+	dirtyY, dirtyH := 5, 3
+	bandOffset := dirtyY * fw * bpp
+	band := frame[bandOffset:] // zero-copy slice into full frame
+	if err := tex.UpdateRegion(0, dirtyY, fw, dirtyH, fw*bpp, band); err != nil {
+		t.Fatalf("strided UpdateRegion: %v", err)
+	}
+
+	fs := (&Context{renderer: r}).FrameStats()
+	fullBytes := int64(fw * fh * bpp)
+	bandBytes := int64(fw * dirtyH * bpp)
+	if fs.UploadBytes != bandBytes {
+		t.Fatalf("FrameStats.UploadBytes = %d, want band %d", fs.UploadBytes, bandBytes)
+	}
+	if fs.UploadRegions != 1 {
+		t.Fatalf("FrameStats.UploadRegions = %d, want 1", fs.UploadRegions)
+	}
+	// Acceptance from #484: dirty rows ≪ full frame.
+	if fs.UploadBytes*10 >= fullBytes {
+		t.Fatalf("upload %d bytes is not < 10%% of full frame %d", fs.UploadBytes, fullBytes)
+	}
+
+	counters := r.GetCounters()
+	if counters.Textures != 1 {
+		t.Fatalf("GetCounters.Textures = %d, want 1", counters.Textures)
+	}
+	if counters.TextureBytesAllocated != fullBytes {
+		t.Fatalf("TextureBytesAllocated = %d, want %d", counters.TextureBytesAllocated, fullBytes)
+	}
+}
+
+func TestUpdateRegionImplementsTextureRegionUpdater(t *testing.T) {
+	var _ gpucontext.TextureRegionUpdater = (*Texture)(nil)
+}
+
+func TestStatsDisabledIsZeroCost(t *testing.T) {
+	DisableStats()
+	r, err := NewHeadlessRenderer()
+	if err != nil {
+		t.Fatalf("NewHeadlessRenderer: %v", err)
+	}
+	defer r.Destroy()
+	defer r.ReleaseInstance()
+
+	data := make([]byte, 4*4*4)
+	tex, err := r.NewTextureFromRGBA(4, 4, data)
+	if err != nil {
+		t.Fatalf("NewTextureFromRGBA: %v", err)
+	}
+	defer tex.Destroy()
+
+	if got := r.GetCounters(); got != (DeviceCounters{}) {
+		t.Fatalf("GetCounters with stats off = %+v, want zero", got)
+	}
+	ctx := &Context{renderer: r}
+	if got := ctx.FrameStats(); got != (FrameStats{}) {
+		t.Fatalf("FrameStats with stats off = %+v, want zero", got)
+	}
+}
+
+func TestDeviceCountersTrackAllocFree(t *testing.T) {
+	EnableStats()
+	defer DisableStats()
+
+	r, err := NewHeadlessRenderer()
+	if err != nil {
+		t.Fatalf("NewHeadlessRenderer: %v", err)
+	}
+	defer r.Destroy()
+	defer r.ReleaseInstance()
+	r.ResetCounters()
+
+	data := make([]byte, 16*16*4)
+	tex, err := r.NewTextureFromRGBA(16, 16, data)
+	if err != nil {
+		t.Fatalf("NewTextureFromRGBA: %v", err)
+	}
+	c := r.GetCounters()
+	if c.Textures != 1 || c.TextureBytesAllocated != 16*16*4 {
+		t.Fatalf("after create: %+v", c)
+	}
+
+	tex.Destroy()
+	c = r.GetCounters()
+	if c.Textures != 0 || c.TextureBytesAllocated != 0 {
+		t.Fatalf("after destroy: %+v", c)
+	}
+}
+
+func TestFrameStatsPresentSkippedOnIdleEndFrame(t *testing.T) {
+	EnableStats()
+	defer DisableStats()
+
+	r := &Renderer{primary: &RenderTarget{}}
+	r.primary.renderer = r
+	r.beginFrameStats()
+	r.EndFrame() // frameStarted=false → present skipped
+
+	last := r.GetFrameStats()
+	if !last.PresentSkipped {
+		t.Fatal("PresentSkipped = false, want true for idle EndFrame")
+	}
+}
+
+func TestUpdateRegionValidationOrderDestroyedFirst(t *testing.T) {
+	// Destroyed check must precede region/stride validation (existing contract).
+	tex := &Texture{
+		width:  10,
+		height: 10,
+		format: gputypes.TextureFormatRGBA8Unorm,
+	}
+	err := tex.UpdateRegion(0, 0, 5, 5, 1, nil) // stride too small would be ErrInvalidStride if live
+	if !errors.Is(err, ErrTextureUpdateDestroyed) {
+		t.Fatalf("error = %v, want ErrTextureUpdateDestroyed", err)
+	}
+}

--- a/texture.go
+++ b/texture.go
@@ -433,7 +433,7 @@ func (t *Texture) UpdateData(data []byte) error {
 // When bytesPerRow > 0, data must be at least bytesPerRow*(h-1)+w*bytesPerPixel
 // bytes (the last row need not be padded). bytesPerRow must be >= w*bytesPerPixel.
 //
-// Related: #484 (geckty dirty-band uploads without extractRegion memcpy).
+// Related: #484 (dirty-band uploads without extractRegion memcpy).
 func (t *Texture) UpdateRegion(x, y, w, h, bytesPerRow int, data []byte) error {
 	if t.renderer == nil || t.renderer.device == nil || t.texture == nil {
 		return ErrTextureUpdateDestroyed

--- a/texture.go
+++ b/texture.go
@@ -25,6 +25,7 @@ type textureCleanupHandle struct {
 	view     *wgpu.TextureView
 	sampler  *wgpu.Sampler
 	renderer *Renderer
+	bytes    int64 // allocated texel bytes for stats free on GC path
 }
 
 // Texture update errors.
@@ -40,6 +41,10 @@ var (
 
 	// ErrInvalidRegion is returned when region parameters are invalid (negative or zero).
 	ErrInvalidRegion = errors.New("gogpu: invalid region parameters")
+
+	// ErrInvalidStride is returned when bytesPerRow is positive but smaller than
+	// the tightly packed row size (w * bytesPerPixel).
+	ErrInvalidStride = errors.New("gogpu: invalid bytesPerRow stride")
 )
 
 // Texture represents a GPU texture resource with its associated view and sampler.
@@ -157,6 +162,13 @@ func (t *Texture) Destroy() {
 	if t.texture != nil {
 		t.texture.Release()
 		t.texture = nil
+	}
+
+	if bpp := t.BytesPerPixel(); bpp > 0 && t.width > 0 && t.height > 0 {
+		t.renderer.recordTextureFree(int64(t.width * t.height * bpp))
+		// Prevent double-counting on a second Destroy call.
+		t.width = 0
+		t.height = 0
 	}
 }
 
@@ -338,6 +350,9 @@ func (r *Renderer) NewTextureFromRGBAWithOptions(width, height int, data []byte,
 		renderer:      r,
 	}
 
+	r.recordTextureAlloc(int64(width * height * 4))
+	r.recordUpload(int64(len(data)), 1)
+
 	// Safety net: if the texture is garbage collected without Destroy(),
 	// enqueue deferred destruction on the render thread.
 	handle := textureCleanupHandle{
@@ -345,6 +360,7 @@ func (r *Renderer) NewTextureFromRGBAWithOptions(width, height int, data []byte,
 		view:     view,
 		sampler:  sampler,
 		renderer: r,
+		bytes:    int64(width * height * 4),
 	}
 	tex.cleanup = runtime.AddCleanup(tex, func(h textureCleanupHandle) {
 		h.renderer.EnqueueDeferredDestroy(func() {
@@ -357,6 +373,7 @@ func (r *Renderer) NewTextureFromRGBAWithOptions(width, height int, data []byte,
 			if h.texture != nil {
 				h.texture.Release()
 			}
+			h.renderer.recordTextureFree(h.bytes)
 		})
 	}, handle)
 
@@ -402,11 +419,22 @@ func (t *Texture) UpdateData(data []byte) error {
 		return fmt.Errorf("gogpu: failed to upload texture data: %w", err)
 	}
 
+	t.renderer.recordUpload(int64(expectedSize), 1)
 	return nil
 }
 
 // UpdateRegion uploads pixel data to a rectangular region of the texture.
-func (t *Texture) UpdateRegion(x, y, w, h int, data []byte) error {
+//
+// bytesPerRow is the stride in bytes between consecutive rows in data
+// (WebGPU ImageDataLayout.bytesPerRow). Pass 0 for tightly packed rows
+// (w * bytesPerPixel) — this preserves the pre-stride dense-upload behavior.
+//
+// When bytesPerRow is 0, data must be exactly w*h*bytesPerPixel bytes.
+// When bytesPerRow > 0, data must be at least bytesPerRow*(h-1)+w*bytesPerPixel
+// bytes (the last row need not be padded). bytesPerRow must be >= w*bytesPerPixel.
+//
+// Related: #484 (geckty dirty-band uploads without extractRegion memcpy).
+func (t *Texture) UpdateRegion(x, y, w, h, bytesPerRow int, data []byte) error {
 	if t.renderer == nil || t.renderer.device == nil || t.texture == nil {
 		return ErrTextureUpdateDestroyed
 	}
@@ -426,12 +454,24 @@ func (t *Texture) UpdateRegion(x, y, w, h int, data []byte) error {
 		return fmt.Errorf("%w: unsupported texture format", ErrInvalidDataSize)
 	}
 
-	expectedSize := w * h * bpp
-	if len(data) != expectedSize {
-		return fmt.Errorf("%w: expected %d bytes (%dx%dx%d), got %d",
-			ErrInvalidDataSize, expectedSize, w, h, bpp, len(data))
+	packedRow := w * bpp
+	stride := bytesPerRow
+	if stride == 0 {
+		stride = packedRow
+	}
+	if stride < packedRow {
+		return fmt.Errorf("%w: bytesPerRow=%d < packed row=%d (w=%d * bpp=%d)",
+			ErrInvalidStride, bytesPerRow, packedRow, w, bpp)
 	}
 
+	// WebGPU writeTexture size: bytesPerRow*(height-1) + bytesPerCopy for last row.
+	expectedSize := stride*(h-1) + packedRow
+	if len(data) < expectedSize {
+		return fmt.Errorf("%w: expected at least %d bytes (stride=%d, %dx%dx%d), got %d",
+			ErrInvalidDataSize, expectedSize, stride, w, h, bpp, len(data))
+	}
+
+	uploadBytes := packedRow * h // logical texel bytes transferred (not stride padding)
 	if err := t.renderer.device.Queue().WriteTexture(
 		&wgpu.ImageCopyTexture{
 			Texture:  t.texture,
@@ -446,8 +486,8 @@ func (t *Texture) UpdateRegion(x, y, w, h int, data []byte) error {
 		data,
 		&wgpu.ImageDataLayout{
 			Offset:       0,
-			BytesPerRow:  uint32(w * bpp), //nolint:gosec // G115: w validated positive above
-			RowsPerImage: uint32(h),       //nolint:gosec // G115: h validated positive above
+			BytesPerRow:  uint32(stride), //nolint:gosec // G115: stride validated positive above
+			RowsPerImage: uint32(h),      //nolint:gosec // G115: h validated positive above
 		},
 		&wgpu.Extent3D{
 			Width:              uint32(w), //nolint:gosec // G115: w validated positive above
@@ -458,5 +498,6 @@ func (t *Texture) UpdateRegion(x, y, w, h int, data []byte) error {
 		return fmt.Errorf("gogpu: failed to upload texture region: %w", err)
 	}
 
+	t.renderer.recordUpload(int64(uploadBytes), 1)
 	return nil
 }

--- a/texture.go
+++ b/texture.go
@@ -425,28 +425,28 @@ func (t *Texture) UpdateData(data []byte) error {
 
 // UpdateRegion uploads pixel data to a rectangular region of the texture.
 //
-// bytesPerRow is the stride in bytes between consecutive rows in data
-// (WebGPU ImageDataLayout.bytesPerRow). Pass 0 for tightly packed rows
-// (w * bytesPerPixel) — this preserves the pre-stride dense-upload behavior.
-//
-// When bytesPerRow is 0, data must be exactly w*h*bytesPerPixel bytes.
-// When bytesPerRow > 0, data must be at least bytesPerRow*(h-1)+w*bytesPerPixel
-// bytes (the last row need not be padded). bytesPerRow must be >= w*bytesPerPixel.
+// region uses stdlib image.Rectangle coordinates (Min = top-left,
+// Max = exclusive bottom-right). layout describes source buffer stride,
+// offset, and rows-per-image (WebGPU GPUTexelCopyBufferLayout semantics).
+// Zero-value layout = offset 0, tightly packed rows, region height.
 //
 // Related: #484 (dirty-band uploads without extractRegion memcpy).
-func (t *Texture) UpdateRegion(x, y, w, h, bytesPerRow int, data []byte) error {
+func (t *Texture) UpdateRegion(region image.Rectangle, data []byte, layout gpucontext.ImageDataLayout) error {
 	if t.renderer == nil || t.renderer.device == nil || t.texture == nil {
 		return ErrTextureUpdateDestroyed
 	}
 
+	x, y := region.Min.X, region.Min.Y
+	w, h := region.Dx(), region.Dy()
+
 	if x < 0 || y < 0 || w <= 0 || h <= 0 {
-		return fmt.Errorf("%w: x=%d, y=%d, w=%d, h=%d (x,y must be non-negative; w,h must be positive)",
-			ErrInvalidRegion, x, y, w, h)
+		return fmt.Errorf("%w: region %v (min must be non-negative; size must be positive)",
+			ErrInvalidRegion, region)
 	}
 
 	if x+w > t.width || y+h > t.height {
-		return fmt.Errorf("%w: region (%d,%d)+(%d,%d) exceeds texture size (%d,%d)",
-			ErrRegionOutOfBounds, x, y, w, h, t.width, t.height)
+		return fmt.Errorf("%w: region %v exceeds texture size (%d,%d)",
+			ErrRegionOutOfBounds, region, t.width, t.height)
 	}
 
 	bpp := t.BytesPerPixel()
@@ -454,21 +454,38 @@ func (t *Texture) UpdateRegion(x, y, w, h, bytesPerRow int, data []byte) error {
 		return fmt.Errorf("%w: unsupported texture format", ErrInvalidDataSize)
 	}
 
+	if layout.Offset < 0 {
+		return fmt.Errorf("%w: negative layout offset %d", ErrInvalidDataSize, layout.Offset)
+	}
+	if layout.Offset > len(data) {
+		return fmt.Errorf("%w: layout offset %d exceeds data length %d",
+			ErrInvalidDataSize, layout.Offset, len(data))
+	}
+
 	packedRow := w * bpp
-	stride := bytesPerRow
+	stride := layout.BytesPerRow
 	if stride == 0 {
 		stride = packedRow
 	}
 	if stride < packedRow {
 		return fmt.Errorf("%w: bytesPerRow=%d < packed row=%d (w=%d * bpp=%d)",
-			ErrInvalidStride, bytesPerRow, packedRow, w, bpp)
+			ErrInvalidStride, layout.BytesPerRow, packedRow, w, bpp)
+	}
+
+	rowsPerImage := layout.RowsPerImage
+	if rowsPerImage == 0 {
+		rowsPerImage = h
+	}
+	if rowsPerImage < h {
+		return fmt.Errorf("%w: rowsPerImage=%d < region height %d",
+			ErrInvalidDataSize, layout.RowsPerImage, h)
 	}
 
 	// WebGPU writeTexture size: bytesPerRow*(height-1) + bytesPerCopy for last row.
 	expectedSize := stride*(h-1) + packedRow
-	if len(data) < expectedSize {
-		return fmt.Errorf("%w: expected at least %d bytes (stride=%d, %dx%dx%d), got %d",
-			ErrInvalidDataSize, expectedSize, stride, w, h, bpp, len(data))
+	if len(data) < layout.Offset+expectedSize {
+		return fmt.Errorf("%w: expected at least %d bytes (offset=%d, stride=%d, %dx%dx%d), got %d",
+			ErrInvalidDataSize, layout.Offset+expectedSize, layout.Offset, stride, w, h, bpp, len(data))
 	}
 
 	uploadBytes := packedRow * h // logical texel bytes transferred (not stride padding)
@@ -485,9 +502,9 @@ func (t *Texture) UpdateRegion(x, y, w, h, bytesPerRow int, data []byte) error {
 		},
 		data,
 		&wgpu.ImageDataLayout{
-			Offset:       0,
-			BytesPerRow:  uint32(stride), //nolint:gosec // G115: stride validated positive above
-			RowsPerImage: uint32(h),      //nolint:gosec // G115: h validated positive above
+			Offset:       uint64(layout.Offset),
+			BytesPerRow:  uint32(stride),       //nolint:gosec // G115: stride validated positive above
+			RowsPerImage: uint32(rowsPerImage), //nolint:gosec // G115: rowsPerImage validated positive above
 		},
 		&wgpu.Extent3D{
 			Width:              uint32(w), //nolint:gosec // G115: w validated positive above

--- a/texture_test.go
+++ b/texture_test.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"testing"
 
+	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/gputypes"
 )
 
@@ -418,7 +419,7 @@ func TestUpdateRegionDestroyedTexture(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.tex.UpdateRegion(0, 0, 5, 5, 0, make([]byte, 100))
+			err := tt.tex.UpdateRegion(image.Rect(0, 0, 5, 5), make([]byte, 100), gpucontext.ImageDataLayout{})
 			if !errors.Is(err, ErrTextureUpdateDestroyed) {
 				t.Errorf("UpdateRegion() error = %v, want ErrTextureUpdateDestroyed", err)
 			}
@@ -440,21 +441,20 @@ func TestUpdateRegionInvalidParams(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		x, y    int
-		w, h    int
+		region  image.Rectangle
 		wantErr error
 	}{
-		{"negative x", -1, 0, 5, 5, ErrTextureUpdateDestroyed},
-		{"negative y", 0, -1, 5, 5, ErrTextureUpdateDestroyed},
-		{"zero width", 0, 0, 0, 5, ErrTextureUpdateDestroyed},
-		{"zero height", 0, 0, 5, 0, ErrTextureUpdateDestroyed},
-		{"negative width", 0, 0, -5, 5, ErrTextureUpdateDestroyed},
-		{"negative height", 0, 0, 5, -5, ErrTextureUpdateDestroyed},
+		{"negative x", image.Rect(-1, 0, 4, 5), ErrTextureUpdateDestroyed},
+		{"negative y", image.Rect(0, -1, 5, 4), ErrTextureUpdateDestroyed},
+		{"zero width", image.Rect(0, 0, 0, 5), ErrTextureUpdateDestroyed},
+		{"zero height", image.Rect(0, 0, 5, 0), ErrTextureUpdateDestroyed},
+		{"negative width", image.Rect(0, 0, -5, 5), ErrTextureUpdateDestroyed},
+		{"negative height", image.Rect(0, 0, 5, -5), ErrTextureUpdateDestroyed},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tex.UpdateRegion(tt.x, tt.y, tt.w, tt.h, 0, make([]byte, 100))
+			err := tex.UpdateRegion(tt.region, make([]byte, 100), gpucontext.ImageDataLayout{})
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("UpdateRegion() error = %v, want %v", err, tt.wantErr)
 			}

--- a/texture_test.go
+++ b/texture_test.go
@@ -418,7 +418,7 @@ func TestUpdateRegionDestroyedTexture(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.tex.UpdateRegion(0, 0, 5, 5, make([]byte, 100))
+			err := tt.tex.UpdateRegion(0, 0, 5, 5, 0, make([]byte, 100))
 			if !errors.Is(err, ErrTextureUpdateDestroyed) {
 				t.Errorf("UpdateRegion() error = %v, want ErrTextureUpdateDestroyed", err)
 			}
@@ -454,7 +454,7 @@ func TestUpdateRegionInvalidParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tex.UpdateRegion(tt.x, tt.y, tt.w, tt.h, make([]byte, 100))
+			err := tex.UpdateRegion(tt.x, tt.y, tt.w, tt.h, 0, make([]byte, 100))
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("UpdateRegion() error = %v, want %v", err, tt.wantErr)
 			}
@@ -472,6 +472,7 @@ func TestTextureUpdateErrors(t *testing.T) {
 		{ErrInvalidDataSize, "gogpu: invalid data size"},
 		{ErrRegionOutOfBounds, "gogpu: region out of bounds"},
 		{ErrInvalidRegion, "gogpu: invalid region parameters"},
+		{ErrInvalidStride, "gogpu: invalid bytesPerRow stride"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- **Strided `Texture.UpdateRegion`** (#484) — `image.Rectangle` + `gpucontext.ImageDataLayout` (WebGPU / Go stdlib idiom). Zero-value layout = offset 0, tight packed rows, region height. Zero-copy dirty-band uploads without `extractRegion` memcpy.
- **GPUStats** (#484) — `Renderer.GetCounters()` (cumulative) + `Context.FrameStats()` (per-frame). Feature-gated via `GOGPU_STATS=1` / `EnableStats()`.
- **deps:** gpucontext v0.31.1-0 (struct API, [gpucontext#35](https://github.com/gogpu/gpucontext/pull/35))

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint` (Go 1.25)
- [x] Headless software: strided band upload < 10% of full frame
- [x] Stats disabled returns zero counters
- [x] CI green on PR