### PR TITLE
release: v0.54.0 — strided UpdateRegion, GPUStats, struct params (ADR-072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.54.0] - 2026-08-30
+## [0.54.0] - 2026-08-31
 
 ### Added
 
@@ -17,7 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **deps:** gpucontext v0.30.0 → v0.31.2 (`TextureRegionUpdater.UpdateRegion` struct API)
+- **Struct params migration** (ADR-072) — `SetViewport`, `SetScissorRect`, `Draw` use `gputypes.Viewport`, `gputypes.ScissorRect`, `gputypes.DrawArgs` structs instead of positional parameters
+- **deps:** wgpu v0.33.0 → v0.34.2 (struct params, type alias removal, pipeline disk cache), gpucontext v0.30.0 → v0.31.3, gputypes v0.7.0 → v0.8.0
+
+### Fixed
+
+- **lint:** darwin goconst (`services` string, `Tink` sound name) and gocognit (print dialog)
 
 ## [0.53.2] - 2026-08-30
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,7 +94,7 @@ Our goal is to become the **reference graphics ecosystem** for Go — comparable
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
-| **v0.54.0** | 2026-08-30 | **Strided UpdateRegion + GPUStats** (#484). deps gpucontext v0.31.2. |
+| **v0.54.0** | 2026-08-31 | **Strided UpdateRegion + GPUStats** (#484). Struct params (ADR-072). deps wgpu v0.34.2, gpucontext v0.31.3, gputypes v0.8.0. |
 | **v0.53.2** | 2026-08-30 | DownlevelCapabilities (ADR-071). deps wgpu v0.33.0, gpucontext v0.30.0. |
 | **v0.50.0** | 2026-08-06 | **Outgoing drag source** (#427, ADR-061) — `StartDrag` all 5 platforms. Per-pixel alpha (#361, @shaolei). Input ordering fix (#425, @FDUTCH). deps wgpu v0.30.36. |
 | **v0.49.2** | 2026-08-05 | Input JustPressed/Delta ordering fix (#425, @FDUTCH). 38 enterprise input tests. |

--- a/internal/platform/darwin/menu.go
+++ b/internal/platform/darwin/menu.go
@@ -8,6 +8,8 @@ import (
 	"github.com/go-webgpu/goffi/ffi"
 )
 
+const roleServices = "services"
+
 // Menu-related selectors (initialized lazily).
 var menuSels struct {
 	initWithTitle                SEL
@@ -565,7 +567,7 @@ func (a *Application) GetMenuSelector(role string) SEL {
 		return menuSels.orderFrontStandardAboutPanel
 	case "preferences":
 		return menuSels.orderFrontPreferencesPanel
-	case "services":
+	case roleServices:
 		return 0 // Services menu is handled specially
 	case "hide":
 		return menuSels.hide
@@ -607,7 +609,7 @@ func AddMenuItemWithRole(menu ID, title string, role string) ID {
 	case "preferences":
 		action = menuSels.orderFrontPreferencesPanel
 		keyEquiv = ","
-	case "services":
+	case roleServices:
 		// GLFW/Electron: empty submenu registered via setServicesMenu:.
 		return addServicesMenuItem(menu, title)
 	case "hide":
@@ -709,7 +711,7 @@ func AddMenuItemWithRoleAndCallback(menu ID, title string, role string, action f
 	}
 
 	// Services is a system-populated submenu — custom Action is ignored.
-	if role == "services" {
+	if role == roleServices {
 		return addServicesMenuItem(menu, title)
 	}
 

--- a/internal/platform/print_darwin.go
+++ b/internal/platform/print_darwin.go
@@ -36,7 +36,7 @@ var _ PrintManager = (*darwinPlatform)(nil)
 // objects are returned as acceptance errors. The modal operation itself is
 // queued asynchronously, allowing the caller to receive a PrintJob before the
 // panel is dismissed.
-func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (PrintJob, error) {
+func (p *darwinPlatform) StartPrint(ctx context.Context, request PrintRequest) (PrintJob, error) { //nolint:gocognit // print dialog orchestration is inherently sequential
 	if ctx == nil {
 		return nil, context.Canceled
 	}

--- a/sound/sound_darwin.go
+++ b/sound/sound_darwin.go
@@ -12,22 +12,24 @@ import (
 	"github.com/go-webgpu/goffi/types"
 )
 
+const darwinSoundTink = "Tink"
+
 // darwinSoundName maps SystemSound to macOS system sound file names.
 // These files are located in /System/Library/Sounds/.
 func darwinSoundName(s SystemSound) string {
 	switch s {
 	case Click:
-		return "Tink"
+		return darwinSoundTink
 	case Invoke:
 		return "Pop"
 	case Focus:
-		return "Tink"
+		return darwinSoundTink
 	case MoveNext:
-		return "Tink"
+		return darwinSoundTink
 	case MovePrev:
-		return "Tink"
+		return darwinSoundTink
 	case GoBack:
-		return "Tink"
+		return darwinSoundTink
 	case Show:
 		return "Blow"
 	case Hide:


### PR DESCRIPTION
## Added

- **Strided `Texture.UpdateRegion`** (#484) — `image.Rectangle` + `gpucontext.ImageDataLayout` (WebGPU / Go stdlib idiom). Zero-copy dirty-band uploads.
- **GPUStats** (#484) — `Renderer.GetCounters()` + `Context.FrameStats()`. Feature-gated `GOGPU_STATS=1`.

## Changed

- **Struct params** (ADR-072) — `SetViewport`, `SetScissorRect`, `Draw` use `gputypes.Viewport`, `gputypes.ScissorRect`, `gputypes.DrawArgs`
- **deps:** wgpu v0.34.2, gpucontext v0.31.3, gputypes v0.8.0

## Fixed

- darwin lint: goconst, gocognit